### PR TITLE
Edit idolcolor

### DIFF
--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -3721,7 +3721,7 @@
     <imas:cv xml:lang="ja">高橋花林</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/高橋花林"/>
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q20041113"/>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">99d9d9</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">99D9D9</imas:Color>
     <imas:Hobby xml:lang="ja">ポエム作り</imas:Hobby>
     <imas:Hobby xml:lang="ja">少女漫画集め</imas:Hobby>
   </rdf:Description>

--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -3721,7 +3721,7 @@
     <imas:cv xml:lang="ja">高橋花林</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/高橋花林"/>
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q20041113"/>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">9763D3</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">99d9d9</imas:Color>
     <imas:Hobby xml:lang="ja">ポエム作り</imas:Hobby>
     <imas:Hobby xml:lang="ja">少女漫画集め</imas:Hobby>
   </rdf:Description>

--- a/RDFs/SideM.rdf
+++ b/RDFs/SideM.rdf
@@ -49,7 +49,7 @@
     <imas:Hobby xml:lang="ja">料理</imas:Hobby>
     <imas:Hobby xml:lang="ja">フィギュア集め</imas:Hobby>
     <imas:Talent xml:lang="ja">スパイスからのカレー作り</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F32333</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E51A2A</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -82,7 +82,7 @@
     <imas:Hobby xml:lang="ja">寝ること</imas:Hobby>
     <imas:Hobby xml:lang="ja">親孝行♪</imas:Hobby>
     <imas:Talent xml:lang="ja">バク転</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">64D509</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">85C20A</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -116,7 +116,7 @@
     <imas:Hobby xml:lang="ja">ヴァイオリン</imas:Hobby>
     <imas:Hobby xml:lang="ja">デート</imas:Hobby>
     <imas:Talent xml:lang="ja">高速ネコふんじゃった</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">1C23AA</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">0F198A</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -149,7 +149,7 @@
     <imas:Hobby xml:lang="ja">特撮</imas:Hobby>
     <imas:Hobby xml:lang="ja">ダーツ</imas:Hobby>
     <imas:Talent xml:lang="ja">料理</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E31C1A</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E51A1A</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -181,7 +181,7 @@
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q17349748"/>
     <imas:Hobby xml:lang="ja">姉の形見の擦り切れた詩集を読む</imas:Hobby>
     <imas:Talent xml:lang="ja">手品</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">1945BA</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">143DB8</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -216,7 +216,7 @@
     <imas:Hobby xml:lang="ja">エコノミークラスで世界を旅する</imas:Hobby>
     <imas:Talent xml:lang="ja">大食い</imas:Talent>
     <imas:Talent xml:lang="ja">天気読み</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">3BAF29</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">44D926</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -248,7 +248,7 @@
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q18457703"/>
     <imas:Hobby xml:lang="ja">なし</imas:Hobby>
     <imas:Talent xml:lang="ja">ピアノ</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">C5A6E2</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">B28CD9</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -280,7 +280,7 @@
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q26043734"/>
     <imas:Hobby xml:lang="ja">ハンドクリームを塗ること</imas:Hobby>
     <imas:Talent xml:lang="ja">1回聞いた音楽を正確にヴァイオリンで奏でることができる</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">3D5AC8</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">1F36AD</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -312,7 +312,7 @@
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q18225739"/>
     <imas:Hobby xml:lang="ja">洗濯</imas:Hobby>
     <imas:Talent xml:lang="ja">暗算</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">6AC4E9</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">85C2E0</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -338,7 +338,7 @@
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q22129969"/>
     <imas:Hobby xml:lang="ja">きぐるみとのしゃしんさつえい</imas:Hobby>
     <imas:Talent xml:lang="ja">みかんのはやむき</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">8BDC63</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">B2F075</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -370,7 +370,7 @@
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q21019125"/>
     <imas:Hobby xml:lang="ja">ハンドクリーム集め</imas:Hobby>
     <imas:Talent xml:lang="ja">運転時の抜け道探し</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">FA90A2</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F2A6B2</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -402,7 +402,7 @@
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q24865828"/>
     <imas:Hobby xml:lang="ja">サッカー</imas:Hobby>
     <imas:Talent xml:lang="ja">サッカー</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">FEE806</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">FFEA00</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -435,7 +435,7 @@
     <imas:Hobby xml:lang="ja">知恵の輪</imas:Hobby>
     <imas:Talent xml:lang="ja">練習メニューの組み立て</imas:Talent>
     <imas:Talent xml:lang="ja">コーチング</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">23CD7A</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">26D97F</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -468,7 +468,7 @@
     <imas:Hobby xml:lang="ja">トレラン</imas:Hobby>
     <imas:Talent xml:lang="ja">警察犬の訓練</imas:Talent>
     <imas:Talent xml:lang="ja">動物全般の躾</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">57B3E5</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">5CA3D6</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -500,7 +500,7 @@
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q20042322"/>
     <imas:Hobby xml:lang="ja">昼寝</imas:Hobby>
     <imas:Talent xml:lang="ja">裁縫</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EE7220</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F26C0D</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -532,7 +532,7 @@
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q17230347"/>
     <imas:Hobby xml:lang="ja">料理</imas:Hobby>
     <imas:Talent xml:lang="ja">銃器類の早解体</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">57B4E5</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">889933</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -564,7 +564,7 @@
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q15975368"/>
     <imas:Hobby xml:lang="ja">珍獣観察</imas:Hobby>
     <imas:Talent xml:lang="ja">人間・動物からマンガやアニメのキャラクターのモノマネや形態模写</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F7BD05</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F2B90D</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -596,7 +596,7 @@
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q24865667"/>
     <imas:Hobby xml:lang="ja">メイド喫茶巡り</imas:Hobby>
     <imas:Talent xml:lang="ja">和太鼓演奏</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">7664A0</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">661FAD</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -629,7 +629,7 @@
     <imas:Hobby xml:lang="ja">いろいろな入浴剤収集</imas:Hobby>
     <imas:Talent xml:lang="ja">競技かるた</imas:Talent>
     <imas:Talent xml:lang="ja">投扇興</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">79A5DF</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">6690CC</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -662,7 +662,7 @@
     <imas:Hobby xml:lang="ja">ゲーム</imas:Hobby>
     <imas:Hobby xml:lang="ja">ギター</imas:Hobby>
     <imas:Talent xml:lang="ja">野球選手のモノマネ</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">FE6B02</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F2590D</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -694,7 +694,7 @@
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q20760484"/>
     <imas:Hobby xml:lang="ja">読書</imas:Hobby>
     <imas:Talent xml:lang="ja">ピアノ</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">1845B9</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">2947A3</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -727,7 +727,7 @@
     <imas:Hobby xml:lang="ja">人間観察</imas:Hobby>
     <imas:Hobby xml:lang="ja">ヴァイオリン</imas:Hobby>
     <imas:Talent xml:lang="ja">気配を消すこと</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">24CAD2</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">40B5BF</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -759,7 +759,7 @@
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q11579372"/>
     <imas:Hobby xml:lang="ja">散歩</imas:Hobby>
     <imas:Talent xml:lang="ja">ヘアメイク</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">71D448</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">62D926</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -792,7 +792,7 @@
     <imas:Hobby xml:lang="ja">カラオケ</imas:Hobby>
     <imas:Hobby xml:lang="ja">ハデパン集め</imas:Hobby>
     <imas:Talent xml:lang="ja">カラオケ採点で意のままの点数を出せる</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F125C1</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F53DA8</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -824,7 +824,7 @@
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q17222626"/>
     <imas:Hobby xml:lang="ja">頭に「にゃこ」を乗せて散歩</imas:Hobby>
     <imas:Talent xml:lang="ja">天空朱雀落とし</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E63C2E</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E52A1A</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -858,7 +858,7 @@
     <imas:Hobby xml:lang="ja">分厚い本を読むこと(最近は家庭の医学を読んでいる)</imas:Hobby>
     <imas:Talent xml:lang="ja">天玄氷刃波</imas:Talent>
     <imas:Talent xml:lang="ja">全国一斉テスト・統一模試全科目1位</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">0F0C9F</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">171782</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -892,7 +892,7 @@
     <imas:Hobby xml:lang="ja">世界旅行</imas:Hobby>
     <imas:Talent xml:lang="ja">早着替え</imas:Talent>
     <imas:Talent xml:lang="ja">華麗なスプーンフォーク捌きによるサーバー技</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F09079</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E06952</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -926,7 +926,7 @@
     <imas:Hobby xml:lang="ja">ジグソーパズル</imas:Hobby>
     <imas:Talent xml:lang="ja">飴細工</imas:Talent>
     <imas:Talent xml:lang="ja">折紙</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">05966F</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">089158</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -953,7 +953,7 @@
     <imas:Hobby xml:lang="ja">禁じられた新たなるレシピの発見</imas:Hobby>
     <imas:Talent xml:lang="ja">召喚術</imas:Talent>
     <imas:Talent xml:lang="ja">詠唱</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">606CB2</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">5C66D6</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -986,7 +986,7 @@
     <imas:Hobby xml:lang="ja">全国ケーキ食べ歩き</imas:Hobby>
     <imas:Talent xml:lang="ja">利きケーキ</imas:Talent>
     <imas:Talent xml:lang="ja">一輪車</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F8C559</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EBB447</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -1018,7 +1018,7 @@
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q24865397"/>
     <imas:Hobby xml:lang="ja">手品</imas:Hobby>
     <imas:Talent xml:lang="ja">逆立ち</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">FA7EB4</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EB4799</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -1050,7 +1050,7 @@
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q24897980"/>
     <imas:Hobby xml:lang="ja">将棋</imas:Hobby>
     <imas:Talent xml:lang="ja">編み物</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">1F1451</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">1F1452</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -1082,7 +1082,7 @@
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q27150521"/>
     <imas:Hobby xml:lang="ja">バスケ</imas:Hobby>
     <imas:Talent xml:lang="ja">ブレイクダンス</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D13037</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E53B1A</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -1114,7 +1114,7 @@
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q11523377"/>
     <imas:Hobby xml:lang="ja">お散歩</imas:Hobby>
     <imas:Talent xml:lang="ja">ピアノ</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F7B5C4</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">FF99B2</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -1147,7 +1147,7 @@
     <imas:Hobby xml:lang="ja">掃除</imas:Hobby>
     <imas:Hobby xml:lang="ja">パズル</imas:Hobby>
     <imas:Talent xml:lang="ja">円周率の暗唱</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">436CA9</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">4C6EB2</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -1181,7 +1181,7 @@
     <imas:Hobby xml:lang="ja">スノボ</imas:Hobby>
     <imas:Hobby xml:lang="ja">サーフィン</imas:Hobby>
     <imas:Talent xml:lang="ja">けん玉</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F5D24B</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F5D63D</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -1214,7 +1214,7 @@
     <imas:Hobby xml:lang="ja">猫カフェ巡り</imas:Hobby>
     <imas:Hobby xml:lang="ja">競馬</imas:Hobby>
     <imas:Talent xml:lang="ja">ラジオ体操</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EE7602</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F27F0D</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -1248,7 +1248,7 @@
     <imas:Hobby xml:lang="ja">ランニング</imas:Hobby>
     <imas:Talent xml:lang="ja">体を動かすことならなんでも</imas:Talent>
     <imas:Talent xml:lang="ja">シューティングゲーム</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">0E0C9F</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">0F0F8A</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -1280,7 +1280,7 @@
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q20042330"/>
     <imas:Hobby xml:lang="ja">資格取得</imas:Hobby>
     <imas:Talent xml:lang="ja">たくさんありすぎてかけないが､最近はあみぐるみにハマっている</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">CA9111</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D99D26</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -1312,7 +1312,7 @@
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q24877064"/>
     <imas:Hobby xml:lang="ja">なんでんなことｵﾏｴに教えないといけねｰんだ? バァーカ!</imas:Hobby>
     <imas:Talent xml:lang="ja">相手をぶったおすことにきまっ てんだろ!</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">AC162A</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">C20A19</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -1346,7 +1346,7 @@
     <imas:Hobby xml:lang="ja">お料理</imas:Hobby>
     <imas:Talent xml:lang="ja">ダンス</imas:Talent>
     <imas:Talent xml:lang="ja">変装</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">70B449</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">7AD65C</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -1379,7 +1379,7 @@
     <imas:Hobby xml:lang="ja">格ゲー</imas:Hobby>
     <imas:Talent xml:lang="ja">居合道</imas:Talent>
     <imas:Talent xml:lang="ja">かつらむき</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E41C1A</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D92626</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -1413,7 +1413,7 @@
     <imas:Hobby xml:lang="ja">読書</imas:Hobby>
     <imas:Talent xml:lang="ja">一度読んだ本の内容は大体覚えている</imas:Talent>
     <imas:Talent xml:lang="ja">食べれるキノコを見分けられる</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">CF9E51</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D6A35C</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -1445,7 +1445,7 @@
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q27150536"/>
     <imas:Hobby xml:lang="ja">星占い</imas:Hobby>
     <imas:Talent xml:lang="ja">折紙</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">111721</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">000000</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -1477,7 +1477,7 @@
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q27150533"/>
     <imas:Hobby xml:lang="ja">一人旅</imas:Hobby>
     <imas:Talent xml:lang="ja">書道</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">477525</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">4C8217</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -1509,7 +1509,7 @@
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q20040112"/>
     <imas:Hobby xml:lang="ja">水族館めぐり</imas:Hobby>
     <imas:Talent xml:lang="ja">素潜り(水中息止め)</imas:Talent>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">1FC1DD</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">20BFDF</imas:Color>
     <schema:gender xml:lang="en">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>

