### PR TITLE
Remove duplicate prefix what is "imas"

### DIFF
--- a/URIs/imas-schema.ttl
+++ b/URIs/imas-schema.ttl
@@ -9,7 +9,6 @@
 @prefix georss: <http://www.georss.org/georss>.
 @prefix gr:    <http://purl.org/goodrelations/v1#>.
 @prefix ic:    <http://imi.ipa.go.jp/ns/core/rdf#>.
-@prefix imas:   <https://crssnky.xyz/URIs/imas-schema#>.
 @prefix jrrk:  <http://purl.org/jrrk#>.
 @prefix owl:   <http://www.w3.org/2002/07/owl#>.
 @prefix pc:    <http://purl.org/procurement/public-contracts#>.


### PR DESCRIPTION
The "imas" prefix is duplicated.

The first value has no effect.
"https://crssnky.xyz/URIs/imas-schema#" is invalid URI.

We can remove `@prefix imas:   <https://crssnky.xyz/URIs/imas-schema#>.` safely.