### PR TITLE
ミリオン、XXスターズのユニット名のカタカナ化

### DIFF
--- a/RDFs/Unit.rdf
+++ b/RDFs/Unit.rdf
@@ -10213,7 +10213,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit"/>
   </rdf:Description>
   <rdf:Description rdf:about="detail/Princess%20Stars">
-    <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Princess Stars</schema:name>
+    <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プリンセススターズ</schema:name>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Matsuda_Arisa"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Emily_Stewart"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Yokoyama_Nao"/>
@@ -10230,7 +10230,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit"/>
   </rdf:Description>
   <rdf:Description rdf:about="detail/Angel%20Stars">
-    <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Angel Stars</schema:name>
+    <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エンジェルスターズ</schema:name>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Nonohara_Akane"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Sakuramori_Kaori"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Shimabara_Elena"/>
@@ -10247,7 +10247,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit"/>
   </rdf:Description>
   <rdf:Description rdf:about="detail/Fairy%20Stars">
-    <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fairy Stars</schema:name>
+    <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フェアリースターズ</schema:name>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Tokoro_Megumi"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Maihama_Ayumu"/>
     <schema:member rdf:resource="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Makabe_Mizuki"/>


### PR DESCRIPTION
CD、ゲームともにカタカナ表記だったため
https://www.lantis.jp/imas/release_LACM-14634.html