--- a/RDFs/Unit.rdf
+++ b/RDFs/Unit.rdf
@@ -9443,7 +9443,7 @@
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Amagase_Toma"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Ijuin_Hokuto"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Mitarai_Shota"/>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">AACF44</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">7AF53D</imas:Color>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit"/>
   </rdf:Description>
   <rdf:Description rdf:about="detail/DRAMATICSTARS">
@@ -9451,14 +9451,14 @@
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Tendo_Teru"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Sakuraba_Kaoru"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Kashiwagi_Tsubasa"/>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F39801</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">FFAA00</imas:Color>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit"/>
   </rdf:Description>
   <rdf:Description rdf:about="detail/Altessimo">
     <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Altessimo</schema:name>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Tsuzuki_Kei"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Kagura_Rei"/>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">FFF57F</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">FFFF99</imas:Color>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit"/>
   </rdf:Description>
   <rdf:Description rdf:about="detail/Beit">
@@ -9466,14 +9466,14 @@
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Takajo_Kyoji"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Pierre"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Watanabe_Minori"/>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">1FB9DF</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">33BBFF</imas:Color>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit"/>
   </rdf:Description>
   <rdf:Description rdf:about="detail/W">
     <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">W</schema:name>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Aoi_Yusuke"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Aoi_Kyosuke"/>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">FEE101</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">FFD400</imas:Color>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit"/>
   </rdf:Description>
   <rdf:Description rdf:about="detail/FRAME">
