### PR TITLE
姓名の整合ルール追加、イヴ・メアリー・キャシーの姓名修正

### DIFF
--- a/.circleci/rdflint-config.yml
+++ b/.circleci/rdflint-config.yml
@@ -1,1 +1,52 @@
 baseUri: https://sparql.crssnky.xyz/imasrdf/
+rules:
+  - name: 姓名整合(和文)
+    target: "RDFs/.*"
+    query: |
+      PREFIX schema: <http://schema.org/>
+      PREFIX imas: <https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#>
+      SELECT ?s ?fn ?gn ?nm ?fnk ?gnk ?nmk
+      WHERE {
+       ?s schema:familyName ?fn; schema:givenName ?gn; schema:name ?nm;
+         imas:familyNameKana ?fnk; imas:givenNameKana ?gnk; imas:nameKana ?nmk.
+       FILTER(LANG(?fn) = 'ja' && LANG(?gn) = 'ja' && LANG(?nm) = 'ja'
+         && LANG(?fnk) = 'ja' && LANG(?gnk) = 'ja' && LANG(?nmk) = 'ja')
+      }
+    valid: |
+      while(rs.hasNext()) {
+        r = rs.next()
+        jn = [r.getLiteral("fn").value + r.getLiteral("gn").value,
+              r.getLiteral("gn").value + r.getLiteral("fn").value,
+              r.getLiteral("gn").value + "・" + r.getLiteral("fn").value]
+        nm = r.getLiteral("nm").value
+        if (!(nm in jn)) {
+          log.warn("姓名, 姓+名が不一致: " + nm + " != " + jn.join("|"))
+        }
+
+        jnk = [r.getLiteral("fnk").value + r.getLiteral("gnk").value,
+               r.getLiteral("gnk").value + r.getLiteral("fnk").value,
+               r.getLiteral("gnk").value + "・" + r.getLiteral("fnk").value]
+        nmk = r.getLiteral("nmk").value
+        if (!(nmk in jnk)) {
+          log.warn("姓名, 姓+名が不一致(かな): " + nmk + " != " + jnk.join("|"))
+        }
+      }
+  - name: 姓名整合(英文)
+    target: "RDFs/.*"
+    query: |
+      PREFIX schema: <http://schema.org/>
+      SELECT ?s ?fn ?gn ?nm
+      WHERE {
+       ?s schema:familyName ?fn; schema:givenName ?gn; schema:name ?nm
+       FILTER(LANG(?fn) = 'en' && LANG(?gn) = 'en' && LANG(?nm) = 'en')
+      }
+    valid: |
+      while(rs.hasNext()) {
+        r = rs.next()
+        jn = [r.getLiteral("fn").value + " " + r.getLiteral("gn").value,
+              r.getLiteral("gn").value + " " + r.getLiteral("fn").value]
+        nm = r.getLiteral("nm").value
+        if (!(nm in jn)) {
+          log.warn("姓名, 姓+名が不一致: " + nm + " != " + jn.join("|"))
+        }
+      }