@@ -9481,7 +9481,7 @@
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Akuno_Hideo"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Kimura_Ryu"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Shingen_Seiji"/>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">00A040</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">14B84B</imas:Color>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit"/>
   </rdf:Description>
   <rdf:Description rdf:about="detail/%E5%BD%A9">
@@ -9489,7 +9489,7 @@
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Nekoyanagi_Kirio"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Hanamura_Shoma"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Kiyosumi_Kuro"/>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">724598</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">6E1B98</imas:Color>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit"/>
   </rdf:Description>
   <rdf:Description rdf:about="detail/High%C3%97Joker">
@@ -9499,14 +9499,14 @@
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Sakaki_Natsuki"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Wakazato_Haruna"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Iseya_Shiki"/>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E70012</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F20D33</imas:Color>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit"/>
   </rdf:Description>
   <rdf:Description rdf:about="detail/%E7%A5%9E%E9%80%9F%E4%B8%80%E9%AD%82">
     <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">神速一魂</schema:name>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Akai_Suzaku"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Kurono_Genbu"/>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D4E4E4</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E3E3E8</imas:Color>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit"/>
   </rdf:Description>
   <rdf:Description rdf:about="detail/CafeParade">
@@ -9516,7 +9516,7 @@
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Asselin_BB_2"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Uzuki_Makio"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Mizushima_Saki"/>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">A6126A</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">B24C90</imas:Color>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit"/>
   </rdf:Description>
   <rdf:Description rdf:about="detail/%E3%82%82%E3%81%B5%E3%82%82%E3%81%B5%E3%81%88%E3%82%93">
@@ -9524,7 +9524,7 @@
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Okamura_Nao"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Tachibana_Shiro"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Himeno_Kanon"/>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F6BED7</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F5A3BE</imas:Color>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit"/>
   </rdf:Description>
   <rdf:Description rdf:about="detail/S.E.M">
@@ -9532,7 +9532,7 @@
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Hazama_Michio"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Maita_Rui"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Yamashita_Jiro"/>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">4D5558</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F20D7F</imas:Color>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit"/>
   </rdf:Description>
   <rdf:Description rdf:about="detail/THE%E8%99%8E%E7%89%99%E9%81%93">
@@ -9540,7 +9540,7 @@
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Taiga_Takeru"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Enjoji_Michiru"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Kizaki_Ren"/>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">4D5558</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">000000</imas:Color>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit"/>
   </rdf:Description>
   <rdf:Description rdf:about="detail/F-LAGS">
@@ -9548,7 +9548,7 @@
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Akizuki_Ryo"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Tsukumo_Kazuki"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Kabuto_Daigo"/>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">0D6FB8</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">1430B8</imas:Color>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit"/>
   </rdf:Description>
   <rdf:Description rdf:about="detail/Legenders">
@@ -9556,7 +9556,7 @@
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Kuzunoha_Amehiko"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Kitamura_Sora"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Koron_Chris"/>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">6881A0</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">5980A6</imas:Color>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit"/>
   </rdf:Description>
 


### PR DESCRIPTION
SideMアイドル・ユニットのカラーを修正しました。
これらは3rdプロデュースバッジの色抽出を基本にしつつも、その他グッズなどから総合的に判断して調整したものです。

また、森久保のカラーが明らかに違ったので修正しました。
こちらはサイリウム商品画像から抽出しました。

（gitに不慣れなのでやり方があっているか不安ですがよろしくお願いいたしますm(_ _)m）