--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -5427,12 +5427,12 @@
 
   <rdf:Description rdf:about="detail/Mary_Cochran">
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pa</imas:Type>
-    <schema:familyName xml:lang="ja">メアリー</schema:familyName>
-    <schema:familyName xml:lang="en">Mary</schema:familyName>
-    <imas:familyNameKana xml:lang="ja">めありー</imas:familyNameKana>
-    <schema:givenName xml:lang="ja">コクラン</schema:givenName>
-    <schema:givenName xml:lang="en">Cochran</schema:givenName>
-    <imas:givenNameKana xml:lang="ja">こくらん</imas:givenNameKana>
+    <schema:familyName xml:lang="ja">コクラン</schema:familyName>
+    <schema:familyName xml:lang="en">Cochran</schema:familyName>
+    <imas:familyNameKana xml:lang="ja">こくらん</imas:familyNameKana>
+    <schema:givenName xml:lang="ja">メアリー</schema:givenName>
+    <schema:givenName xml:lang="en">Mary</schema:givenName>
+    <imas:givenNameKana xml:lang="ja">めありー</imas:givenNameKana>
     <schema:gender xml:lang="en">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -5518,12 +5518,12 @@
 
   <rdf:Description rdf:about="detail/Cathy_Graham">
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pa</imas:Type>
-    <schema:familyName xml:lang="ja">キャシー</schema:familyName>
-    <schema:familyName xml:lang="en">Cathy</schema:familyName>
-    <imas:familyNameKana xml:lang="ja">きゃしー</imas:familyNameKana>
-    <schema:givenName xml:lang="ja">グラハム</schema:givenName>
-    <schema:givenName xml:lang="en">Graham</schema:givenName>
-    <imas:givenNameKana xml:lang="ja">ぐらはむ</imas:givenNameKana>
+    <schema:familyName xml:lang="ja">グラハム</schema:familyName>
+    <schema:familyName xml:lang="en">Graham</schema:familyName>
+    <imas:familyNameKana xml:lang="ja">ぐらはむ</imas:familyNameKana>
+    <schema:givenName xml:lang="ja">キャシー</schema:givenName>
+    <schema:givenName xml:lang="en">Cathy</schema:givenName>
+    <imas:givenNameKana xml:lang="ja">きゃしー</imas:givenNameKana>
     <schema:gender xml:lang="en">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -5809,12 +5809,12 @@
 
   <rdf:Description rdf:about="detail/Eve_Santaclaus">
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pa</imas:Type>
-    <schema:familyName xml:lang="ja">イヴ</schema:familyName>
-    <schema:familyName xml:lang="en">Eve</schema:familyName>
-    <imas:familyNameKana xml:lang="ja">いゔ</imas:familyNameKana>
-    <schema:givenName xml:lang="ja">サンタクロース</schema:givenName>
-    <schema:givenName xml:lang="en">Santaclaus</schema:givenName>
-    <imas:givenNameKana xml:lang="ja">さんたくろーす</imas:givenNameKana>
+    <schema:familyName xml:lang="ja">サンタクロース</schema:familyName>
+    <schema:familyName xml:lang="en">Santaclaus</schema:familyName>
+    <imas:familyNameKana xml:lang="ja">さんたくろーす</imas:familyNameKana>
+    <schema:givenName xml:lang="ja">イヴ</schema:givenName>
+    <schema:givenName xml:lang="en">Eve</schema:givenName>
+    <imas:givenNameKana xml:lang="ja">いゔ</imas:givenNameKana>
     <schema:gender xml:lang="en">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>

--- a/RDFs/Staff.rdf
+++ b/RDFs/Staff.rdf
@@ -105,7 +105,7 @@
   </rdf:Description>
   <rdf:Description rdf:about="detail/Saito_Takashi">
     <schema:familyName xml:lang="ja">齋藤</schema:familyName>
-    <schema:familyName xml:lang="en">Ssaito</schema:familyName>
+    <schema:familyName xml:lang="en">Saito</schema:familyName>
     <imas:familyNameKana xml:lang="ja">さいとう</imas:familyNameKana>
     <schema:givenName xml:lang="ja">孝司</schema:givenName>
     <schema:givenName xml:lang="en">Takashi</schema:givenName>


### PR DESCRIPTION
rdflintに姓名の整合ルール追加、その際に発見した誤りの修正

- rdflintのルールに姓名の整合チェックを追加
- イヴ・メアリー・キャシーの姓名が逆になっていたので修正
- 齋藤孝司の姓が「Ssaito」となっていたので修正

```
RDFs/CinderellaGirls.rdf
  WARN  姓名整合(和文): 姓名, 姓+名が不一致: イヴ・サンタクロース != イヴサンタクロース|サンタクロースイヴ|サンタクロース・イヴ
  WARN  姓名整合(和文): 姓名, 姓+名が不一致(かな): いゔ・さんたくろーす != いゔさんたくろーす|さんたくろーすいゔ|さんたくろーす・いゔ
  WARN  姓名整合(和文): 姓名, 姓+名が不一致: メアリー・コクラン != メアリーコクラン|コクランメアリー|コクラン・メアリー
  WARN  姓名整合(和文): 姓名, 姓+名が不一致(かな): めありー・こくらん != めありーこくらん|こくらんめありー|こくらん・めありー
  WARN  姓名整合(和文): 姓名, 姓+名が不一致: キャシー・グラハム != キャシーグラハム|グラハムキャシー|グラハム・キャシー
  WARN  姓名整合(和文): 姓名, 姓+名が不一致(かな): きゃしー・ぐらはむ != きゃしーぐらはむ|ぐらはむきゃしー|ぐらはむ・きゃしー

RDFs/Staff.rdf
  WARN  姓名整合(英文): 姓名, 姓+名が不一致: Saito Takashi != Ssaito Takashi|Takashi Ssaito
```
