### PR TITLE
imas:IdolShapeを追加

### DIFF
--- a/.circleci/rdflint-suppress.yml
+++ b/.circleci/rdflint-suppress.yml
@@ -133,9 +133,9 @@ RDFs/SideM.rdf:
     locationType: TRIPLE
     subject: https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Tsuzuki_Kei
     predicate: http://xmlns.com/foaf/0.1/age
-    object: '"??"'
+    object: '"??"@ja'
     message: 'DataType not matched: expected NATURAL, but STRING (triple: https://sparql.crssnky.xyz/imasrdf/RDFs/detail/Tsuzuki_Kei
-        - http://xmlns.com/foaf/0.1/age - "??")'
+        - http://xmlns.com/foaf/0.1/age - "??"@ja)'
 RDFs/Staff.rdf:
   - key: com.github.imas.rdflint.validator.impl.notmatchedGuessedDataType
     level: INFO

--- a/RDFs/283.rdf
+++ b/RDFs/283.rdf
@@ -42,7 +42,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--04-25</schema:birthDate>
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">お出かけ</imas:Hobby>
     <imas:Hobby xml:lang="ja">公園で日向ぼっこ</imas:Hobby>
     <imas:Talent xml:lang="ja">鳥に好かれる</imas:Talent>
@@ -77,7 +77,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--07-22</schema:birthDate>
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">人と話すこと</imas:Hobby>
     <imas:Hobby xml:lang="ja">体を動かすこと</imas:Hobby>
     <imas:Talent xml:lang="ja">スポーツ全般</imas:Talent>
@@ -112,7 +112,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--03-04</schema:birthDate>
     <imas:Constellation xml:lang="ja">魚座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">音楽鑑賞</imas:Hobby>
     <imas:Hobby xml:lang="ja">綺麗な景色を探すこと</imas:Hobby>
     <imas:Hobby xml:lang="ja">占い</imas:Hobby>
@@ -149,7 +149,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--02-25</schema:birthDate>
     <imas:Constellation xml:lang="ja">魚座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Hobby xml:lang="ja">うちの手料理、なんでも絶品たい！</imas:Hobby>
     <imas:Talent xml:lang="ja">そっくりな似顔絵は描けるたい！</imas:Talent>
     <imas:cv xml:lang="ja">礒部花凜</imas:cv>
@@ -183,7 +183,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--01-16</schema:birthDate>
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">アイドルライブ鑑賞</imas:Hobby>
     <imas:Hobby xml:lang="ja">カメラ</imas:Hobby>
     <imas:Hobby xml:lang="ja">ゲーム</imas:Hobby>
@@ -222,7 +222,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--06-27</schema:birthDate>
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">色々な所に出かける</imas:Hobby>
     <imas:Talent xml:lang="ja">自分を最大限カッコ良く見せる立ち振る舞い</imas:Talent>
     <imas:cv xml:lang="ja">八巻アンナ</imas:cv>
@@ -256,7 +256,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-24</schema:birthDate>
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">放浪</imas:Hobby>
     <imas:Hobby xml:lang="ja">人をからかう</imas:Hobby>
     <imas:Talent xml:lang="ja">自分で髪を切る</imas:Talent>
@@ -291,7 +291,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--09-23</schema:birthDate>
     <imas:Constellation xml:lang="ja">天秤座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Hobby xml:lang="ja">かわいいもの全般の収集</imas:Hobby>
     <imas:Hobby xml:lang="ja">手芸</imas:Hobby>
     <imas:Hobby xml:lang="ja">献血</imas:Hobby>
@@ -329,7 +329,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--04-18</schema:birthDate>
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">雑貨作り</imas:Hobby>
     <imas:Talent xml:lang="ja">裁縫</imas:Talent>
     <imas:Talent xml:lang="ja">道案内</imas:Talent>
@@ -364,7 +364,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--12-25</schema:birthDate>
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">お昼寝</imas:Hobby>
     <imas:Hobby xml:lang="ja">ネットサーフィン</imas:Hobby>
     <imas:Hobby xml:lang="ja">アニメ</imas:Hobby>
@@ -401,7 +401,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--12-25</schema:birthDate>
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">ショッピング</imas:Hobby>
     <imas:Hobby xml:lang="ja">ネイル</imas:Hobby>
     <imas:Hobby xml:lang="ja">自撮り</imas:Hobby>
@@ -438,7 +438,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--07-29</schema:birthDate>
     <imas:Constellation xml:lang="ja">獅子座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">日曜日朝の子供向け番組を見る事</imas:Hobby>
     <imas:Hobby xml:lang="ja">グッズ集め</imas:Hobby>
     <imas:Talent xml:lang="ja">好きな番組の決め台詞を数多く覚えている</imas:Talent>
@@ -473,7 +473,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--11-26</schema:birthDate>
     <imas:Constellation xml:lang="ja">射手座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">洋楽</imas:Hobby>
     <imas:Hobby xml:lang="ja">ゲーム</imas:Hobby>
     <imas:Talent xml:lang="ja">スポーツ全般</imas:Talent>
@@ -509,7 +509,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-16</schema:birthDate>
     <imas:Constellation xml:lang="ja">獅子座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">トレーニング</imas:Hobby>
     <imas:Hobby xml:lang="ja">ストレッチ</imas:Hobby>
     <imas:Talent xml:lang="ja">トータルコーディネート</imas:Talent>
@@ -544,7 +544,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--10-19</schema:birthDate>
     <imas:Constellation xml:lang="ja">天秤座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Hobby xml:lang="ja">少女漫画</imas:Hobby>
     <imas:Hobby xml:lang="ja">芸道全般</imas:Hobby>
     <imas:Talent xml:lang="ja">折り紙</imas:Talent>
@@ -580,7 +580,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--02-24</schema:birthDate>
     <imas:Constellation xml:lang="ja">魚座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">スイーツ店巡り</imas:Hobby>
     <imas:Talent xml:lang="ja">たくさん食べられること</imas:Talent>
     <imas:cv xml:lang="ja">白石晴香</imas:cv>
@@ -614,7 +614,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--12-04</schema:birthDate>
     <imas:Constellation xml:lang="ja">射手座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">お友達とおしゃべり♪</imas:Hobby>
     <imas:Talent xml:lang="ja">みんなと仲良くなること♪</imas:Talent>
     <imas:cv xml:lang="ja">幸村恵理</imas:cv>
@@ -648,7 +648,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--01-04</schema:birthDate>
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">both</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">both</imas:Handedness>
     <imas:Hobby xml:lang="ja">人間観察</imas:Hobby>
     <imas:Hobby xml:lang="ja">人に話しかけること</imas:Hobby>
     <imas:Talent xml:lang="ja">記憶力がいい</imas:Talent>
@@ -683,7 +683,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-02</schema:birthDate>
     <imas:Constellation xml:lang="ja">獅子座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">友達と遊ぶ</imas:Hobby>
     <imas:Hobby xml:lang="ja">最近の曲を聞く</imas:Hobby>
     <imas:Talent xml:lang="ja">何時間でも電話できること</imas:Talent>

--- a/RDFs/283.rdf
+++ b/RDFs/283.rdf
@@ -51,7 +51,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q52319813"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">FFBAD6</imas:Color>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">ほんわかした癒し系の女の子で、心優しい性格。見ていて守りたくなるタイプで、一緒にいるだけで何となく幸せな気持ちになる。高校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -86,7 +86,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q48764554"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">FFE012</imas:Color>
     <schema:birthPlace xml:lang="ja">アメリカ　マサチューセッツ州</schema:birthPlace>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">天真爛漫な性格で、誰にでも積極的に話しかける。とにかく元気で友達想いの女の子。日本人の父とアメリカ人の母を持つ。高校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -123,7 +123,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q27151126"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">144384</imas:Color>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">後ろでまとめた黒髪が印象的な、クール系美少女。自分が納得するまで努力を欠かさないストイックな性格の持ち主。高校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -157,7 +157,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q18990383"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F94CAD</imas:Color>
     <schema:birthPlace xml:lang="ja">長崎</schema:birthPlace>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">自信たっぷりで何があってもポジティブな性格。スタイルもよく人目を引く可愛さだが、よく転ぶ、ダンスを間違えるなどのドジな一面も併せ持つ。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -196,7 +196,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q56886205"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">3B91C4</imas:Color>
     <schema:birthPlace xml:lang="ja">福島</schema:birthPlace>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">自由奔放で掴みどころのないサブカル系眼鏡女子。美人でノリもよく、初対面の人に対しても気後れせずに話しができる。大学1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -230,7 +230,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q56059704"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">006047</imas:Color>
     <schema:birthPlace xml:lang="ja">高知</schema:birthPlace>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">女子校に通い、スポーツ万能、学業優秀、容姿端麗なモデル系美人。立ち居振舞いも王子様のようにかっこよく、女子からの人気が高い。高校3年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -265,7 +265,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q48765622"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">A846FB</imas:Color>
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">ダウナー系で、面倒なことが嫌いなパンキッシュガール。顔もスタイルも抜群の美少女だが、自分の興味を持ったこと以外には無頓着な性格。高校3年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -303,7 +303,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17225022"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D9F2DD</imas:Color>
     <schema:birthPlace xml:lang="ja">青森</schema:birthPlace>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">ミステリアスな雰囲気を醸し出す銀髪の女の子。儚げな雰囲気とぐるぐると巻いた包帯が特徴的。口数は少ないが、心優しい性格。高校2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -338,7 +338,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q20040525"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">FBFBFB</imas:Color>
     <schema:birthPlace xml:lang="ja">山口</schema:birthPlace>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">優しい笑顔が印象的な、事務所のお姉さん的存在。母性溢れる落ち着いた佇まいが特徴。手先が器用で、かわいい小物を作るのが趣味。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -375,7 +375,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q24820042"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E75BEC</imas:Color>
     <schema:birthPlace xml:lang="ja">富山</schema:birthPlace>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">大崎姉妹の双子の姉。幼い頃から妹の甘奈に面倒を見てもらっている。人と話すのが苦手で、アニメやゲームなど、インドアな趣味が多い。高校2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -412,7 +412,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q30929032"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F54275</imas:Color>
     <schema:birthPlace xml:lang="ja">富山</schema:birthPlace>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">大崎姉妹の双子の妹。誰とでも分け隔てなく接する天真爛漫なギャル。今しかできないことを全力で楽しみたい今ドキの女の子。高校2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -447,7 +447,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q43427019"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E75029</imas:Color>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">大人びた容姿と高い身長が特徴の女の子。何にでも興味津々で純粋な様子は、まるで子犬のよう。特撮モノが大好きでヒーローに憧れている。小学6年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -483,7 +483,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q62024310"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">FFCB13</imas:Color>
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">ボーイッシュでクールな女の子。言葉遣いが乱暴なので人に怖がられることが多いが、根は純情で、素直になれないタイプ。高校2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -518,7 +518,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q43426885"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">90E667</imas:Color>
     <schema:birthPlace xml:lang="ja">愛知</schema:birthPlace>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">裕福な家庭に生まれた社長令嬢。家名に誇りを持ち、自らもその肩書に恥じぬよう日々鍛錬を積んでいる。スタイルがよく、引き締まっている。大学2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -554,7 +554,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q56702852"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">84C0EA</imas:Color>
     <schema:birthPlace xml:lang="ja">鳥取</schema:birthPlace>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">落ち着いた佇まいの大和撫子。常に礼儀正しく、一歩引いて相手を立てる性格。少女漫画好きという意外な趣味を持つ。高校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -588,7 +588,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17993659"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F93B90</imas:Color>
     <schema:birthPlace xml:lang="ja">千葉</schema:birthPlace>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">クラスに一人はいるごく普通の女の子。明るく親しみやすい性格で、甘いものが大好き。名前にちなんで、チョコ好きアイドルを売りにしている。高校2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -622,7 +622,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q59141816"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">5CE626</imas:Color>
     <schema:birthPlace xml:lang="ja">茨城</schema:birthPlace>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">常に控えめな笑顔で、清楚に見える女の子。可愛いものが大好きで、周囲への気配りをするなど人に好かれるように振る舞う。専門学校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -657,7 +657,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q62078438"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F30100</imas:Color>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">常に面白いことを探し、じっとしていることがない、探究心の強い女の子。興味を持ったら一直線だが、飽きっぽい一面も持つ中学2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -692,7 +692,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1050949"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">FF00FF</imas:Color>
     <schema:birthPlace xml:lang="ja">埼玉</schema:birthPlace>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">ノリがよく、楽天的で大雑把な性格の女の子。難しいことを考えるのは苦手だが、親しみやすい高校3年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>

--- a/RDFs/765AS.rdf
+++ b/RDFs/765AS.rdf
@@ -43,7 +43,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--04-03</schema:birthDate>
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">カラオケ</imas:Hobby>
     <imas:Hobby xml:lang="ja">長電話</imas:Hobby>
     <imas:Talent xml:lang="ja">お菓子作り</imas:Talent>
@@ -80,7 +80,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--02-25</schema:birthDate>
     <imas:Constellation xml:lang="ja">魚座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">音楽鑑賞</imas:Hobby>
     <imas:Talent xml:lang="ja">歌</imas:Talent>
     <imas:Favorite xml:lang="ja">トレーニング</imas:Favorite>
@@ -116,7 +116,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--11-23</schema:birthDate>
     <imas:Constellation xml:lang="ja">射手座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">友達とおしゃべり</imas:Hobby>
     <imas:Hobby xml:lang="ja">ネイルアート</imas:Hobby>
     <imas:Talent xml:lang="ja">寝ること</imas:Talent>
@@ -154,7 +154,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--12-24</schema:birthDate>
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">MY詩集を書くこと</imas:Hobby>
     <imas:Talent xml:lang="ja">日本茶をいれること</imas:Talent>
     <imas:Favorite xml:lang="ja">ブログ</imas:Favorite>
@@ -190,7 +190,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--03-25</schema:birthDate>
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">オセロ</imas:Hobby>
     <imas:Hobby xml:lang="ja">野球</imas:Hobby>
     <imas:Talent xml:lang="ja">節約</imas:Talent>
@@ -228,7 +228,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-29</schema:birthDate>
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">スポーツ全般</imas:Hobby>
     <imas:Talent xml:lang="ja">空手</imas:Talent>
     <imas:Talent xml:lang="ja">ダンス</imas:Talent>
@@ -265,7 +265,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-05</schema:birthDate>
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">海外旅行</imas:Hobby>
     <imas:Hobby xml:lang="ja">食べ歩き</imas:Hobby>
     <imas:Talent xml:lang="ja">ショッピング</imas:Talent>
@@ -302,7 +302,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--01-21</schema:birthDate>
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">天体観測</imas:Hobby>
     <imas:Hobby xml:lang="ja">歴史</imas:Hobby>
     <imas:Talent xml:lang="ja">直感</imas:Talent>
@@ -339,7 +339,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--06-23</schema:birthDate>
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">資格取得</imas:Hobby>
     <imas:Talent xml:lang="ja">分析・実践</imas:Talent>
     <imas:Favorite xml:lang="ja">ゲーム</imas:Favorite>
@@ -376,7 +376,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--07-19</schema:birthDate>
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">犬の散歩</imas:Hobby>
     <imas:Talent xml:lang="ja">占い</imas:Talent>
     <imas:Favorite xml:lang="ja">カフェ巡り</imas:Favorite>
@@ -412,7 +412,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-22</schema:birthDate>
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">メール</imas:Hobby>
     <imas:Hobby xml:lang="ja">エコ</imas:Hobby>
     <imas:Talent xml:lang="ja">モノマネ</imas:Talent>
@@ -449,7 +449,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-22</schema:birthDate>
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Hobby xml:lang="ja">メール</imas:Hobby>
     <imas:Hobby xml:lang="ja">ゲーム</imas:Hobby>
     <imas:Talent xml:lang="ja">モノマネ</imas:Talent>
@@ -486,7 +486,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--10-10</schema:birthDate>
     <imas:Constellation xml:lang="ja">天秤座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">編み物</imas:Hobby>
     <imas:Hobby xml:lang="ja">卓球</imas:Hobby>
     <imas:Talent xml:lang="ja">家事全般</imas:Talent>

--- a/RDFs/765AS.rdf
+++ b/RDFs/765AS.rdf
@@ -52,7 +52,7 @@
     <imas:cv xml:lang="ja">中村繪里子</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/中村繪里子"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q911795"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">765AS</imas:Title>
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
@@ -88,7 +88,7 @@
     <imas:cv xml:lang="ja">今井麻美</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/今井麻美"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1042804"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">765AS</imas:Title>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
@@ -126,7 +126,7 @@
     <imas:cv xml:lang="ja">長谷川明子</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/長谷川明子"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q901104"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">765AS</imas:Title>
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
@@ -162,7 +162,7 @@
     <imas:cv xml:lang="ja">浅倉杏美</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/浅倉杏美"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q8191313"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">765AS</imas:Title>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
@@ -200,7 +200,7 @@
     <imas:cv xml:lang="ja">仁後真耶子</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/仁後真耶子"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1096256"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">765AS</imas:Title>
     <schema:birthPlace xml:lang="ja">埼玉</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
@@ -237,7 +237,7 @@
     <imas:cv xml:lang="ja">平田宏美</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/平田宏美"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q224847"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">765AS</imas:Title>
     <schema:birthPlace xml:lang="ja">静岡</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
@@ -274,7 +274,7 @@
     <imas:cv xml:lang="ja">釘宮理恵</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/釘宮理恵"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q49554"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">765AS</imas:Title>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
@@ -311,7 +311,7 @@
     <imas:cv xml:lang="ja">原由実</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/原由実"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q901521"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">765AS</imas:Title>
     <schema:birthPlace xml:lang="ja">京都？</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
@@ -348,7 +348,7 @@
     <imas:cv xml:lang="ja">若林直美</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/若林直美"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q3870205"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">765AS</imas:Title>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
@@ -384,7 +384,7 @@
     <imas:cv xml:lang="ja">たかはし智秋</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/たかはし智秋"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1149403"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">765AS</imas:Title>
     <schema:birthPlace xml:lang="ja">千葉</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
@@ -421,7 +421,7 @@
     <imas:cv xml:lang="ja">下田麻美</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/下田麻美"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1070511"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">765AS</imas:Title>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
@@ -458,7 +458,7 @@
     <imas:cv xml:lang="ja">下田麻美</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/下田麻美"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1070511"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">765AS</imas:Title>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
@@ -496,7 +496,7 @@
     <imas:cv xml:lang="ja">沼倉愛美</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/沼倉愛美"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q3844242"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">765AS</imas:Title>
     <schema:birthPlace xml:lang="ja">沖縄</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>

--- a/RDFs/765MillionStars.rdf
+++ b/RDFs/765MillionStars.rdf
@@ -43,7 +43,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--06-28</schema:birthDate>
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">可愛い髪留めを集めること</imas:Hobby>
     <imas:Talent xml:lang="ja">歌うこと</imas:Talent>
     <imas:Favorite xml:lang="ja">ライブ</imas:Favorite>
@@ -79,7 +79,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--09-14</schema:birthDate>
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">テニス</imas:Hobby>
     <imas:Talent xml:lang="ja">ピアノ</imas:Talent>
     <imas:Favorite xml:lang="ja">うどん</imas:Favorite>
@@ -115,7 +115,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--07-30</schema:birthDate>
     <imas:Constellation xml:lang="ja">獅子座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Hobby xml:lang="ja">遊びの計画をたてること</imas:Hobby>
     <imas:Talent xml:lang="ja">じゃんけん</imas:Talent>
     <imas:Favorite xml:lang="ja">ビーフステーキ</imas:Favorite>
@@ -151,7 +151,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--10-05</schema:birthDate>
     <imas:Constellation xml:lang="ja">天秤座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">お風呂</imas:Hobby>
     <imas:Talent xml:lang="ja">フェンシング</imas:Talent>
     <imas:Favorite xml:lang="ja">アイス</imas:Favorite>
@@ -187,7 +187,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--10-26</schema:birthDate>
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">パーティー</imas:Hobby>
     <imas:Talent xml:lang="ja">サンバを踊ること</imas:Talent>
     <imas:Favorite xml:lang="ja">みんなで騒ぐこと</imas:Favorite>
@@ -223,7 +223,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--03-22</schema:birthDate>
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">格闘ゲーム</imas:Hobby>
     <imas:Talent xml:lang="ja">料理</imas:Talent>
     <imas:Favorite xml:lang="ja">友達との長電話</imas:Favorite>
@@ -259,7 +259,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--04-15</schema:birthDate>
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">カラオケ</imas:Hobby>
     <imas:Talent xml:lang="ja">人の誕生日を覚えること</imas:Talent>
     <imas:Favorite xml:lang="ja">友達</imas:Favorite>
@@ -295,7 +295,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--02-04</schema:birthDate>
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">漫画あつめ</imas:Hobby>
     <imas:Talent xml:lang="ja">演技</imas:Talent>
     <imas:Favorite xml:lang="ja">焼きマシュマロ</imas:Favorite>
@@ -332,7 +332,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--02-20</schema:birthDate>
     <imas:Constellation xml:lang="ja">魚座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">バイオリン</imas:Hobby>
     <imas:Talent xml:lang="ja">アジリティのハンドラー</imas:Talent>
     <imas:Favorite xml:lang="ja">紅茶</imas:Favorite>
@@ -369,7 +369,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--12-03</schema:birthDate>
     <imas:Constellation xml:lang="ja">射手座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Hobby xml:lang="ja">スキップ</imas:Hobby>
     <imas:Talent xml:lang="ja">インラインスケート</imas:Talent>
     <imas:Favorite xml:lang="ja">プリン</imas:Favorite>
@@ -405,7 +405,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-31</schema:birthDate>
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">オンラインゲーム</imas:Hobby>
     <imas:Talent xml:lang="ja">タイピング</imas:Talent>
     <imas:Favorite xml:lang="ja">かわいいもの</imas:Favorite>
@@ -444,7 +444,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--03-01</schema:birthDate>
     <imas:Constellation xml:lang="ja">魚座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">物を作ること</imas:Hobby>
     <imas:Talent xml:lang="ja">目を閉じたまま歩ける</imas:Talent>
     <imas:Favorite xml:lang="ja">ハト</imas:Favorite>
@@ -480,7 +480,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--03-18</schema:birthDate>
     <imas:Constellation xml:lang="ja">魚座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">読書</imas:Hobby>
     <imas:Talent xml:lang="ja">ペン回し</imas:Talent>
     <imas:Favorite xml:lang="ja">おはぎ</imas:Favorite>
@@ -516,7 +516,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--12-29</schema:birthDate>
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">ハリネズミの飼育</imas:Hobby>
     <imas:Talent xml:lang="ja">一晩寝ると元気になれる</imas:Talent>
     <imas:Favorite xml:lang="ja">友達</imas:Favorite>
@@ -553,7 +553,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--06-07</schema:birthDate>
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">アイドルのデータ集め</imas:Hobby>
     <imas:Talent xml:lang="ja">アイドルの変装を見破れる</imas:Talent>
     <imas:Favorite xml:lang="ja">ファミレスのデザート</imas:Favorite>
@@ -589,7 +589,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-10</schema:birthDate>
     <imas:Constellation xml:lang="ja">獅子座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">ボルダリング</imas:Hobby>
     <imas:Talent xml:lang="ja">常人にできないポージングができる</imas:Talent>
     <imas:Favorite xml:lang="ja">ダンス</imas:Favorite>
@@ -625,7 +625,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--12-16</schema:birthDate>
     <imas:Constellation xml:lang="ja">射手座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">アニメ鑑賞</imas:Hobby>
     <imas:Talent xml:lang="ja">早起き</imas:Talent>
     <imas:Favorite xml:lang="ja">おかあさん</imas:Favorite>
@@ -661,7 +661,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--11-11</schema:birthDate>
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Hobby xml:lang="ja">ファンに喜んでもらうこと</imas:Hobby>
     <imas:Talent xml:lang="ja">口げんか</imas:Talent>
     <imas:Favorite xml:lang="ja">かわいい扇子</imas:Favorite>
@@ -697,7 +697,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--01-08</schema:birthDate>
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">かるた遊び</imas:Hobby>
     <imas:Talent xml:lang="ja">日本舞踊</imas:Talent>
     <imas:Favorite xml:lang="ja">抹茶</imas:Favorite>
@@ -733,7 +733,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--01-18</schema:birthDate>
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">お気に入りの絵本を探すこと</imas:Hobby>
     <imas:Talent xml:lang="ja">記憶力</imas:Talent>
     <imas:Talent xml:lang="ja">集中力が高い</imas:Talent>
@@ -770,7 +770,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--07-23</schema:birthDate>
     <imas:Constellation xml:lang="ja">獅子座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">ショッピング</imas:Hobby>
     <imas:Talent xml:lang="ja">ダンス</imas:Talent>
     <imas:Favorite xml:lang="ja">わさび</imas:Favorite>
@@ -806,7 +806,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--07-04</schema:birthDate>
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">ガーデニング</imas:Hobby>
     <imas:Talent xml:lang="ja">天気を当てること</imas:Talent>
     <imas:Favorite xml:lang="ja">おばあちゃん</imas:Favorite>
@@ -842,7 +842,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-18</schema:birthDate>
     <imas:Constellation xml:lang="ja">獅子座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">なんでも歌にすること</imas:Hobby>
     <imas:Talent xml:lang="ja">合唱</imas:Talent>
     <imas:Favorite xml:lang="ja">屋上で歌うこと</imas:Favorite>
@@ -878,7 +878,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--02-12</schema:birthDate>
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">銭湯＆温泉巡り</imas:Hobby>
     <imas:Talent xml:lang="ja">スタミナがある</imas:Talent>
     <imas:Favorite xml:lang="ja">友達とおしゃべり</imas:Favorite>
@@ -914,7 +914,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--10-21</schema:birthDate>
     <imas:Constellation xml:lang="ja">天秤座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">カフェでアパレル誌チェック</imas:Hobby>
     <imas:Talent xml:lang="ja">人の名前と顔を忘れない</imas:Talent>
     <imas:Favorite xml:lang="ja">憧れの目で見られること</imas:Favorite>
@@ -950,7 +950,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--06-12</schema:birthDate>
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">北米ドラマ鑑賞</imas:Hobby>
     <imas:Talent xml:lang="ja">麻雀</imas:Talent>
     <imas:Favorite xml:lang="ja">日本酒</imas:Favorite>
@@ -986,7 +986,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--04-29</schema:birthDate>
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">探検</imas:Hobby>
     <imas:Talent xml:lang="ja">石投げ</imas:Talent>
     <imas:Favorite xml:lang="ja">アスレチックランド</imas:Favorite>
@@ -1022,7 +1022,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--09-02</schema:birthDate>
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">献血</imas:Hobby>
     <imas:Talent xml:lang="ja">息を止めること</imas:Talent>
     <imas:Favorite xml:lang="ja">猫</imas:Favorite>
@@ -1058,7 +1058,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--04-24</schema:birthDate>
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">囲碁</imas:Hobby>
     <imas:Hobby xml:lang="ja">将棋</imas:Hobby>
     <imas:Talent xml:lang="ja">視力が高い</imas:Talent>
@@ -1095,7 +1095,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--03-30</schema:birthDate>
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">格闘技観戦</imas:Hobby>
     <imas:Talent xml:lang="ja">バイクの運転</imas:Talent>
     <imas:Favorite xml:lang="ja">焼肉</imas:Favorite>
@@ -1131,7 +1131,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--01-27</schema:birthDate>
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">手品</imas:Hobby>
     <imas:Talent xml:lang="ja">バトントワリング</imas:Talent>
     <imas:Favorite xml:lang="ja">クロスワードパズル</imas:Favorite>
@@ -1167,7 +1167,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-27</schema:birthDate>
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">アロマテラピー</imas:Hobby>
     <imas:Talent xml:lang="ja">ポーカーフェイス</imas:Talent>
     <imas:Favorite xml:lang="ja">お風呂</imas:Favorite>
@@ -1203,7 +1203,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--11-21</schema:birthDate>
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">ヨガエクササイズ</imas:Hobby>
     <imas:Talent xml:lang="ja">メイク</imas:Talent>
     <imas:Favorite xml:lang="ja">可愛くてセクシーな服</imas:Favorite>
@@ -1239,7 +1239,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--09-20</schema:birthDate>
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Hobby xml:lang="ja">野球</imas:Hobby>
     <imas:Talent xml:lang="ja">変化球</imas:Talent>
     <imas:Favorite xml:lang="ja">アイドル</imas:Favorite>
@@ -1275,7 +1275,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-17</schema:birthDate>
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">登山</imas:Hobby>
     <imas:Talent xml:lang="ja">肺活量が大きい</imas:Talent>
     <imas:Favorite xml:lang="ja">ドライブ</imas:Favorite>
@@ -1311,7 +1311,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--11-06</schema:birthDate>
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">かわいいシール集め</imas:Hobby>
     <imas:Talent xml:lang="ja">演技や台詞の暗記</imas:Talent>
     <imas:Favorite xml:lang="ja">ホットケーキ</imas:Favorite>
@@ -1341,7 +1341,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--09-26</schema:birthDate>
     <imas:Constellation xml:lang="ja">天秤座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Hobby xml:lang="ja">なし</imas:Hobby>
     <imas:Talent xml:lang="ja">ギター</imas:Talent>
     <imas:Favorite xml:lang="ja">パンクロック</imas:Favorite>
@@ -1377,7 +1377,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-29</schema:birthDate>
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">庭園</imas:Hobby>
     <imas:Hobby xml:lang="ja">甘味処の散策</imas:Hobby>
     <imas:Talent xml:lang="ja">着物の着付け</imas:Talent>
@@ -1415,7 +1415,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--03-27</schema:birthDate>
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">乗馬</imas:Hobby>
     <imas:Talent xml:lang="ja">合唱</imas:Talent>
     <imas:Talent xml:lang="ja">ゴルフ</imas:Talent>

--- a/RDFs/765MillionStars.rdf
+++ b/RDFs/765MillionStars.rdf
@@ -51,7 +51,7 @@
     <imas:cv xml:lang="ja">山崎はるか</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/山崎はるか"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1661535"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
@@ -87,7 +87,7 @@
     <imas:cv xml:lang="ja">田所あずさ</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/田所あずさ"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q247629"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">埼玉</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
@@ -123,7 +123,7 @@
     <imas:cv xml:lang="ja">Machico</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/Machico"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11232628"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
@@ -159,7 +159,7 @@
     <imas:cv xml:lang="ja">種田梨沙</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/種田梨沙"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q130125"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
@@ -195,7 +195,7 @@
     <imas:cv xml:lang="ja">角元明日香</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/角元明日香"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q16265138"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">ブラジル</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
@@ -231,7 +231,7 @@
     <imas:cv xml:lang="ja">大関英里</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/大関英里"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q16264714"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
@@ -267,7 +267,7 @@
     <imas:cv xml:lang="ja">藤井ゆきよ</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/藤井ゆきよ"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11622668"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">埼玉</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
@@ -304,7 +304,7 @@
     <imas:cv xml:lang="ja">諏訪彩花</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/諏訪彩花"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11631872"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">愛知</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
@@ -341,7 +341,7 @@
     <imas:cv xml:lang="ja">麻倉もも</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/麻倉もも"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q16263653"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
@@ -377,7 +377,7 @@
     <imas:cv xml:lang="ja">小笠原早紀</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/小笠原早紀"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11463365"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">埼玉</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
@@ -413,7 +413,7 @@
     <imas:cv xml:lang="ja">夏川椎菜</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/夏川椎菜"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17226876"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
@@ -452,7 +452,7 @@
     <imas:cv xml:lang="ja">中村温姫</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/中村温姫"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q20041868"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
@@ -488,7 +488,7 @@
     <imas:cv xml:lang="ja">伊藤美来</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/伊藤美来"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q16264202"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
@@ -525,7 +525,7 @@
     <imas:cv xml:lang="ja">駒形友梨</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/駒形友梨"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11668361"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">茨城</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
@@ -561,7 +561,7 @@
     <imas:cv xml:lang="ja">村川梨衣</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/村川梨衣"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q2811985"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
@@ -597,7 +597,7 @@
     <imas:cv xml:lang="ja">上田麗奈</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/上田麗奈"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q16264425"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">千葉</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
@@ -633,7 +633,7 @@
     <imas:cv xml:lang="ja">原嶋あかり</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/原嶋あかり"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11409597"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
@@ -669,7 +669,7 @@
     <imas:cv xml:lang="ja">小岩井ことり</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/小岩井ことり"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11460022"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
@@ -705,7 +705,7 @@
     <imas:cv xml:lang="ja">郁原ゆう</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/郁原ゆう"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17349881"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">イギリス</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
@@ -742,7 +742,7 @@
     <imas:cv xml:lang="ja">雨宮天</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/雨宮天"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q14635194"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
@@ -778,7 +778,7 @@
     <imas:cv xml:lang="ja">戸田めぐみ</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/戸田めぐみ"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q16003597"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">愛媛</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
@@ -814,7 +814,7 @@
     <imas:cv xml:lang="ja">田村奈央</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/田村奈央"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11576902"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">北海道</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
@@ -850,7 +850,7 @@
     <imas:cv xml:lang="ja">木戸衣吹</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/木戸衣吹"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q2276072"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
@@ -886,7 +886,7 @@
     <imas:cv xml:lang="ja">渡部優衣</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/渡部優衣"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11562757"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">大阪</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
@@ -922,7 +922,7 @@
     <imas:cv xml:lang="ja">野村香菜子</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/野村香菜子"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17215985"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
@@ -958,7 +958,7 @@
     <imas:cv xml:lang="ja">高橋未奈美</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/高橋未奈美"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q14756009"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">山口</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
@@ -994,7 +994,7 @@
     <imas:cv xml:lang="ja">稲川英里</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/稲川英里"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q16264225"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">香川</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
@@ -1030,7 +1030,7 @@
     <imas:cv xml:lang="ja">末柄里恵</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/末柄里恵"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17159842"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">千葉</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
@@ -1067,7 +1067,7 @@
     <imas:cv xml:lang="ja">桐谷蝶々</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/桐谷蝶々"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17157954"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
@@ -1103,7 +1103,7 @@
     <imas:cv xml:lang="ja">浜崎奈々</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/浜崎奈々"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11557669"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
@@ -1139,7 +1139,7 @@
     <imas:cv xml:lang="ja">阿部里果</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/阿部里果"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q16263736"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
@@ -1175,7 +1175,7 @@
     <imas:cv xml:lang="ja">近藤唯</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/近藤唯"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11638757"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
@@ -1211,7 +1211,7 @@
     <imas:cv xml:lang="ja">山口立花子</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/山口立花子"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11467404"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">広島</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
@@ -1247,7 +1247,7 @@
     <imas:cv xml:lang="ja">斉藤佑圭</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/斉藤佑圭"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1064842"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
@@ -1283,7 +1283,7 @@
     <imas:cv xml:lang="ja">平山笑美</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/平山笑美"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11482546"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">長野</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
@@ -1319,7 +1319,7 @@
     <imas:cv xml:lang="ja">渡部恵子</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/渡部恵子"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17217372"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
@@ -1349,7 +1349,7 @@
     <imas:cv xml:lang="ja">愛美</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/愛美"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11457880"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">福岡</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
@@ -1387,7 +1387,7 @@
     <imas:cv xml:lang="ja">南早紀</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/南早紀"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q28690521"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">石川</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
@@ -1425,7 +1425,7 @@
     <imas:cv xml:lang="ja">香里有佐</imas:cv>
     <!--<imas:cv rdf:resource="http://ja.dbpedia.org/resource/香里有佐"/>-->
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q30932235"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">MillionStars</imas:Title>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>

--- a/RDFs/876.rdf
+++ b/RDFs/876.rdf
@@ -48,7 +48,7 @@
     <imas:cv xml:lang="ja">戸松遥</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/戸松遥"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q50025"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">DearlyStars</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -79,7 +79,7 @@
     <imas:cv xml:lang="ja">花澤香菜</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/花澤香菜"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q49524"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">DearlyStars</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -110,7 +110,7 @@
     <imas:cv xml:lang="ja">三瓶由布子</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/三瓶由布子"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q958874"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">DearlyStars</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -140,7 +140,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1193033"/>
     <imas:Hobby xml:lang="ja">料理</imas:Hobby>
     <schema:birthPlace xml:lang="ja">大阪</schema:birthPlace>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">DearlyStars</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -173,7 +173,7 @@
     <imas:cv xml:lang="ja">ゆりん</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/ゆりん"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q8061678"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">DearlyStars</imas:Title>
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
@@ -193,7 +193,7 @@
     <imas:cv xml:lang="ja">今野宏美</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/今野宏美"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q843178"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1054Pro</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -212,7 +212,7 @@
     <imas:cv xml:lang="ja">阿澄佳奈</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/阿澄佳奈"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q49474"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1054Pro</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -231,7 +231,7 @@
     <imas:cv xml:lang="ja">茅原実里</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/茅原実里"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q256910"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1054Pro</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>

--- a/RDFs/876.rdf
+++ b/RDFs/876.rdf
@@ -168,7 +168,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--12-14</schema:birthDate>
     <imas:Constellation xml:lang="ja">射手座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">both</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">both</imas:Handedness>
     <imas:Hobby xml:lang="ja">カラオケ</imas:Hobby>
     <imas:cv xml:lang="ja">ゆりん</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/ゆりん"/>

--- a/RDFs/961.rdf
+++ b/RDFs/961.rdf
@@ -51,7 +51,7 @@
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--09-16</schema:birthDate>
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Hobby xml:lang="ja">オルゴール集め</imas:Hobby>
     <imas:Hobby xml:lang="ja">ロボのおもちゃ</imas:Hobby>
     <imas:Talent xml:lang="ja">クロール</imas:Talent>

--- a/RDFs/961.rdf
+++ b/RDFs/961.rdf
@@ -32,7 +32,7 @@
     <imas:cv xml:lang="ja">茅原実里</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/茅原実里"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q256910"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">961ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -59,7 +59,7 @@
     <imas:cv xml:lang="ja">高橋李依</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/高橋李依"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17160610"/>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">961ProIdols</imas:Title>
     <schema:birthPlace xml:lang="ja">オーストリア</schema:birthPlace>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>

--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -31,7 +31,7 @@
     <schema:givenName xml:lang="ja">卯月</schema:givenName>
     <schema:givenName xml:lang="en">Uzuki</schema:givenName>
     <imas:givenNameKana xml:lang="ja">うづき</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">島村卯月</schema:name>
@@ -64,7 +64,7 @@
     <schema:givenName xml:lang="ja">有香</schema:givenName>
     <schema:givenName xml:lang="en">Yuka</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ゆか</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">中野有香</schema:name>
@@ -97,7 +97,7 @@
     <schema:givenName xml:lang="ja">ゆかり</schema:givenName>
     <schema:givenName xml:lang="en">Yukari</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ゆかり</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">水本ゆかり</schema:name>
@@ -130,7 +130,7 @@
     <schema:givenName xml:lang="ja">舞</schema:givenName>
     <schema:givenName xml:lang="en">Mai</schema:givenName>
     <imas:givenNameKana xml:lang="ja">まい</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">福山舞</schema:name>
@@ -159,7 +159,7 @@
     <schema:givenName xml:lang="ja">法子</schema:givenName>
     <schema:givenName xml:lang="en">Noriko</schema:givenName>
     <imas:givenNameKana xml:lang="ja">のりこ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">椎名法子</schema:name>
@@ -192,7 +192,7 @@
     <schema:givenName xml:lang="ja">加奈</schema:givenName>
     <schema:givenName xml:lang="en">Kana</schema:givenName>
     <imas:givenNameKana xml:lang="ja">かな</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">今井加奈</schema:name>
@@ -221,7 +221,7 @@
     <schema:givenName xml:lang="ja">亜里沙</schema:givenName>
     <schema:givenName xml:lang="en">Arisa</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ありさ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">持田亜里沙</schema:name>
@@ -250,7 +250,7 @@
     <schema:givenName xml:lang="ja">かな子</schema:givenName>
     <schema:givenName xml:lang="en">Kanako</schema:givenName>
     <imas:givenNameKana xml:lang="ja">かなこ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">三村かな子</schema:name>
@@ -283,7 +283,7 @@
     <schema:givenName xml:lang="ja">沙織</schema:givenName>
     <schema:givenName xml:lang="en">Saori</schema:givenName>
     <imas:givenNameKana xml:lang="ja">さおり</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">奥山沙織</schema:name>
@@ -312,7 +312,7 @@
     <schema:givenName xml:lang="ja">美里</schema:givenName>
     <schema:givenName xml:lang="en">Misato</schema:givenName>
     <imas:givenNameKana xml:lang="ja">みさと</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">間中美里</schema:name>
@@ -341,7 +341,7 @@
     <schema:givenName xml:lang="ja">美穂</schema:givenName>
     <schema:givenName xml:lang="en">Miho</schema:givenName>
     <imas:givenNameKana xml:lang="ja">みほ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">小日向美穂</schema:name>
@@ -374,7 +374,7 @@
     <schema:givenName xml:lang="ja">智絵里</schema:givenName>
     <schema:givenName xml:lang="en">Chieri</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ちえり</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">緒方智絵里</schema:name>
@@ -407,7 +407,7 @@
     <schema:givenName xml:lang="ja">響子</schema:givenName>
     <schema:givenName xml:lang="en">Kyoko</schema:givenName>
     <imas:givenNameKana xml:lang="ja">きょうこ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">五十嵐響子</schema:name>
@@ -440,7 +440,7 @@
     <schema:givenName xml:lang="ja">美由紀</schema:givenName>
     <schema:givenName xml:lang="en">Miyuki</schema:givenName>
     <imas:givenNameKana xml:lang="ja">みゆき</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">柳瀬美由紀</schema:name>
@@ -469,7 +469,7 @@
     <schema:givenName xml:lang="ja">桃華</schema:givenName>
     <schema:givenName xml:lang="en">Momoka</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ももか</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">櫻井桃華</schema:name>
@@ -502,7 +502,7 @@
     <schema:givenName xml:lang="ja">椿</schema:givenName>
     <schema:givenName xml:lang="en">Tsubaki</schema:givenName>
     <imas:givenNameKana xml:lang="ja">つばき</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">江上椿</schema:name>
@@ -531,7 +531,7 @@
     <schema:givenName xml:lang="ja">蓮実</schema:givenName>
     <schema:givenName xml:lang="en">Hasumi</schema:givenName>
     <imas:givenNameKana xml:lang="ja">はすみ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">長富蓮実</schema:name>
@@ -561,7 +561,7 @@
     <schema:givenName xml:lang="ja">千佳</schema:givenName>
     <schema:givenName xml:lang="en">Chika</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ちか</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">横山千佳</schema:name>
@@ -590,7 +590,7 @@
     <schema:givenName xml:lang="ja">裕美</schema:givenName>
     <schema:givenName xml:lang="en">Hiromi</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ひろみ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">関裕美</schema:name>
@@ -623,7 +623,7 @@
     <schema:givenName xml:lang="ja">優</schema:givenName>
     <schema:givenName xml:lang="en">Yuu</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ゆう</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">太田優</schema:name>
@@ -653,7 +653,7 @@
     <schema:givenName xml:lang="ja">愛海</schema:givenName>
     <schema:givenName xml:lang="en">Atsumi</schema:givenName>
     <imas:givenNameKana xml:lang="ja">あつみ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">棟方愛海</schema:name>
@@ -686,7 +686,7 @@
     <schema:givenName xml:lang="ja">里奈</schema:givenName>
     <schema:givenName xml:lang="en">Rina</schema:givenName>
     <imas:givenNameKana xml:lang="ja">りな</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">藤本里奈</schema:name>
@@ -720,7 +720,7 @@
     <schema:givenName xml:lang="ja">みちる</schema:givenName>
     <schema:givenName xml:lang="en">Michiru</schema:givenName>
     <imas:givenNameKana xml:lang="ja">みちる</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">大原みちる</schema:name>
@@ -749,7 +749,7 @@
     <schema:givenName xml:lang="ja">こずえ</schema:givenName>
     <schema:givenName xml:lang="en">Kozue</schema:givenName>
     <imas:givenNameKana xml:lang="ja">こずえ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">遊佐こずえ</schema:name>
@@ -781,7 +781,7 @@
     <schema:givenName xml:lang="ja">くるみ</schema:givenName>
     <schema:givenName xml:lang="en">Kurumi</schema:givenName>
     <imas:givenNameKana xml:lang="ja">くるみ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">大沼くるみ</schema:name>
@@ -811,7 +811,7 @@
     <schema:givenName xml:lang="ja">志希</schema:givenName>
     <schema:givenName xml:lang="en">Shiki</schema:givenName>
     <imas:givenNameKana xml:lang="ja">しき</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">一ノ瀬志希</schema:name>
@@ -846,7 +846,7 @@
     <schema:givenName xml:lang="ja">みく</schema:givenName>
     <schema:givenName xml:lang="en">Miku</schema:givenName>
     <imas:givenNameKana xml:lang="ja">みく</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">前川みく</schema:name>
@@ -879,7 +879,7 @@
     <schema:givenName xml:lang="ja">瑛梨華</schema:givenName>
     <schema:givenName xml:lang="en">Erika</schema:givenName>
     <imas:givenNameKana xml:lang="ja">えりか</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">赤西瑛梨華</schema:name>
@@ -908,7 +908,7 @@
     <schema:givenName xml:lang="ja">早耶</schema:givenName>
     <schema:givenName xml:lang="en">Saya</schema:givenName>
     <imas:givenNameKana xml:lang="ja">さや</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">松原早耶</schema:name>
@@ -937,7 +937,7 @@
     <schema:givenName xml:lang="ja">雪乃</schema:givenName>
     <schema:givenName xml:lang="en">Yukino</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ゆきの</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">相原雪乃</schema:name>
@@ -966,7 +966,7 @@
     <schema:givenName xml:lang="ja">フレデリカ</schema:givenName>
     <schema:givenName xml:lang="en">Frederica</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ふれでりか</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">宮本フレデリカ</schema:name>
@@ -999,7 +999,7 @@
     <schema:givenName xml:lang="ja">紗枝</schema:givenName>
     <schema:givenName xml:lang="en">Sae</schema:givenName>
     <imas:givenNameKana xml:lang="ja">さえ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">小早川紗枝</schema:name>
@@ -1032,7 +1032,7 @@
     <schema:givenName xml:lang="ja">琴歌</schema:givenName>
     <schema:givenName xml:lang="en">Kotoka</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ことか</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">西園寺琴歌</schema:name>
@@ -1061,7 +1061,7 @@
     <schema:givenName xml:lang="ja">杏</schema:givenName>
     <schema:givenName xml:lang="en">Anzu</schema:givenName>
     <imas:givenNameKana xml:lang="ja">あんず</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">双葉杏</schema:name>
@@ -1094,7 +1094,7 @@
     <schema:givenName xml:lang="ja">菲菲</schema:givenName>
     <schema:givenName xml:lang="en">Fueifuei</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ふぇいふぇい</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">楊菲菲</schema:name>
@@ -1123,7 +1123,7 @@
     <schema:givenName xml:lang="ja">あずき</schema:givenName>
     <schema:givenName xml:lang="en">Azuki</schema:givenName>
     <imas:givenNameKana xml:lang="ja">あずき</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">桃井あずき</schema:name>
@@ -1152,7 +1152,7 @@
     <schema:givenName xml:lang="ja">星花</schema:givenName>
     <schema:givenName xml:lang="en">Seika</schema:givenName>
     <imas:givenNameKana xml:lang="ja">せいか</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">涼宮星花</schema:name>
@@ -1181,7 +1181,7 @@
     <schema:givenName xml:lang="ja">雅</schema:givenName>
     <schema:givenName xml:lang="en">Miyabi</schema:givenName>
     <imas:givenNameKana xml:lang="ja">みやび</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">月宮雅</schema:name>
@@ -1210,7 +1210,7 @@
     <schema:givenName xml:lang="ja">レナ</schema:givenName>
     <schema:givenName xml:lang="en">Rena</schema:givenName>
     <imas:givenNameKana xml:lang="ja">れな</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">兵藤レナ</schema:name>
@@ -1239,7 +1239,7 @@
     <schema:givenName xml:lang="ja">仁美</schema:givenName>
     <schema:givenName xml:lang="en">Hitomi</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ひとみ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">丹羽仁美</schema:name>
@@ -1269,7 +1269,7 @@
     <schema:givenName xml:lang="ja">歌鈴</schema:givenName>
     <schema:givenName xml:lang="en">Karin</schema:givenName>
     <imas:givenNameKana xml:lang="ja">かりん</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">道明寺歌鈴</schema:name>
@@ -1302,7 +1302,7 @@
     <schema:givenName xml:lang="ja">清良</schema:givenName>
     <schema:givenName xml:lang="en">Kiyora</schema:givenName>
     <imas:givenNameKana xml:lang="ja">きよら</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">柳清良</schema:name>
@@ -1331,7 +1331,7 @@
     <schema:givenName xml:lang="ja">雪菜</schema:givenName>
     <schema:givenName xml:lang="en">Setsuna</schema:givenName>
     <imas:givenNameKana xml:lang="ja">せつな</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">井村雪菜</schema:name>
@@ -1360,7 +1360,7 @@
     <schema:givenName xml:lang="ja">若葉</schema:givenName>
     <schema:givenName xml:lang="en">Wakaba</schema:givenName>
     <imas:givenNameKana xml:lang="ja">わかば</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">日下部若葉</schema:name>
@@ -1389,7 +1389,7 @@
     <schema:givenName xml:lang="ja">里美</schema:givenName>
     <schema:givenName xml:lang="en">Satomi</schema:givenName>
     <imas:givenNameKana xml:lang="ja">さとみ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">榊原里美</schema:name>
@@ -1418,7 +1418,7 @@
     <schema:givenName xml:lang="ja">幸子</schema:givenName>
     <schema:givenName xml:lang="en">Sachiko</schema:givenName>
     <imas:givenNameKana xml:lang="ja">さちこ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">輿水幸子</schema:name>
@@ -1451,7 +1451,7 @@
     <schema:givenName xml:lang="ja">都</schema:givenName>
     <schema:givenName xml:lang="en">Miyako</schema:givenName>
     <imas:givenNameKana xml:lang="ja">みやこ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">安斎都</schema:name>
@@ -1481,7 +1481,7 @@
     <schema:givenName xml:lang="ja">風香</schema:givenName>
     <schema:givenName xml:lang="en">Fuka</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ふうか</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">浅野風香</schema:name>
@@ -1510,7 +1510,7 @@
     <schema:givenName xml:lang="ja">由里子</schema:givenName>
     <schema:givenName xml:lang="en">Yuriko</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ゆりこ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">大西由里子</schema:name>
@@ -1540,7 +1540,7 @@
     <schema:givenName xml:lang="ja">菜々</schema:givenName>
     <schema:givenName xml:lang="en">Nana</schema:givenName>
     <imas:givenNameKana xml:lang="ja">なな</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">安部菜々</schema:name>
@@ -1573,7 +1573,7 @@
     <schema:givenName xml:lang="ja">忍</schema:givenName>
     <schema:givenName xml:lang="en">Shinobu</schema:givenName>
     <imas:givenNameKana xml:lang="ja">しのぶ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">工藤忍</schema:name>
@@ -1602,7 +1602,7 @@
     <schema:givenName xml:lang="ja">ネネ</schema:givenName>
     <schema:givenName xml:lang="en">Nene</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ねね</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">栗原ネネ</schema:name>
@@ -1632,7 +1632,7 @@
     <schema:givenName xml:lang="ja">小春</schema:givenName>
     <schema:givenName xml:lang="en">Koharu</schema:givenName>
     <imas:givenNameKana xml:lang="ja">こはる</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">古賀小春</schema:name>
@@ -1656,7 +1656,7 @@
 
   <rdf:Description rdf:about="detail/Clarice">
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cu</imas:Type>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">クラリス</schema:name>
@@ -1685,7 +1685,7 @@
     <schema:givenName xml:lang="ja">まゆ</schema:givenName>
     <schema:givenName xml:lang="en">Mayu</schema:givenName>
     <imas:givenNameKana xml:lang="ja">まゆ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">佐久間まゆ</schema:name>
@@ -1719,7 +1719,7 @@
     <schema:givenName xml:lang="ja">さくら</schema:givenName>
     <schema:givenName xml:lang="en">Sakura</schema:givenName>
     <imas:givenNameKana xml:lang="ja">さくら</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">村松さくら</schema:name>
@@ -1748,7 +1748,7 @@
     <schema:givenName xml:lang="ja">ほたる</schema:givenName>
     <schema:givenName xml:lang="en">Hotaru</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ほたる</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">白菊ほたる</schema:name>
@@ -1782,7 +1782,7 @@
     <schema:givenName xml:lang="ja">美玲</schema:givenName>
     <schema:givenName xml:lang="en">Mirei</schema:givenName>
     <imas:givenNameKana xml:lang="ja">みれい</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">早坂美玲</schema:name>
@@ -1815,7 +1815,7 @@
     <schema:givenName xml:lang="ja">柑奈</schema:givenName>
     <schema:givenName xml:lang="en">Kanna</schema:givenName>
     <imas:givenNameKana xml:lang="ja">かんな</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">有浦柑奈</schema:name>
@@ -1844,7 +1844,7 @@
     <schema:givenName xml:lang="ja">悠貴</schema:givenName>
     <schema:givenName xml:lang="en">Yuuki</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ゆうき</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">乙倉悠貴</schema:name>
@@ -1878,7 +1878,7 @@
     <schema:givenName xml:lang="ja">美世</schema:givenName>
     <schema:givenName xml:lang="en">Miyo</schema:givenName>
     <imas:givenNameKana xml:lang="ja">みよ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">原田美世</schema:name>
@@ -1908,7 +1908,7 @@
     <schema:givenName xml:lang="ja">晶葉</schema:givenName>
     <schema:givenName xml:lang="en">Akiha</schema:givenName>
     <imas:givenNameKana xml:lang="ja">あきは</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">池袋晶葉</schema:name>
@@ -1937,7 +1937,7 @@
     <schema:givenName xml:lang="ja">あかり</schema:givenName>
     <schema:givenName xml:lang="en">Akari</schema:givenName>
     <imas:givenNameKana xml:lang="ja">あかり</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">辻野あかり</schema:name>
@@ -1967,7 +1967,7 @@
     <schema:givenName xml:lang="ja">千夜</schema:givenName>
     <schema:givenName xml:lang="en">Chiyo</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ちよ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">白雪千夜</schema:name>
@@ -2000,7 +2000,7 @@
     <schema:givenName xml:lang="ja">ちとせ</schema:givenName>
     <schema:givenName xml:lang="en">Chitose</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ちとせ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">黒埼ちとせ</schema:name>
@@ -2034,7 +2034,7 @@
     <schema:givenName xml:lang="ja">凛</schema:givenName>
     <schema:givenName xml:lang="en">Rin</schema:givenName>
     <imas:givenNameKana xml:lang="ja">りん</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">渋谷凛</schema:name>
@@ -2067,7 +2067,7 @@
     <schema:givenName xml:lang="ja">千秋</schema:givenName>
     <schema:givenName xml:lang="en">Chiaki</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ちあき</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">黒川千秋</schema:name>
@@ -2096,7 +2096,7 @@
     <schema:givenName xml:lang="ja">沙理奈</schema:givenName>
     <schema:givenName xml:lang="en">Sarina</schema:givenName>
     <imas:givenNameKana xml:lang="ja">さりな</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">松本沙理奈</schema:name>
@@ -2125,7 +2125,7 @@
     <schema:givenName xml:lang="ja">アヤ</schema:givenName>
     <schema:givenName xml:lang="en">Aya</schema:givenName>
     <imas:givenNameKana xml:lang="ja">あや</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">桐野アヤ</schema:name>
@@ -2154,7 +2154,7 @@
     <schema:givenName xml:lang="ja">礼子</schema:givenName>
     <schema:givenName xml:lang="en">Reiko</schema:givenName>
     <imas:givenNameKana xml:lang="ja">れいこ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">高橋礼子</schema:name>
@@ -2183,7 +2183,7 @@
     <schema:givenName xml:lang="ja">千夏</schema:givenName>
     <schema:givenName xml:lang="en">Chinatsu</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ちなつ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">相川千夏</schema:name>
@@ -2212,7 +2212,7 @@
     <schema:givenName xml:lang="ja">瑞樹</schema:givenName>
     <schema:givenName xml:lang="en">Mizuki</schema:givenName>
     <imas:givenNameKana xml:lang="ja">みずき</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">川島瑞樹</schema:name>
@@ -2246,7 +2246,7 @@
     <schema:givenName xml:lang="ja">奈緒</schema:givenName>
     <schema:givenName xml:lang="en">Nao</schema:givenName>
     <imas:givenNameKana xml:lang="ja">なお</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">神谷奈緒</schema:name>
@@ -2279,7 +2279,7 @@
     <schema:givenName xml:lang="ja">春菜</schema:givenName>
     <schema:givenName xml:lang="en">Haruna</schema:givenName>
     <imas:givenNameKana xml:lang="ja">はるな</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">上条春菜</schema:name>
@@ -2312,7 +2312,7 @@
     <schema:givenName xml:lang="ja">比奈</schema:givenName>
     <schema:givenName xml:lang="en">Hina</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ひな</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">荒木比奈</schema:name>
@@ -2345,7 +2345,7 @@
     <schema:givenName xml:lang="ja">あい</schema:givenName>
     <schema:givenName xml:lang="en">Ai</schema:givenName>
     <imas:givenNameKana xml:lang="ja">あい</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">東郷あい</schema:name>
@@ -2374,7 +2374,7 @@
     <schema:givenName xml:lang="ja">李衣菜</schema:givenName>
     <schema:givenName xml:lang="en">Rina</schema:givenName>
     <imas:givenNameKana xml:lang="ja">りいな</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">多田李衣菜</schema:name>
@@ -2407,7 +2407,7 @@
     <schema:givenName xml:lang="ja">聖來</schema:givenName>
     <schema:givenName xml:lang="en">Seira</schema:givenName>
     <imas:givenNameKana xml:lang="ja">せいら</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">水木聖來</schema:name>
@@ -2436,7 +2436,7 @@
     <schema:givenName xml:lang="ja">千枝</schema:givenName>
     <schema:givenName xml:lang="en">Chie</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ちえ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">佐々木千枝</schema:name>
@@ -2469,7 +2469,7 @@
     <schema:givenName xml:lang="ja">美優</schema:givenName>
     <schema:givenName xml:lang="en">Miyu</schema:givenName>
     <imas:givenNameKana xml:lang="ja">みゆ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">三船美優</schema:name>
@@ -2502,7 +2502,7 @@
     <schema:givenName xml:lang="ja">瞳子</schema:givenName>
     <schema:givenName xml:lang="en">Toko</schema:givenName>
     <imas:givenNameKana xml:lang="ja">とうこ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">服部瞳子</schema:name>
@@ -2532,7 +2532,7 @@
     <schema:givenName xml:lang="ja">真奈美</schema:givenName>
     <schema:givenName xml:lang="en">Manami</schema:givenName>
     <imas:givenNameKana xml:lang="ja">まなみ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">木場真奈美</schema:name>
@@ -2562,7 +2562,7 @@
     <schema:givenName xml:lang="ja">肇</schema:givenName>
     <schema:givenName xml:lang="en">Hajime</schema:givenName>
     <imas:givenNameKana xml:lang="ja">はじめ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">藤原肇</schema:name>
@@ -2596,7 +2596,7 @@
     <schema:givenName xml:lang="ja">美波</schema:givenName>
     <schema:givenName xml:lang="en">Minami</schema:givenName>
     <imas:givenNameKana xml:lang="ja">みなみ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">新田美波</schema:name>
@@ -2630,7 +2630,7 @@
     <schema:givenName xml:lang="ja">翠</schema:givenName>
     <schema:givenName xml:lang="en">Midori</schema:givenName>
     <imas:givenNameKana xml:lang="ja">みどり</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">水野翠</schema:name>
@@ -2659,7 +2659,7 @@
     <schema:givenName xml:lang="ja">頼子</schema:givenName>
     <schema:givenName xml:lang="en">Yoriko</schema:givenName>
     <imas:givenNameKana xml:lang="ja">よりこ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">古澤頼子</schema:name>
@@ -2689,7 +2689,7 @@
     <schema:givenName xml:lang="ja">ありす</schema:givenName>
     <schema:givenName xml:lang="en">Arisu</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ありす</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">橘ありす</schema:name>
@@ -2723,7 +2723,7 @@
     <schema:givenName xml:lang="ja">文香</schema:givenName>
     <schema:givenName xml:lang="en">Fumika</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ふみか</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">鷺沢文香</schema:name>
@@ -2756,7 +2756,7 @@
     <schema:givenName xml:lang="ja">マキノ</schema:givenName>
     <schema:givenName xml:lang="en">Makino</schema:givenName>
     <imas:givenNameKana xml:lang="ja">まきの</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">八神マキノ</schema:name>
@@ -2779,7 +2779,7 @@
 
   <rdf:Description rdf:about="detail/Layla">
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Co</imas:Type>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">ライラ</schema:name>
@@ -2808,7 +2808,7 @@
     <schema:givenName xml:lang="ja">七海</schema:givenName>
     <schema:givenName xml:lang="en">Nanami</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ななみ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">浅利七海</schema:name>
@@ -2832,7 +2832,7 @@
 
   <rdf:Description rdf:about="detail/Helen">
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Co</imas:Type>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">ヘレン</schema:name>
@@ -2861,7 +2861,7 @@
     <schema:givenName xml:lang="ja">涼</schema:givenName>
     <schema:givenName xml:lang="en">Ryo</schema:givenName>
     <imas:givenNameKana xml:lang="ja">りょう</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">松永涼</schema:name>
@@ -2894,7 +2894,7 @@
     <schema:givenName xml:lang="ja">千奈美</schema:givenName>
     <schema:givenName xml:lang="en">Chinami</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ちなみ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">小室千奈美</schema:name>
@@ -2923,7 +2923,7 @@
     <schema:givenName xml:lang="ja">のあ</schema:givenName>
     <schema:givenName xml:lang="en">Noa</schema:givenName>
     <imas:givenNameKana xml:lang="ja">のあ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">高峯のあ</schema:name>
@@ -2952,7 +2952,7 @@
     <schema:givenName xml:lang="ja">楓</schema:givenName>
     <schema:givenName xml:lang="en">Kaede</schema:givenName>
     <imas:givenNameKana xml:lang="ja">かえで</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">高垣楓</schema:name>
@@ -2985,7 +2985,7 @@
     <schema:givenName xml:lang="ja">蘭子</schema:givenName>
     <schema:givenName xml:lang="en">Ranko</schema:givenName>
     <imas:givenNameKana xml:lang="ja">らんこ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">神崎蘭子</schema:name>
@@ -3018,7 +3018,7 @@
     <schema:givenName xml:lang="ja">惠</schema:givenName>
     <schema:givenName xml:lang="en">Megumi</schema:givenName>
     <imas:givenNameKana xml:lang="ja">めぐみ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">伊集院惠</schema:name>
@@ -3047,7 +3047,7 @@
     <schema:givenName xml:lang="ja">志乃</schema:givenName>
     <schema:givenName xml:lang="en">Shino</schema:givenName>
     <imas:givenNameKana xml:lang="ja">しの</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">柊志乃</schema:name>
@@ -3076,7 +3076,7 @@
     <schema:givenName xml:lang="ja">加蓮</schema:givenName>
     <schema:givenName xml:lang="en">Karen</schema:givenName>
     <imas:givenNameKana xml:lang="ja">かれん</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">北条加蓮</schema:name>
@@ -3103,7 +3103,7 @@
 
   <rdf:Description rdf:about="detail/Kate">
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Co</imas:Type>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">ケイト</schema:name>
@@ -3132,7 +3132,7 @@
     <schema:givenName xml:lang="ja">詩織</schema:givenName>
     <schema:givenName xml:lang="en">Shiori</schema:givenName>
     <imas:givenNameKana xml:lang="ja">しおり</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">瀬名詩織</schema:name>
@@ -3161,7 +3161,7 @@
     <schema:givenName xml:lang="ja">穂乃香</schema:givenName>
     <schema:givenName xml:lang="en">Honoka</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ほのか</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">綾瀬穂乃香</schema:name>
@@ -3190,7 +3190,7 @@
     <schema:givenName xml:lang="ja">雪美</schema:givenName>
     <schema:givenName xml:lang="en">Yukimi</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ゆきみ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">佐城雪美</schema:name>
@@ -3222,7 +3222,7 @@
     <schema:givenName xml:lang="ja">礼</schema:givenName>
     <schema:givenName xml:lang="en">Rei</schema:givenName>
     <imas:givenNameKana xml:lang="ja">れい</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">篠原礼</schema:name>
@@ -3251,7 +3251,7 @@
     <schema:givenName xml:lang="ja">留美</schema:givenName>
     <schema:givenName xml:lang="en">Rumi</schema:givenName>
     <imas:givenNameKana xml:lang="ja">るみ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">和久井留美</schema:name>
@@ -3280,7 +3280,7 @@
     <schema:givenName xml:lang="ja">沙紀</schema:givenName>
     <schema:givenName xml:lang="en">Saki</schema:givenName>
     <imas:givenNameKana xml:lang="ja">さき</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">吉岡沙紀</schema:name>
@@ -3309,7 +3309,7 @@
     <schema:givenName xml:lang="ja">音葉</schema:givenName>
     <schema:givenName xml:lang="en">Otoha</schema:givenName>
     <imas:givenNameKana xml:lang="ja">おとは</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">梅木音葉</schema:name>
@@ -3339,7 +3339,7 @@
     <schema:givenName xml:lang="ja">小梅</schema:givenName>
     <schema:givenName xml:lang="en">Koume</schema:givenName>
     <imas:givenNameKana xml:lang="ja">こうめ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">白坂小梅</schema:name>
@@ -3373,7 +3373,7 @@
     <schema:givenName xml:lang="ja">彩華</schema:givenName>
     <schema:givenName xml:lang="en">Ayaka</schema:givenName>
     <imas:givenNameKana xml:lang="ja">あやか</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">岸部彩華</schema:name>
@@ -3404,7 +3404,7 @@
     <schema:givenName xml:lang="ja">むつみ</schema:givenName>
     <schema:givenName xml:lang="en">Mutsumi</schema:givenName>
     <imas:givenNameKana xml:lang="ja">むつみ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">氏家むつみ</schema:name>
@@ -3434,7 +3434,7 @@
     <schema:givenName xml:lang="ja">保奈美</schema:givenName>
     <schema:givenName xml:lang="en">Honami</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ほなみ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">西川保奈美</schema:name>
@@ -3464,7 +3464,7 @@
     <schema:givenName xml:lang="ja">由愛</schema:givenName>
     <schema:givenName xml:lang="en">Yume</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ゆめ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">成宮由愛</schema:name>
@@ -3494,7 +3494,7 @@
     <schema:givenName xml:lang="ja">朋</schema:givenName>
     <schema:givenName xml:lang="en">Tomo</schema:givenName>
     <imas:givenNameKana xml:lang="ja">とも</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">藤居朋</schema:name>
@@ -3523,7 +3523,7 @@
     <schema:givenName xml:lang="ja">周子</schema:givenName>
     <schema:givenName xml:lang="en">Syuko</schema:givenName>
     <imas:givenNameKana xml:lang="ja">しゅうこ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">塩見周子</schema:name>
@@ -3557,7 +3557,7 @@
     <schema:givenName xml:lang="ja">珠美</schema:givenName>
     <schema:givenName xml:lang="en">Tamami</schema:givenName>
     <imas:givenNameKana xml:lang="ja">たまみ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">脇山珠美</schema:name>
@@ -3591,7 +3591,7 @@
     <schema:givenName xml:lang="ja">泰葉</schema:givenName>
     <schema:givenName xml:lang="en">Yasuha</schema:givenName>
     <imas:givenNameKana xml:lang="ja">やすは</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">岡崎泰葉</schema:name>
@@ -3620,7 +3620,7 @@
     <schema:givenName xml:lang="ja">奏</schema:givenName>
     <schema:givenName xml:lang="en">Kanade</schema:givenName>
     <imas:givenNameKana xml:lang="ja">かなで</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">速水奏</schema:name>
@@ -3653,7 +3653,7 @@
     <schema:givenName xml:lang="ja">泉</schema:givenName>
     <schema:givenName xml:lang="en">Izumi</schema:givenName>
     <imas:givenNameKana xml:lang="ja">いずみ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">大石泉</schema:name>
@@ -3682,7 +3682,7 @@
     <schema:givenName xml:lang="ja">千鶴</schema:givenName>
     <schema:givenName xml:lang="en">Chizuru</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ちづる</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">松尾千鶴</schema:name>
@@ -3712,7 +3712,7 @@
     <schema:givenName xml:lang="ja">乃々</schema:givenName>
     <schema:givenName xml:lang="en">Nono</schema:givenName>
     <imas:givenNameKana xml:lang="ja">のの</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">森久保乃々</schema:name>
@@ -3740,7 +3740,7 @@
 
   <rdf:Description rdf:about="detail/Anastasia">
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Co</imas:Type>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">アナスタシア</schema:name>
@@ -3774,7 +3774,7 @@
     <schema:givenName xml:lang="ja">亜季</schema:givenName>
     <schema:givenName xml:lang="en">Aki</schema:givenName>
     <imas:givenNameKana xml:lang="ja">あき</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">大和亜季</schema:name>
@@ -3808,7 +3808,7 @@
     <schema:givenName xml:lang="ja">晴</schema:givenName>
     <schema:givenName xml:lang="en">Haru</schema:givenName>
     <imas:givenNameKana xml:lang="ja">はる</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">結城晴</schema:name>
@@ -3841,7 +3841,7 @@
     <schema:givenName xml:lang="ja">飛鳥</schema:givenName>
     <schema:givenName xml:lang="en">Asuka</schema:givenName>
     <imas:givenNameKana xml:lang="ja">あすか</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">二宮飛鳥</schema:name>
@@ -3876,7 +3876,7 @@
     <schema:givenName xml:lang="ja">つかさ</schema:givenName>
     <schema:givenName xml:lang="en">Tsukasa</schema:givenName>
     <imas:givenNameKana xml:lang="ja">つかさ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">桐生つかさ</schema:name>
@@ -3907,7 +3907,7 @@
     <schema:givenName xml:lang="ja">聖</schema:givenName>
     <schema:givenName xml:lang="en">Hijiri</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ひじり</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">望月聖</schema:name>
@@ -3936,7 +3936,7 @@
     <schema:givenName xml:lang="ja">茄子</schema:givenName>
     <schema:givenName xml:lang="en">Kako</schema:givenName>
     <imas:givenNameKana xml:lang="ja">かこ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">鷹富士茄子</schema:name>
@@ -3969,7 +3969,7 @@
     <schema:givenName xml:lang="ja">あきら</schema:givenName>
     <schema:givenName xml:lang="en">Akira</schema:givenName>
     <imas:givenNameKana xml:lang="ja">あきら</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">砂塚あきら</schema:name>
@@ -4000,7 +4000,7 @@
     <schema:givenName xml:lang="ja">颯</schema:givenName>
     <schema:givenName xml:lang="en">Hayate</schema:givenName>
     <imas:givenNameKana xml:lang="ja">はやて</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">久川颯</schema:name>
@@ -4035,7 +4035,7 @@
     <schema:givenName xml:lang="ja">未央</schema:givenName>
     <schema:givenName xml:lang="en">Mio</schema:givenName>
     <imas:givenNameKana xml:lang="ja">みお</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">本田未央</schema:name>
@@ -4068,7 +4068,7 @@
     <schema:givenName xml:lang="ja">藍子</schema:givenName>
     <schema:givenName xml:lang="en">Aiko</schema:givenName>
     <imas:givenNameKana xml:lang="ja">あいこ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">高森藍子</schema:name>
@@ -4101,7 +4101,7 @@
     <schema:givenName xml:lang="ja">芽衣子</schema:givenName>
     <schema:givenName xml:lang="en">Meiko</schema:givenName>
     <imas:givenNameKana xml:lang="ja">めいこ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">並木芽衣子</schema:name>
@@ -4130,7 +4130,7 @@
     <schema:givenName xml:lang="ja">薫</schema:givenName>
     <schema:givenName xml:lang="en">Kaoru</schema:givenName>
     <imas:givenNameKana xml:lang="ja">かおる</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">龍崎薫</schema:name>
@@ -4163,7 +4163,7 @@
     <schema:givenName xml:lang="ja">夏樹</schema:givenName>
     <schema:givenName xml:lang="en">Natsuki</schema:givenName>
     <imas:givenNameKana xml:lang="ja">なつき</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">木村夏樹</schema:name>
@@ -4196,7 +4196,7 @@
     <schema:givenName xml:lang="ja">久美子</schema:givenName>
     <schema:givenName xml:lang="en">Kumiko</schema:givenName>
     <imas:givenNameKana xml:lang="ja">くみこ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">松山久美子</schema:name>
@@ -4225,7 +4225,7 @@
     <schema:givenName xml:lang="ja">洋子</schema:givenName>
     <schema:givenName xml:lang="en">Yoko</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ようこ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">斉藤洋子</schema:name>
@@ -4254,7 +4254,7 @@
     <schema:givenName xml:lang="ja">麻理菜</schema:givenName>
     <schema:givenName xml:lang="en">Marina</schema:givenName>
     <imas:givenNameKana xml:lang="ja">まりな</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">沢田麻理菜</schema:name>
@@ -4283,7 +4283,7 @@
     <schema:givenName xml:lang="ja">美羽</schema:givenName>
     <schema:givenName xml:lang="en">Miu</schema:givenName>
     <imas:givenNameKana xml:lang="ja">みう</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">矢口美羽</schema:name>
@@ -4312,7 +4312,7 @@
     <schema:givenName xml:lang="ja">みりあ</schema:givenName>
     <schema:givenName xml:lang="en">Miria</schema:givenName>
     <imas:givenNameKana xml:lang="ja">みりあ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">赤城みりあ</schema:name>
@@ -4345,7 +4345,7 @@
     <schema:givenName xml:lang="ja">渚</schema:givenName>
     <schema:givenName xml:lang="en">Nagisa</schema:givenName>
     <imas:givenNameKana xml:lang="ja">なぎさ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">愛野渚</schema:name>
@@ -4374,7 +4374,7 @@
     <schema:givenName xml:lang="ja">いつき</schema:givenName>
     <schema:givenName xml:lang="en">Itsuki</schema:givenName>
     <imas:givenNameKana xml:lang="ja">いつき</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">真鍋いつき</schema:name>
@@ -4403,7 +4403,7 @@
     <schema:givenName xml:lang="ja">唯</schema:givenName>
     <schema:givenName xml:lang="en">Yui</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ゆい</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">大槻唯</schema:name>
@@ -4436,7 +4436,7 @@
     <schema:givenName xml:lang="ja">友紀</schema:givenName>
     <schema:givenName xml:lang="en">Yuki</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ゆき</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">姫川友紀</schema:name>
@@ -4469,7 +4469,7 @@
     <schema:givenName xml:lang="ja">柚</schema:givenName>
     <schema:givenName xml:lang="en">Yuzu</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ゆず</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">喜多見柚</schema:name>
@@ -4502,7 +4502,7 @@
     <schema:givenName xml:lang="ja">鈴帆</schema:givenName>
     <schema:givenName xml:lang="en">Suzuho</schema:givenName>
     <imas:givenNameKana xml:lang="ja">すずほ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">上田鈴帆</schema:name>
@@ -4535,7 +4535,7 @@
     <schema:givenName xml:lang="ja">菜帆</schema:givenName>
     <schema:givenName xml:lang="en">Naho</schema:givenName>
     <imas:givenNameKana xml:lang="ja">なほ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">海老原菜帆</schema:name>
@@ -4565,7 +4565,7 @@
     <schema:givenName xml:lang="ja">雫</schema:givenName>
     <schema:givenName xml:lang="en">Shizuku</schema:givenName>
     <imas:givenNameKana xml:lang="ja">しずく</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">及川雫</schema:name>
@@ -4599,7 +4599,7 @@
     <schema:givenName xml:lang="ja">麗奈</schema:givenName>
     <schema:givenName xml:lang="en">Reina</schema:givenName>
     <imas:givenNameKana xml:lang="ja">れいな</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">小関麗奈</schema:name>
@@ -4628,7 +4628,7 @@
     <schema:givenName xml:lang="ja">美紗希</schema:givenName>
     <schema:givenName xml:lang="en">Misaki</schema:givenName>
     <imas:givenNameKana xml:lang="ja">みさき</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">衛藤美紗希</schema:name>
@@ -4658,7 +4658,7 @@
     <schema:givenName xml:lang="ja">輝子</schema:givenName>
     <schema:givenName xml:lang="en">Syoko</schema:givenName>
     <imas:givenNameKana xml:lang="ja">しょうこ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">星輝子</schema:name>
@@ -4691,7 +4691,7 @@
     <schema:givenName xml:lang="ja">早苗</schema:givenName>
     <schema:givenName xml:lang="en">Sanae</schema:givenName>
     <imas:givenNameKana xml:lang="ja">さなえ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">片桐早苗</schema:name>
@@ -4725,7 +4725,7 @@
     <schema:givenName xml:lang="ja">裕子</schema:givenName>
     <schema:givenName xml:lang="en">Yuko</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ゆうこ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">堀裕子</schema:name>
@@ -4758,7 +4758,7 @@
     <schema:givenName xml:lang="ja">櫂</schema:givenName>
     <schema:givenName xml:lang="en">Kai</schema:givenName>
     <imas:givenNameKana xml:lang="ja">かい</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">西島櫂</schema:name>
@@ -4787,7 +4787,7 @@
     <schema:givenName xml:lang="ja">梨沙</schema:givenName>
     <schema:givenName xml:lang="en">Risa</schema:givenName>
     <imas:givenNameKana xml:lang="ja">りさ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">的場梨沙</schema:name>
@@ -4817,7 +4817,7 @@
     <schema:givenName xml:lang="ja">時子</schema:givenName>
     <schema:givenName xml:lang="en">Tokiko</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ときこ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">財前時子</schema:name>
@@ -4847,7 +4847,7 @@
     <schema:givenName xml:lang="ja">芳乃</schema:givenName>
     <schema:givenName xml:lang="en">Yoshino</schema:givenName>
     <imas:givenNameKana xml:lang="ja">よしの</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">依田芳乃</schema:name>
@@ -4882,7 +4882,7 @@
     <schema:givenName xml:lang="ja">夕美</schema:givenName>
     <schema:givenName xml:lang="en">Yumi</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ゆみ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">相葉夕美</schema:name>
@@ -4915,7 +4915,7 @@
     <schema:givenName xml:lang="ja">そら</schema:givenName>
     <schema:givenName xml:lang="en">Sora</schema:givenName>
     <imas:givenNameKana xml:lang="ja">そら</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">野々村そら</schema:name>
@@ -4944,7 +4944,7 @@
     <schema:givenName xml:lang="ja">愛結奈</schema:givenName>
     <schema:givenName xml:lang="en">Ayuna</schema:givenName>
     <imas:givenNameKana xml:lang="ja">あゆな</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">浜川愛結奈</schema:name>
@@ -4973,7 +4973,7 @@
     <schema:givenName xml:lang="ja">智香</schema:givenName>
     <schema:givenName xml:lang="en">Tomoka</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ともか</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">若林智香</schema:name>
@@ -5002,7 +5002,7 @@
     <schema:givenName xml:lang="ja">美嘉</schema:givenName>
     <schema:givenName xml:lang="en">Mika</schema:givenName>
     <imas:givenNameKana xml:lang="ja">みか</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">城ヶ崎美嘉</schema:name>
@@ -5035,7 +5035,7 @@
     <schema:givenName xml:lang="ja">莉嘉</schema:givenName>
     <schema:givenName xml:lang="en">Rika</schema:givenName>
     <imas:givenNameKana xml:lang="ja">りか</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">城ヶ崎莉嘉</schema:name>
@@ -5068,7 +5068,7 @@
     <schema:givenName xml:lang="ja">恵磨</schema:givenName>
     <schema:givenName xml:lang="en">Ema</schema:givenName>
     <imas:givenNameKana xml:lang="ja">えま</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">仙崎恵磨</schema:name>
@@ -5097,7 +5097,7 @@
     <schema:givenName xml:lang="ja">茜</schema:givenName>
     <schema:givenName xml:lang="en">Akane</schema:givenName>
     <imas:givenNameKana xml:lang="ja">あかね</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">日野茜</schema:name>
@@ -5130,7 +5130,7 @@
     <schema:givenName xml:lang="ja">きらり</schema:givenName>
     <schema:givenName xml:lang="en">Kirari</schema:givenName>
     <imas:givenNameKana xml:lang="ja">きらり</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">諸星きらり</schema:name>
@@ -5163,7 +5163,7 @@
     <schema:givenName xml:lang="ja">愛梨</schema:givenName>
     <schema:givenName xml:lang="en">Airi</schema:givenName>
     <imas:givenNameKana xml:lang="ja">あいり</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">十時愛梨</schema:name>
@@ -5190,7 +5190,7 @@
 
   <rdf:Description rdf:about="detail/Natalia">
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pa</imas:Type>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">ナターリア</schema:name>
@@ -5222,7 +5222,7 @@
     <schema:givenName xml:lang="ja">夏美</schema:givenName>
     <schema:givenName xml:lang="en">Natsumi</schema:givenName>
     <imas:givenNameKana xml:lang="ja">なつみ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">相馬夏美</schema:name>
@@ -5251,7 +5251,7 @@
     <schema:givenName xml:lang="ja">志保</schema:givenName>
     <schema:givenName xml:lang="en">Shiho</schema:givenName>
     <imas:givenNameKana xml:lang="ja">しほ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">槙原志保</schema:name>
@@ -5280,7 +5280,7 @@
     <schema:givenName xml:lang="ja">拓海</schema:givenName>
     <schema:givenName xml:lang="en">Takumi</schema:givenName>
     <imas:givenNameKana xml:lang="ja">たくみ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">向井拓海</schema:name>
@@ -5313,7 +5313,7 @@
     <schema:givenName xml:lang="ja">仁奈</schema:givenName>
     <schema:givenName xml:lang="en">Nina</schema:givenName>
     <imas:givenNameKana xml:lang="ja">にな</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">市原仁奈</schema:name>
@@ -5346,7 +5346,7 @@
     <schema:givenName xml:lang="ja">日菜子</schema:givenName>
     <schema:givenName xml:lang="en">Hinako</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ひなこ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">喜多日菜子</schema:name>
@@ -5379,7 +5379,7 @@
     <schema:givenName xml:lang="ja">海</schema:givenName>
     <schema:givenName xml:lang="en">Umi</schema:givenName>
     <imas:givenNameKana xml:lang="ja">うみ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">杉坂海</schema:name>
@@ -5408,7 +5408,7 @@
     <schema:givenName xml:lang="ja">真尋</schema:givenName>
     <schema:givenName xml:lang="en">Mahiro</schema:givenName>
     <imas:givenNameKana xml:lang="ja">まひろ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">北川真尋</schema:name>
@@ -5439,7 +5439,7 @@
     <schema:givenName xml:lang="ja">メアリー</schema:givenName>
     <schema:givenName xml:lang="en">Mary</schema:givenName>
     <imas:givenNameKana xml:lang="ja">めありー</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">メアリー・コクラン</schema:name>
@@ -5469,7 +5469,7 @@
     <schema:givenName xml:lang="ja">伊吹</schema:givenName>
     <schema:givenName xml:lang="en">Ibuki</schema:givenName>
     <imas:givenNameKana xml:lang="ja">いぶき</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">小松伊吹</schema:name>
@@ -5500,7 +5500,7 @@
     <schema:givenName xml:lang="ja">紗南</schema:givenName>
     <schema:givenName xml:lang="en">Sana</schema:givenName>
     <imas:givenNameKana xml:lang="ja">さな</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">三好紗南</schema:name>
@@ -5530,7 +5530,7 @@
     <schema:givenName xml:lang="ja">キャシー</schema:givenName>
     <schema:givenName xml:lang="en">Cathy</schema:givenName>
     <imas:givenNameKana xml:lang="ja">きゃしー</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">キャシー・グラハム</schema:name>
@@ -5560,7 +5560,7 @@
     <schema:givenName xml:lang="ja">笑美</schema:givenName>
     <schema:givenName xml:lang="en">Emi</schema:givenName>
     <imas:givenNameKana xml:lang="ja">えみ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">難波笑美</schema:name>
@@ -5594,7 +5594,7 @@
     <schema:givenName xml:lang="ja">あやめ</schema:givenName>
     <schema:givenName xml:lang="en">Ayame</schema:givenName>
     <imas:givenNameKana xml:lang="ja">あやめ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">浜口あやめ</schema:name>
@@ -5629,7 +5629,7 @@
     <schema:givenName xml:lang="ja">巴</schema:givenName>
     <schema:givenName xml:lang="en">Tomoe</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ともえ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">村上巴</schema:name>
@@ -5663,7 +5663,7 @@
     <schema:givenName xml:lang="ja">亜子</schema:givenName>
     <schema:givenName xml:lang="en">Ako</schema:givenName>
     <imas:givenNameKana xml:lang="ja">あこ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">土屋亜子</schema:name>
@@ -5693,7 +5693,7 @@
     <schema:givenName xml:lang="ja">葵</schema:givenName>
     <schema:givenName xml:lang="en">Aoi</schema:givenName>
     <imas:givenNameKana xml:lang="ja">あおい</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">首藤葵</schema:name>
@@ -5722,7 +5722,7 @@
     <schema:givenName xml:lang="ja">清美</schema:givenName>
     <schema:givenName xml:lang="en">Kiyomi</schema:givenName>
     <imas:givenNameKana xml:lang="ja">きよみ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">冴島清美</schema:name>
@@ -5753,7 +5753,7 @@
     <schema:givenName xml:lang="ja">心</schema:givenName>
     <schema:givenName xml:lang="en">Shin</schema:givenName>
     <imas:givenNameKana xml:lang="ja">しん</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">佐藤心</schema:name>
@@ -5787,7 +5787,7 @@
     <schema:givenName xml:lang="ja">光</schema:givenName>
     <schema:givenName xml:lang="en">Hikaru</schema:givenName>
     <imas:givenNameKana xml:lang="ja">ひかる</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">南条光</schema:name>
@@ -5821,7 +5821,7 @@
     <schema:givenName xml:lang="ja">イヴ</schema:givenName>
     <schema:givenName xml:lang="en">Eve</schema:givenName>
     <imas:givenNameKana xml:lang="ja">いゔ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">イヴ・サンタクロース</schema:name>
@@ -5850,7 +5850,7 @@
     <schema:givenName xml:lang="ja">りあむ</schema:givenName>
     <schema:givenName xml:lang="en">Riamu</schema:givenName>
     <imas:givenNameKana xml:lang="ja">りあむ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">夢見りあむ</schema:name>
@@ -5883,7 +5883,7 @@
     <schema:givenName xml:lang="ja">凪</schema:givenName>
     <schema:givenName xml:lang="en">Nagi</schema:givenName>
     <imas:givenNameKana xml:lang="ja">なぎ</imas:givenNameKana>
-    <schema:gender xml:lang="en">female</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">CinderellaGirls</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">久川凪</schema:name>

--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -43,7 +43,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--04-24</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">59.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">87.0</imas:Hip>
@@ -76,7 +76,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">40.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--03-23</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">77.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Hip>
@@ -109,7 +109,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--10-18</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Hip>
@@ -142,7 +142,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">28.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--01-21</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">64.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">70.0</imas:Hip>
@@ -171,7 +171,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">38.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--10-10</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">76.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">79.0</imas:Hip>
@@ -204,7 +204,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">41.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--03-03</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">79.0</imas:Hip>
@@ -233,7 +233,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-24</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">77.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">54.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">76.0</imas:Hip>
@@ -262,7 +262,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">52.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--01-06</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">90.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">65.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">89.0</imas:Hip>
@@ -295,7 +295,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">47.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--06-12</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Hip>
@@ -324,7 +324,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">46.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--11-06</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">84.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Hip>
@@ -353,7 +353,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--12-16</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">59.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Hip>
@@ -386,7 +386,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--06-11</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">79.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -419,7 +419,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-10</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -452,7 +452,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">33.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--03-16</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">75.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">54.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">77.0</imas:Hip>
@@ -481,7 +481,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">39.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--04-08</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">72.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">53.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">75.0</imas:Hip>
@@ -514,7 +514,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">46.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--02-06</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -543,7 +543,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--03-19</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Hip>
@@ -573,7 +573,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">31.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--12-18</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">60.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">65.0</imas:Hip>
@@ -602,7 +602,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-17</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -635,7 +635,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--01-28</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">both</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">both</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">89.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">87.0</imas:Hip>
@@ -665,7 +665,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">41.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-01</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">both</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">both</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">73.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">75.0</imas:Hip>
@@ -698,7 +698,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">41.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--10-14</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">77.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -732,7 +732,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">40.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--04-12</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -761,7 +761,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">28.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--02-19</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">62.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">50.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">65.0</imas:Hip>
@@ -793,7 +793,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">40.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--03-30</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust xml:lang="ja">おっきい</imas:Bust>
     <imas:Waist xml:lang="ja">ふつう</imas:Waist>
     <imas:Hip xml:lang="ja">まぁまぁ</imas:Hip>
@@ -823,7 +823,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-30</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Hip>
@@ -858,7 +858,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--02-22</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Hip>
@@ -891,7 +891,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--07-07</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">both</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">both</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">92.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">59.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">88.0</imas:Hip>
@@ -920,7 +920,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--12-28</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Hip>
@@ -949,7 +949,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">51.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--02-14</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">92.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">90.0</imas:Hip>
@@ -978,7 +978,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">46.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--02-14</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Hip>
@@ -1011,7 +1011,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--10-18</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -1044,7 +1044,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">46.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--01-23</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">87.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Hip>
@@ -1073,7 +1073,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">30.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--09-02</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust xml:lang="ja">？</imas:Bust>
     <imas:Waist xml:lang="ja">？</imas:Waist>
     <imas:Hip xml:lang="ja">？</imas:Hip>
@@ -1106,7 +1106,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">41.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--09-29</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">84.0</imas:Hip>
@@ -1135,7 +1135,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">40.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--07-07</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</imas:Hip>
@@ -1164,7 +1164,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-28</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Hip>
@@ -1193,7 +1193,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">44.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--10-30</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Hip>
@@ -1222,7 +1222,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">48.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--10-03</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">92.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">84.0</imas:Hip>
@@ -1251,7 +1251,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--06-04</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">79.0</imas:Hip>
@@ -1281,7 +1281,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--01-01</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Hip>
@@ -1314,7 +1314,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">47.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-12</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Hip>
@@ -1343,7 +1343,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">48.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-27</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">60.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">88.0</imas:Hip>
@@ -1372,7 +1372,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">40.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-04</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">77.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">54.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</imas:Hip>
@@ -1401,7 +1401,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">46.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-27</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">91.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Hip>
@@ -1430,7 +1430,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">37.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--11-25</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">74.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">52.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">75.0</imas:Hip>
@@ -1463,7 +1463,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">41.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--01-06</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">77.0</imas:Hip>
@@ -1493,7 +1493,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">48.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--02-11</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">88.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">59.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">84.0</imas:Hip>
@@ -1522,7 +1522,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">44.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--03-20</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Hip>
@@ -1552,7 +1552,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">40.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-15</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">84.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">84.0</imas:Hip>
@@ -1585,7 +1585,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">41.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--03-09</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">54.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Hip>
@@ -1614,7 +1614,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">44.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--09-09</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">77.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">54.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</imas:Hip>
@@ -1644,7 +1644,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">35.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--04-01</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">72.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">54.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">77.0</imas:Hip>
@@ -1668,7 +1668,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-26</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Hip>
@@ -1697,7 +1697,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">40.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--09-07</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">both</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">both</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">54.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -1731,7 +1731,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">38.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--03-27</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">75.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">77.0</imas:Hip>
@@ -1760,7 +1760,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--04-19</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">77.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">53.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">79.0</imas:Hip>
@@ -1794,7 +1794,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">39.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-09</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">75.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">54.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">77.0</imas:Hip>
@@ -1827,7 +1827,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">44.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--03-06</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -1856,7 +1856,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">40.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--10-06</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">70.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">53.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">74.0</imas:Hip>
@@ -1890,7 +1890,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">46.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--11-14</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">59.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Hip>
@@ -1920,7 +1920,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">39.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--06-10</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">75.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">53.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">74.0</imas:Hip>
@@ -1949,7 +1949,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">44.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--11-05</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">60.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Hip>
@@ -1979,7 +1979,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">40.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--02-04</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">72.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">52.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">74.0</imas:Hip>
@@ -2012,7 +2012,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">44.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--11-10</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">84.0</imas:Hip>
@@ -2046,7 +2046,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">44.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-10</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Hip>
@@ -2079,7 +2079,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--02-26</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Hip>
@@ -2108,7 +2108,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">48.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--09-01</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">92.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Hip>
@@ -2137,7 +2137,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--04-08</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Hip>
@@ -2166,7 +2166,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">51.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-08</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">91.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">62.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">90.0</imas:Hip>
@@ -2195,7 +2195,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--11-11</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Hip>
@@ -2224,7 +2224,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">44.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--11-25</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">87.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Hip>
@@ -2258,7 +2258,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">44.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--09-16</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Hip>
@@ -2291,7 +2291,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--04-10</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">79.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -2324,7 +2324,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--04-09</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Hip>
@@ -2357,7 +2357,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--02-07</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">both</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">both</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Hip>
@@ -2386,7 +2386,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">41.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--06-30</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Hip>
@@ -2419,7 +2419,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--04-27</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -2448,7 +2448,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">33.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--06-07</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">73.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">49.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">73.0</imas:Hip>
@@ -2481,7 +2481,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">46.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--02-25</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">60.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Hip>
@@ -2514,7 +2514,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">48.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--10-11</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -2544,7 +2544,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">50.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-08</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">88.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">60.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">89.0</imas:Hip>
@@ -2574,7 +2574,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--06-15</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">both</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">both</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">84.0</imas:Hip>
@@ -2608,7 +2608,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--07-27</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Hip>
@@ -2642,7 +2642,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">47.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--12-05</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">54.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Hip>
@@ -2671,7 +2671,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-18</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">59.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Hip>
@@ -2701,7 +2701,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">34.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--07-31</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">68.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">52.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">67.0</imas:Hip>
@@ -2735,7 +2735,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--10-27</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">84.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">54.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Hip>
@@ -2768,7 +2768,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--11-07</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Hip>
@@ -2791,7 +2791,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">40.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-21</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">75.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">54.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</imas:Hip>
@@ -2820,7 +2820,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">41.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--10-09</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">77.0</imas:Hip>
@@ -2844,7 +2844,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">46.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--04-04</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">90.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Hip>
@@ -2873,7 +2873,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">47.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--10-01</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">90.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Hip>
@@ -2906,7 +2906,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--06-09</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">84.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Hip>
@@ -2935,7 +2935,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">48.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--03-25</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">87.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Hip>
@@ -2964,7 +2964,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">49.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--06-14</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Hip>
@@ -2997,7 +2997,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">41.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--04-08</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -3030,7 +3030,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">44.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--09-24</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Hip>
@@ -3059,7 +3059,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--12-25</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">84.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">54.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Hip>
@@ -3088,7 +3088,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--09-05</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Hip>
@@ -3115,7 +3115,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-15</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">59.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Hip>
@@ -3144,7 +3144,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">48.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--01-10</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Hip>
@@ -3173,7 +3173,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">46.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-29</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">84.0</imas:Hip>
@@ -3202,7 +3202,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">30.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--09-28</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">63.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">47.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">65.0</imas:Hip>
@@ -3234,7 +3234,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">49.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--11-22</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">93.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">88.0</imas:Hip>
@@ -3263,7 +3263,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">49.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--04-07</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">60.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Hip>
@@ -3292,7 +3292,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-08</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">60.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Hip>
@@ -3321,7 +3321,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">49.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--06-20</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Hip>
@@ -3351,7 +3351,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">34.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--03-28</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">65.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">50.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">70.0</imas:Hip>
@@ -3385,7 +3385,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">46.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--11-13</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">89.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">59.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Hip>
@@ -3416,7 +3416,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--07-13</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -3446,7 +3446,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--10-23</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">both</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">both</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">88.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">60.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Hip>
@@ -3476,7 +3476,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">40.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--11-03</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">both</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">both</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">72.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">51.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">73.0</imas:Hip>
@@ -3506,7 +3506,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--07-01</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Hip>
@@ -3535,7 +3535,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--12-12</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Hip>
@@ -3569,7 +3569,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">38.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--09-20</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">72.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">53.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">75.0</imas:Hip>
@@ -3603,7 +3603,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--07-16</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">79.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -3632,7 +3632,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--07-01</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">84.0</imas:Hip>
@@ -3665,7 +3665,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">41.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--11-11</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Hip>
@@ -3694,7 +3694,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--03-21</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">54.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Hip>
@@ -3724,7 +3724,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">38.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-27</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">73.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">76.0</imas:Hip>
@@ -3752,7 +3752,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--09-19</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">both</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">both</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">54.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -3786,7 +3786,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">51.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--12-16</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">92.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">60.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Hip>
@@ -3820,7 +3820,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">37.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--07-17</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">74.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</imas:Hip>
@@ -3853,7 +3853,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--02-03</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">75.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</imas:Hip>
@@ -3888,7 +3888,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--02-24</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Hip>
@@ -3919,7 +3919,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">37.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--12-25</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">59.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Hip>
@@ -3948,7 +3948,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--01-01</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">88.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">88.0</imas:Hip>
@@ -3981,7 +3981,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--10-07</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</imas:Hip>
@@ -4012,7 +4012,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--06-16</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Hip>
@@ -4047,7 +4047,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">46.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--12-01</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">84.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">87.0</imas:Hip>
@@ -4080,7 +4080,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--07-25</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">74.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">60.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">79.0</imas:Hip>
@@ -4113,7 +4113,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">44.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--10-14</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Hip>
@@ -4142,7 +4142,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">32.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--07-20</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">65.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">51.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">70.0</imas:Hip>
@@ -4175,7 +4175,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">41.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-19</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Hip>
@@ -4208,7 +4208,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">44.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--01-21</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Hip>
@@ -4237,7 +4237,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">46.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--12-29</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Hip>
@@ -4266,7 +4266,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">47.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-06</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">87.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">87.0</imas:Hip>
@@ -4295,7 +4295,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">41.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--07-10</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -4324,7 +4324,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">36.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--04-14</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">75.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</imas:Hip>
@@ -4357,7 +4357,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">47.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-01</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">84.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Hip>
@@ -4386,7 +4386,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">46.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--12-29</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Hip>
@@ -4415,7 +4415,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-07</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">84.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Hip>
@@ -4448,7 +4448,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">44.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--09-14</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -4481,7 +4481,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--12-02</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Hip>
@@ -4514,7 +4514,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--10-26</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">76.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">79.0</imas:Hip>
@@ -4547,7 +4547,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-03</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">92.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">65.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">93.0</imas:Hip>
@@ -4577,7 +4577,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--06-03</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">both</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">both</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">105.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">64.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">92.0</imas:Hip>
@@ -4611,7 +4611,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">41.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--03-05</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">75.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">50.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">77.0</imas:Hip>
@@ -4640,7 +4640,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--03-18</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">84.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -4670,7 +4670,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">35.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--06-06</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">73.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">53.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">75.0</imas:Hip>
@@ -4703,7 +4703,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">47.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--03-07</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">92.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">84.0</imas:Hip>
@@ -4737,7 +4737,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">44.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--03-13</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -4770,7 +4770,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">49.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-17</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">59.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Hip>
@@ -4799,7 +4799,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">38.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--11-19</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">71.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">73.0</imas:Hip>
@@ -4829,7 +4829,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">46.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--04-18</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Hip>
@@ -4859,7 +4859,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">40.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--07-03</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">73.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">53.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">73.0</imas:Hip>
@@ -4894,7 +4894,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--04-15</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -4927,7 +4927,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">46.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--01-03</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">84.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Hip>
@@ -4956,7 +4956,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">50.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-25</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">92.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Hip>
@@ -4985,7 +4985,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-30</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Hip>
@@ -5014,7 +5014,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--11-12</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Hip>
@@ -5047,7 +5047,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">36.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--07-30</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">72.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">54.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">75.0</imas:Hip>
@@ -5080,7 +5080,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--06-27</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Hip>
@@ -5109,7 +5109,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">40.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-04</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">60.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Hip>
@@ -5142,7 +5142,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">60.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--09-01</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">91.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">64.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Hip>
@@ -5175,7 +5175,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">46.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--12-08</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">88.0</imas:Hip>
@@ -5202,7 +5202,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--06-29</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">84.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Hip>
@@ -5234,7 +5234,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">46.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--07-23</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">60.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">89.0</imas:Hip>
@@ -5263,7 +5263,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">46.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--04-27</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">91.0</imas:Hip>
@@ -5292,7 +5292,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">53.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-07</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">95.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">60.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">87.0</imas:Hip>
@@ -5325,7 +5325,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">29.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--02-08</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">61.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">67.0</imas:Hip>
@@ -5358,7 +5358,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">38.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--04-06</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</imas:Hip>
@@ -5391,7 +5391,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--07-20</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">88.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">86.0</imas:Hip>
@@ -5420,7 +5420,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--02-17</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">75.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">79.0</imas:Hip>
@@ -5451,7 +5451,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">41.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--01-19</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">71.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">59.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">73.0</imas:Hip>
@@ -5481,7 +5481,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">48.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--11-17</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">59.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">88.0</imas:Hip>
@@ -5512,7 +5512,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">39.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--06-25</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">75.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -5542,7 +5542,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">49.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--09-19</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Hip>
@@ -5572,7 +5572,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-01</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">82.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -5606,7 +5606,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--01-13</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -5641,7 +5641,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">37.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--01-03</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">74.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">53.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">76.0</imas:Hip>
@@ -5675,7 +5675,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-02</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">85.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">54.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">83.0</imas:Hip>
@@ -5705,7 +5705,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">39.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-18</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">73.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">53.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">75.0</imas:Hip>
@@ -5734,7 +5734,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--09-26</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">76.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</imas:Hip>
@@ -5765,7 +5765,7 @@
     <schema:weight xml:lang="ja">ダイエットちゅう</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--07-22</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust xml:lang="ja">ぼんっ</imas:Bust>
     <imas:Waist xml:lang="ja">きゅっ</imas:Waist>
     <imas:Hip xml:lang="ja">ぼんっ♪</imas:Hip>
@@ -5799,7 +5799,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">41.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--09-13</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">79.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -5833,7 +5833,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">44.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--12-24</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">81.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>
@@ -5862,7 +5862,7 @@
     <schema:weight xml:lang="ja">リンゴたくさん</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--09-12</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust xml:lang="ja">でっかい</imas:Bust>
     <imas:Waist xml:lang="ja">ふつう</imas:Waist>
     <imas:Hip xml:lang="ja">たぶんふつう</imas:Hip>
@@ -5895,7 +5895,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">40.0</schema:weight>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--06-16</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">76.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</imas:Waist>
     <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</imas:Hip>

--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -1077,7 +1077,7 @@
     <imas:Bust xml:lang="ja">？</imas:Bust>
     <imas:Waist xml:lang="ja">？</imas:Waist>
     <imas:Hip xml:lang="ja">？</imas:Hip>
-    <imas:Constellation xml:lang="ja">花も恥らう乙女座</imas:Constellation>
+    <imas:Constellation xml:lang="ja">花も恥じらう乙女座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">北海道</schema:birthPlace>
     <imas:cv xml:lang="ja">五十嵐裕美</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/五十嵐裕美"/>

--- a/RDFs/SideM.rdf
+++ b/RDFs/SideM.rdf
@@ -50,7 +50,7 @@
     <imas:Hobby xml:lang="ja">フィギュア集め</imas:Hobby>
     <imas:Talent xml:lang="ja">スパイスからのカレー作り</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F32333</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -83,7 +83,7 @@
     <imas:Hobby xml:lang="ja">親孝行♪</imas:Hobby>
     <imas:Talent xml:lang="ja">バク転</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">94D509</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -117,7 +117,7 @@
     <imas:Hobby xml:lang="ja">デート</imas:Hobby>
     <imas:Talent xml:lang="ja">高速ネコふんじゃった</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">1C23AA</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -150,7 +150,7 @@
     <imas:Hobby xml:lang="ja">ダーツ</imas:Hobby>
     <imas:Talent xml:lang="ja">料理</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E31C1A</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -182,7 +182,7 @@
     <imas:Hobby xml:lang="ja">姉の形見の擦り切れた詩集を読む</imas:Hobby>
     <imas:Talent xml:lang="ja">手品</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">1945BA</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -217,7 +217,7 @@
     <imas:Talent xml:lang="ja">大食い</imas:Talent>
     <imas:Talent xml:lang="ja">天気読み</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">3BAF29</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -249,7 +249,7 @@
     <imas:Hobby xml:lang="ja">なし</imas:Hobby>
     <imas:Talent xml:lang="ja">ピアノ</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">C5A6E2</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -281,7 +281,7 @@
     <imas:Hobby xml:lang="ja">ハンドクリームを塗ること</imas:Hobby>
     <imas:Talent xml:lang="ja">1回聞いた音楽を正確にヴァイオリンで奏でることができる</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">3D5AC8</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -313,7 +313,7 @@
     <imas:Hobby xml:lang="ja">洗濯</imas:Hobby>
     <imas:Talent xml:lang="ja">暗算</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">6AC4E9</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -339,7 +339,7 @@
     <imas:Hobby xml:lang="ja">きぐるみとのしゃしんさつえい</imas:Hobby>
     <imas:Talent xml:lang="ja">みかんのはやむき</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">8BDC63</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -371,7 +371,7 @@
     <imas:Hobby xml:lang="ja">ハンドクリーム集め</imas:Hobby>
     <imas:Talent xml:lang="ja">運転時の抜け道探し</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">FA90A2</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -403,7 +403,7 @@
     <imas:Hobby xml:lang="ja">サッカー</imas:Hobby>
     <imas:Talent xml:lang="ja">サッカー</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">FEE806</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -436,7 +436,7 @@
     <imas:Talent xml:lang="ja">練習メニューの組み立て</imas:Talent>
     <imas:Talent xml:lang="ja">コーチング</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">23CD7A</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -469,7 +469,7 @@
     <imas:Talent xml:lang="ja">警察犬の訓練</imas:Talent>
     <imas:Talent xml:lang="ja">動物全般の躾</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">57B3E5</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -501,7 +501,7 @@
     <imas:Hobby xml:lang="ja">昼寝</imas:Hobby>
     <imas:Talent xml:lang="ja">裁縫</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EE7220</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -533,7 +533,7 @@
     <imas:Hobby xml:lang="ja">料理</imas:Hobby>
     <imas:Talent xml:lang="ja">銃器類の早解体</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">78853A</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -565,7 +565,7 @@
     <imas:Hobby xml:lang="ja">珍獣観察</imas:Hobby>
     <imas:Talent xml:lang="ja">人間・動物からマンガやアニメのキャラクターのモノマネや形態模写</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F7BD05</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -597,7 +597,7 @@
     <imas:Hobby xml:lang="ja">メイド喫茶巡り</imas:Hobby>
     <imas:Talent xml:lang="ja">和太鼓演奏</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">7664A0</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -630,7 +630,7 @@
     <imas:Talent xml:lang="ja">競技かるた</imas:Talent>
     <imas:Talent xml:lang="ja">投扇興</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">79A5DF</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -663,7 +663,7 @@
     <imas:Hobby xml:lang="ja">ギター</imas:Hobby>
     <imas:Talent xml:lang="ja">野球選手のモノマネ</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">FE6B02</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -695,7 +695,7 @@
     <imas:Hobby xml:lang="ja">読書</imas:Hobby>
     <imas:Talent xml:lang="ja">ピアノ</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">1845B9</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -728,7 +728,7 @@
     <imas:Hobby xml:lang="ja">ヴァイオリン</imas:Hobby>
     <imas:Talent xml:lang="ja">気配を消すこと</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">24CAD2</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -760,7 +760,7 @@
     <imas:Hobby xml:lang="ja">散歩</imas:Hobby>
     <imas:Talent xml:lang="ja">ヘアメイク</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">71D448</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -793,7 +793,7 @@
     <imas:Hobby xml:lang="ja">ハデパン集め</imas:Hobby>
     <imas:Talent xml:lang="ja">カラオケ採点で意のままの点数を出せる</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F125C1</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -825,7 +825,7 @@
     <imas:Hobby xml:lang="ja">頭に「にゃこ」を乗せて散歩</imas:Hobby>
     <imas:Talent xml:lang="ja">天空朱雀落とし</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E63C2E</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -859,7 +859,7 @@
     <imas:Talent xml:lang="ja">天玄氷刃波</imas:Talent>
     <imas:Talent xml:lang="ja">全国一斉テスト・統一模試全科目1位</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">0F0C9F</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -893,7 +893,7 @@
     <imas:Talent xml:lang="ja">早着替え</imas:Talent>
     <imas:Talent xml:lang="ja">華麗なスプーンフォーク捌きによるサーバー技</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F09079</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -927,7 +927,7 @@
     <imas:Talent xml:lang="ja">飴細工</imas:Talent>
     <imas:Talent xml:lang="ja">折紙</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">02946C</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -954,7 +954,7 @@
     <imas:Talent xml:lang="ja">召喚術</imas:Talent>
     <imas:Talent xml:lang="ja">詠唱</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">606CB2</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -987,7 +987,7 @@
     <imas:Talent xml:lang="ja">利きケーキ</imas:Talent>
     <imas:Talent xml:lang="ja">一輪車</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F8C559</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -1019,7 +1019,7 @@
     <imas:Hobby xml:lang="ja">手品</imas:Hobby>
     <imas:Talent xml:lang="ja">逆立ち</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">FA7EB4</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -1051,7 +1051,7 @@
     <imas:Hobby xml:lang="ja">将棋</imas:Hobby>
     <imas:Talent xml:lang="ja">編み物</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">1F1451</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -1083,7 +1083,7 @@
     <imas:Hobby xml:lang="ja">バスケ</imas:Hobby>
     <imas:Talent xml:lang="ja">ブレイクダンス</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D13037</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -1115,7 +1115,7 @@
     <imas:Hobby xml:lang="ja">お散歩</imas:Hobby>
     <imas:Talent xml:lang="ja">ピアノ</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F7B5C4</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -1148,7 +1148,7 @@
     <imas:Hobby xml:lang="ja">パズル</imas:Hobby>
     <imas:Talent xml:lang="ja">円周率の暗唱</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">436CA9</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -1182,7 +1182,7 @@
     <imas:Hobby xml:lang="ja">サーフィン</imas:Hobby>
     <imas:Talent xml:lang="ja">けん玉</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F5D24B</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -1215,7 +1215,7 @@
     <imas:Hobby xml:lang="ja">競馬</imas:Hobby>
     <imas:Talent xml:lang="ja">ラジオ体操</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EE7602</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -1249,7 +1249,7 @@
     <imas:Talent xml:lang="ja">体を動かすことならなんでも</imas:Talent>
     <imas:Talent xml:lang="ja">シューティングゲーム</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">0E0C9F</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -1281,7 +1281,7 @@
     <imas:Hobby xml:lang="ja">資格取得</imas:Hobby>
     <imas:Talent xml:lang="ja">たくさんありすぎてかけないが､最近はあみぐるみにハマっている</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">CA9111</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -1313,7 +1313,7 @@
     <imas:Hobby xml:lang="ja">なんでんなことｵﾏｴに教えないといけねｰんだ? バァーカ!</imas:Hobby>
     <imas:Talent xml:lang="ja">相手をぶったおすことにきまっ てんだろ!</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">AC162A</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -1347,7 +1347,7 @@
     <imas:Talent xml:lang="ja">ダンス</imas:Talent>
     <imas:Talent xml:lang="ja">変装</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">70B449</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -1380,7 +1380,7 @@
     <imas:Talent xml:lang="ja">居合道</imas:Talent>
     <imas:Talent xml:lang="ja">かつらむき</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E41C1A</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -1414,7 +1414,7 @@
     <imas:Talent xml:lang="ja">一度読んだ本の内容は大体覚えている</imas:Talent>
     <imas:Talent xml:lang="ja">食べれるキノコを見分けられる</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">CF9E51</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -1446,7 +1446,7 @@
     <imas:Hobby xml:lang="ja">星占い</imas:Hobby>
     <imas:Talent xml:lang="ja">折紙</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">111721</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -1478,7 +1478,7 @@
     <imas:Hobby xml:lang="ja">一人旅</imas:Hobby>
     <imas:Talent xml:lang="ja">書道</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">477525</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>
@@ -1510,7 +1510,7 @@
     <imas:Hobby xml:lang="ja">水族館めぐり</imas:Hobby>
     <imas:Talent xml:lang="ja">素潜り(水中息止め)</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">1FC1DD</imas:Color>
-    <schema:gender xml:lang="en">male</schema:gender>
+    <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
   </rdf:Description>

--- a/RDFs/SideM.rdf
+++ b/RDFs/SideM.rdf
@@ -223,7 +223,7 @@
   </rdf:Description>
 
   <rdf:Description rdf:about="detail/Tsuzuki_Kei">
-    <foaf:age xml:lang="en">??</foaf:age>
+    <foaf:age xml:lang="ja">??</foaf:age>
     <schema:name xml:lang="ja">都築圭</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">都築圭</rdfs:label>
     <schema:name xml:lang="en">Tsuzuki Kei</schema:name>

--- a/RDFs/SideM.rdf
+++ b/RDFs/SideM.rdf
@@ -38,7 +38,7 @@
     <imas:Category xml:lang="ja">フィジカル</imas:Category>
     <imas:Constellation xml:lang="ja">魚座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">175.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">57.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">25.5</imas:ShoeSize>
@@ -72,7 +72,7 @@
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <imas:Category xml:lang="ja">メンタル</imas:Category>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">163.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">49.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">24.5</imas:ShoeSize>
@@ -104,7 +104,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
     <schema:birthPlace xml:lang="ja">京都</schema:birthPlace>
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">180.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">64.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">26.5</imas:ShoeSize>
@@ -138,7 +138,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
     <schema:birthPlace xml:lang="ja">福島</schema:birthPlace>
     <imas:Constellation xml:lang="ja">魚座</imas:Constellation>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">175.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">63.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">26.0</imas:ShoeSize>
@@ -171,7 +171,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
     <schema:birthPlace xml:lang="ja">京都</schema:birthPlace>
     <imas:Constellation xml:lang="ja">天秤座</imas:Constellation>
-    <imas:Handedness xml:lang="en">both</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">both</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">178.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">26.5</imas:ShoeSize>
@@ -203,7 +203,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
     <schema:birthPlace xml:lang="ja">新潟</schema:birthPlace>
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">182.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">68.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">27.0</imas:ShoeSize>
@@ -223,7 +223,7 @@
   </rdf:Description>
 
   <rdf:Description rdf:about="detail/Tsuzuki_Kei">
-    <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#string">??</foaf:age>
+    <foaf:age xml:lang="en">??</foaf:age>
     <schema:name xml:lang="ja">都築圭</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">都築圭</rdfs:label>
     <schema:name xml:lang="en">Tsuzuki Kei</schema:name>
@@ -238,7 +238,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
     <schema:birthPlace xml:lang="ja">ベルリン</schema:birthPlace>
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">182.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">54.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">27.0</imas:ShoeSize>
@@ -270,7 +270,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">165.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">52.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">24.5</imas:ShoeSize>
@@ -302,7 +302,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">182.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">62.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">27.0</imas:ShoeSize>
@@ -328,7 +328,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
     <schema:birthPlace xml:lang="ja">うみのむこう</schema:birthPlace>
     <imas:Constellation xml:lang="ja">獅子座</imas:Constellation>
-    <imas:Handedness xml:lang="en">both</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">both</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">165.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">50.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">24.5</imas:ShoeSize>
@@ -360,7 +360,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
     <schema:birthPlace xml:lang="ja">茨城</schema:birthPlace>
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">178.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">26.5</imas:ShoeSize>
@@ -392,7 +392,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
     <schema:birthPlace xml:lang="ja">長野</schema:birthPlace>
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">161.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">52.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">24.0</imas:ShoeSize>
@@ -424,7 +424,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
     <schema:birthPlace xml:lang="ja">長野</schema:birthPlace>
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">161.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">52.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">24.0</imas:ShoeSize>
@@ -457,7 +457,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Constellation xml:lang="ja">魚座</imas:Constellation>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">171.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">67.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">25.5</imas:ShoeSize>
@@ -490,7 +490,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
     <schema:birthPlace xml:lang="ja">千葉</schema:birthPlace>
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">175.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">70.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">26.0</imas:ShoeSize>
@@ -522,7 +522,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
     <schema:birthPlace xml:lang="ja">熊本</schema:birthPlace>
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">185.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">78.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">27.0</imas:ShoeSize>
@@ -554,7 +554,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
     <schema:birthPlace xml:lang="ja">群馬</schema:birthPlace>
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
-    <imas:Handedness xml:lang="en">both</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">both</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">165.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">54.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">24.5</imas:ShoeSize>
@@ -586,7 +586,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
     <schema:birthPlace xml:lang="ja">新潟</schema:birthPlace>
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">174.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">25.5</imas:ShoeSize>
@@ -618,7 +618,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
     <schema:birthPlace xml:lang="ja">鎌倉</schema:birthPlace>
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">178.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">67.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">26.5</imas:ShoeSize>
@@ -651,7 +651,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
     <schema:birthPlace xml:lang="ja">兵庫</schema:birthPlace>
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">162.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">48.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">24.0</imas:ShoeSize>
@@ -684,7 +684,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
     <schema:birthPlace xml:lang="ja">山梨</schema:birthPlace>
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">158.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">49.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">23.5</imas:ShoeSize>
@@ -716,7 +716,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
     <schema:birthPlace xml:lang="ja">札幌</schema:birthPlace>
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">170.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">54.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">25.5</imas:ShoeSize>
@@ -749,7 +749,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
     <schema:birthPlace xml:lang="ja">石川</schema:birthPlace>
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">173.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">25.5</imas:ShoeSize>
@@ -781,7 +781,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
     <schema:birthPlace xml:lang="ja">青森</schema:birthPlace>
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">169.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">52.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">25.0</imas:ShoeSize>
@@ -814,7 +814,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
     <schema:birthPlace xml:lang="ja">北海道</schema:birthPlace>
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">170.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">65.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">25.5</imas:ShoeSize>
@@ -846,7 +846,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
     <schema:birthPlace xml:lang="ja">京都</schema:birthPlace>
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">190.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">65.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">28.0</imas:ShoeSize>
@@ -880,7 +880,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
     <schema:birthPlace xml:lang="ja">兵庫</schema:birthPlace>
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">181.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">64.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">27.0</imas:ShoeSize>
@@ -914,7 +914,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
     <schema:birthPlace xml:lang="ja">大阪</schema:birthPlace>
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">177.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">65.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">26.0</imas:ShoeSize>
@@ -942,7 +942,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
     <schema:birthPlace xml:lang="ja">ゲヘナ</schema:birthPlace>
     <imas:Constellation xml:lang="ja">天秤座</imas:Constellation>
-    <imas:Handedness xml:lang="en">both</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">both</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">174.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">66.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">25.5</imas:ShoeSize>
@@ -975,7 +975,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
     <schema:birthPlace xml:lang="ja">高知</schema:birthPlace>
     <imas:Constellation xml:lang="ja">射手座</imas:Constellation>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">163.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">52.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">24.5</imas:ShoeSize>
@@ -1008,7 +1008,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
     <schema:birthPlace xml:lang="ja">千葉</schema:birthPlace>
     <imas:Constellation xml:lang="ja">獅子座</imas:Constellation>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">160.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">48.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">24.0</imas:ShoeSize>
@@ -1040,7 +1040,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
     <schema:birthPlace xml:lang="ja">千葉</schema:birthPlace>
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">143.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">33.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">21.0</imas:ShoeSize>
@@ -1072,7 +1072,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
     <schema:birthPlace xml:lang="ja">栃木</schema:birthPlace>
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">139.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">34.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">20.5</imas:ShoeSize>
@@ -1104,7 +1104,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">125.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">22.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">20.0</imas:ShoeSize>
@@ -1136,7 +1136,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
     <schema:birthPlace xml:lang="ja">淡路島</schema:birthPlace>
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">178.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">65.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">26.5</imas:ShoeSize>
@@ -1169,7 +1169,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
     <schema:birthPlace xml:lang="ja">横須賀</schema:birthPlace>
     <imas:Constellation xml:lang="ja">獅子座</imas:Constellation>
-    <imas:Handedness xml:lang="en">both</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">both</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">170.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">25.5</imas:ShoeSize>
@@ -1203,7 +1203,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
     <schema:birthPlace xml:lang="ja">石川</schema:birthPlace>
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">185.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">70.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">27.0</imas:ShoeSize>
@@ -1236,7 +1236,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
     <schema:birthPlace xml:lang="ja">宮城</schema:birthPlace>
     <imas:Constellation xml:lang="ja">射手座</imas:Constellation>
-    <imas:Handedness xml:lang="en">left</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">165.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">52.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">24.5</imas:ShoeSize>
@@ -1270,7 +1270,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
     <schema:birthPlace xml:lang="ja">高知</schema:birthPlace>
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
-    <imas:Handedness xml:lang="en">both</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">both</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">185.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">80.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">28.5</imas:ShoeSize>
@@ -1302,7 +1302,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">不明</imas:BloodType>
     <schema:birthPlace xml:lang="ja">海外の何処か</schema:birthPlace>
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
-    <imas:Handedness xml:lang="en">both</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">both</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">172.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">59.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">25.5</imas:ShoeSize>
@@ -1334,7 +1334,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">164.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">54.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">24.5</imas:ShoeSize>
@@ -1368,7 +1368,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
     <schema:birthPlace xml:lang="ja">広島</schema:birthPlace>
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">160.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">52.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">24.0</imas:ShoeSize>
@@ -1401,7 +1401,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
     <schema:birthPlace xml:lang="ja">岐阜</schema:birthPlace>
     <imas:Constellation xml:lang="ja">天秤座</imas:Constellation>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">178.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">64.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">26.5</imas:ShoeSize>
@@ -1435,7 +1435,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
     <schema:birthPlace xml:lang="ja">奈良</schema:birthPlace>
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
-    <imas:Handedness xml:lang="en">both</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">both</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">191.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">74.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">28.0</imas:ShoeSize>
@@ -1467,7 +1467,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
     <schema:birthPlace xml:lang="ja">三重</schema:birthPlace>
     <imas:Constellation xml:lang="ja">射手座</imas:Constellation>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">174.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">62.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">26.5</imas:ShoeSize>
@@ -1499,7 +1499,7 @@
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AB</imas:BloodType>
     <schema:birthPlace xml:lang="ja">埼玉</schema:birthPlace>
     <imas:Constellation xml:lang="ja">天秤座</imas:Constellation>
-    <imas:Handedness xml:lang="en">right</imas:Handedness>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">187.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</schema:weight>
     <imas:ShoeSize rdf:datatype="http://www.w3.org/2001/XMLSchema#float">27.5</imas:ShoeSize>

--- a/constrains/idol.ttl
+++ b/constrains/idol.ttl
@@ -87,10 +87,9 @@ imas-shape:IdolShape a sh:NodeShape;
         # 体重
         # 何人かのアイドルは体重が数値じゃない
         sh:path schema:weight;
-        sh:or (
+        sh:xone (
             [ sh:datatype xsd:float; ]
             [ sh:datatype rdf:langString; ]
-            [ sh:datatype xsd:string; ]
         );
         sh:maxCount 1;
     ];
@@ -98,10 +97,9 @@ imas-shape:IdolShape a sh:NodeShape;
         # 身長
         # 何人かのアイドルは数値じゃない
         sh:path schema:height;
-        sh:or (
+        sh:xone (
             [ sh:datatype xsd:float; ]
             [ sh:datatype rdf:langString; ]
-            [ sh:datatype xsd:string; ]
         );
         sh:maxCount 1;
     ];
@@ -109,10 +107,9 @@ imas-shape:IdolShape a sh:NodeShape;
         # 胸囲
         # 何人かのアイドルは数値じゃない
         sh:path imas:Bust;
-        sh:or (
+        sh:xone (
             [ sh:datatype xsd:float; ]
             [ sh:datatype rdf:langString; ]
-            [ sh:datatype xsd:string; ]
         );
         sh:maxCount 1;
     ];
@@ -120,10 +117,9 @@ imas-shape:IdolShape a sh:NodeShape;
         # 腹囲
         # 何人かのアイドルは数値じゃない
         sh:path imas:Waist;
-        sh:or (
+        sh:xone (
             [ sh:datatype xsd:float; ]
             [ sh:datatype rdf:langString; ]
-            [ sh:datatype xsd:string; ]
         );
         sh:maxCount 1;
     ];
@@ -131,10 +127,9 @@ imas-shape:IdolShape a sh:NodeShape;
         # 腰囲
         # 何人かのアイドルは数値じゃない
         sh:path imas:Hip;
-        sh:or (
+        sh:xone (
             [ sh:datatype xsd:float; ]
             [ sh:datatype rdf:langString; ]
-            [ sh:datatype xsd:string; ]
         );
         sh:maxCount 1;
     ];
@@ -162,10 +157,9 @@ imas-shape:IdolShape a sh:NodeShape;
         # 年齢
         # 何人かのアイドルは数字じゃない
         sh:path foaf:age;
-        sh:or (
+        sh:xone (
             [ sh:datatype xsd:integer; ]
             [ sh:datatype rdf:langString; ]
-            [ sh:datatype xsd:string; ]
         );
         sh:maxCount 1;
     ];
@@ -181,8 +175,8 @@ imas-shape:IdolShape a sh:NodeShape;
         # 利き手
         # 両手利きもいるのでbothも許容
         sh:path imas:Handedness;
-        sh:datatype rdf:langString;
-        sh:pattern "^(right|left|both)$";
+        sh:datatype xsd:string;
+        sh:in ("right" "left" "both");
         sh:maxCount 1;
     ];
     sh:property [

--- a/constrains/idol.ttl
+++ b/constrains/idol.ttl
@@ -91,7 +91,10 @@ imas-shape:IdolShape a sh:NodeShape;
                 sh:datatype xsd:float;
                 sh:minExclusive 0;
             ]
-            [ sh:datatype rdf:langString; ]
+            [
+                sh:datatype rdf:langString;
+                sh:languageIn ("ja")
+            ]
         );
         sh:maxCount 1;
     ];
@@ -104,7 +107,10 @@ imas-shape:IdolShape a sh:NodeShape;
                 sh:datatype xsd:float;
                 sh:minExclusive 0;
             ]
-            [ sh:datatype rdf:langString; ]
+            [
+                sh:datatype rdf:langString;
+                sh:languageIn ("ja")
+            ]
         );
         sh:maxCount 1;
     ];
@@ -117,7 +123,10 @@ imas-shape:IdolShape a sh:NodeShape;
                 sh:datatype xsd:float;
                 sh:minExclusive 0;
             ]
-            [ sh:datatype rdf:langString; ]
+            [
+                sh:datatype rdf:langString;
+                sh:languageIn ("ja")
+            ]
         );
         sh:maxCount 1;
     ];
@@ -130,7 +139,10 @@ imas-shape:IdolShape a sh:NodeShape;
                 sh:datatype xsd:float;
                 sh:minExclusive 0;
             ]
-            [ sh:datatype rdf:langString; ]
+            [
+                sh:datatype rdf:langString;
+                sh:languageIn ("ja")
+            ]
         );
         sh:maxCount 1;
     ];
@@ -143,7 +155,10 @@ imas-shape:IdolShape a sh:NodeShape;
                 sh:datatype xsd:float;
                 sh:minExclusive 0;
             ]
-            [ sh:datatype rdf:langString; ]
+            [
+                sh:datatype rdf:langString;
+                sh:languageIn ("ja")
+            ]
         );
         sh:maxCount 1;
     ];
@@ -175,7 +190,10 @@ imas-shape:IdolShape a sh:NodeShape;
                 sh:datatype xsd:integer;
                 sh:minInclusive 0;
             ]
-            [ sh:datatype rdf:langString; ]
+            [
+                sh:datatype rdf:langString;
+                sh:languageIn ("ja")
+            ]
         );
         sh:maxCount 1;
     ];

--- a/constrains/idol.ttl
+++ b/constrains/idol.ttl
@@ -71,8 +71,8 @@ imas-shape:IdolShape a sh:NodeShape;
         # 性別
         # femaleかmaleのみで、性別は必ず一つだけ存在する
         sh:path schema:gender;
-        sh:datatype rdf:langString;
-        sh:pattern "^(female|male)$";
+        sh:datatype xsd:string;
+        sh:in ("female" "male");
         sh:minCount 1;
         sh:maxCount 1;
     ];

--- a/constrains/idol.ttl
+++ b/constrains/idol.ttl
@@ -1,0 +1,207 @@
+PREFIX schema: <http://schema.org/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX imas: <https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+
+imas:IdolShape a sh:NodeShape;
+    sh:targetClass imas:Idol;
+    sh:property [
+        # アイドルの登場するコンテンツのタイトル
+        sh:path imas:Title;
+        sh:datatype rdf:langString;
+        sh:minCount 1;
+    ];
+    sh:property [
+        # アイドルのプロフィール等に書かれている名前(ロコはロコで伴田路子ではない)
+        # 絶対に一つだけ存在する(maxCount 1, minCount 1)
+        sh:path rdfs:label;
+        sh:datatype xsd:string;
+        sh:minCount 1;
+        sh:maxCount 1;
+    ];
+    sh:property [
+        # アイドルの本名
+        # ジュリア、アスラン=BBⅡ世とか本名がわかってないアイドルが何人かいるため数の制限はない
+        # 日本語、英語表記一つづつ存在する想定のため、uniqueLang=true
+        sh:path schema:name;
+        sh:datatype rdf:langString;
+        sh:uniqueLang true;
+    ];
+    sh:property [
+        # 本名の仮名
+        # 仮名は日本語なのでlang=ja
+        sh:path imas:nameKana;
+        sh:datatype rdf:langString;
+        sh:languageIn ("ja");
+        sh:maxCount 1;
+    ];
+    sh:property [
+        # 下の名前
+        # 日本語、英語表記一つづつ存在する想定のため、uniqueLang=true
+        sh:path schema:givenName;
+        sh:datatype rdf:langString;
+        sh:uniqueLang true;
+    ];
+    sh:property [
+        # 上の名前
+        # 日本語、英語表記一つづつ存在する想定のため、uniqueLang=true
+        sh:path schema:familyName;
+        sh:datatype rdf:langString;
+        sh:uniqueLang true;
+    ];
+    sh:property [
+        # 下の名前の読み
+        # 仮名は日本語なのでlang=ja
+        sh:path imas:givenNameKana;
+        sh:datatype rdf:langString;
+        sh:languageIn ("ja");
+    ];
+    sh:property [
+        # 上の名前の読み
+        # 仮名は日本語なのでlang=ja
+        sh:path imas:familyNameKana;
+        sh:datatype rdf:langString;
+        sh:languageIn ("ja");
+    ];
+    sh:property [
+        # 性別
+        # femaleかmaleのみで、性別は必ず一つだけ存在する
+        sh:path schema:gender;
+        sh:datatype rdf:langString;
+        sh:pattern "^(female|male)$";
+        sh:minCount 1;
+        sh:maxCount 1;
+    ];
+    sh:property [
+        # テーマカラー
+        # 最大一つだけ存在して、目的語の型はhexBinary
+        sh:path imas:Color;
+        sh:datatype xsd:hexBinary;
+        sh:maxCount 1;
+    ];
+    sh:property [
+        # 体重
+        # 何人かのアイドルは体重が数値じゃない
+        sh:path schema:weight;
+        sh:or (
+            [ sh:datatype xsd:float; ]
+            [ sh:datatype rdf:langString; ]
+            [ sh:datatype xsd:string; ]
+        );
+        sh:maxCount 1;
+    ];
+    sh:property [
+        # 身長
+        # 何人かのアイドルは数値じゃない
+        sh:path schema:height;
+        sh:or (
+            [ sh:datatype xsd:float; ]
+            [ sh:datatype rdf:langString; ]
+            [ sh:datatype xsd:string; ]
+        );
+        sh:maxCount 1;
+    ];
+    sh:property [
+        # 胸囲
+        # 何人かのアイドルは数値じゃない
+        sh:path imas:Bust;
+        sh:or (
+            [ sh:datatype xsd:float; ]
+            [ sh:datatype rdf:langString; ]
+            [ sh:datatype xsd:string; ]
+        );
+        sh:maxCount 1;
+    ];
+    sh:property [
+        # 腹囲
+        # 何人かのアイドルは数値じゃない
+        sh:path imas:Waist;
+        sh:or (
+            [ sh:datatype xsd:float; ]
+            [ sh:datatype rdf:langString; ]
+            [ sh:datatype xsd:string; ]
+        );
+        sh:maxCount 1;
+    ];
+    sh:property [
+        # 腰囲
+        # 何人かのアイドルは数値じゃない
+        sh:path imas:Hip;
+        sh:or (
+            [ sh:datatype xsd:float; ]
+            [ sh:datatype rdf:langString; ]
+            [ sh:datatype xsd:string; ]
+        );
+        sh:maxCount 1;
+    ];
+    sh:property [
+        # 特技
+        # 今の所英語で特技を書くアイドルはいないので日本語のみ受け入れ
+        # アイドルによっては複数あるので数の制限はない
+        sh:path imas:Talent;
+        sh:datatype rdf:langString;
+        sh:languageIn ("ja");
+    ];
+    sh:property [
+        # 誕生日
+        sh:path schema:birthDate;
+        sh:datatype xsd:gMonthDay;
+        sh:maxCount 1;
+    ];
+    sh:property [
+        # 出身
+        sh:path schema:birthPlace;
+        sh:datatype rdf:langString;
+        sh:maxCount 1;
+    ];
+    sh:property [
+        # 年齢
+        # 何人かのアイドルは数字じゃない
+        sh:path foaf:age;
+        sh:or (
+            [ sh:datatype xsd:integer; ]
+            [ sh:datatype rdf:langString; ]
+            [ sh:datatype xsd:string; ]
+        );
+        sh:maxCount 1;
+    ];
+    sh:property [
+        # 血液型
+        # 牙崎漣が血液型不明なので、仕方なく「不明」も許容
+        sh:path imas:BloodType;
+        sh:datatype xsd:string;
+        sh:pattern "^(A|B|O|AB|不明)$";
+        sh:maxCount 1;
+    ];
+    sh:property [
+        # 利き手
+        # 両手利きもいるのでbothも許容
+        sh:path imas:Handedness;
+        sh:datatype rdf:langString;
+        sh:pattern "^(right|left|both)$";
+        sh:maxCount 1;
+    ];
+    sh:property [
+        # 星座
+        # 杏が「花も恥じらう乙女座」となっているので、文頭/文末一致がない
+        sh:path imas:Constellation;
+        sh:datatype rdf:langString;
+        sh:pattern "(牡羊座|牡牛座|双子座|蟹座|獅子座|乙女座|天秤座|蠍座|射手座|山羊座|水瓶座|魚座)";
+        sh:maxCount 1;
+    ];
+    sh:property [
+        # 趣味
+        # アイドルによっては複数あるので数の制限はない
+        sh:path imas:Hobby;
+        sh:datatype rdf:langString;
+    ];
+    sh:property [
+        # 所属ユニット
+        # 目的語はimas:Unit
+        sh:path schema:memberOf;
+        sh:class imas:Unit;
+    ];
+    sh:closed false.

--- a/constrains/idol.ttl
+++ b/constrains/idol.ttl
@@ -87,7 +87,10 @@ imas-shape:IdolShape a sh:NodeShape;
         rdfs:comment "何人かのアイドルは体重が数値じゃない";
         sh:path schema:weight;
         sh:xone (
-            [ sh:datatype xsd:float; ]
+            [
+                sh:datatype xsd:float;
+                sh:minExclusive 0;
+            ]
             [ sh:datatype rdf:langString; ]
         );
         sh:maxCount 1;
@@ -97,7 +100,10 @@ imas-shape:IdolShape a sh:NodeShape;
         rdfs:comment "何人かのアイドルは身長が数値じゃない";
         sh:path schema:height;
         sh:xone (
-            [ sh:datatype xsd:float; ]
+            [
+                sh:datatype xsd:float;
+                sh:minExclusive 0;
+            ]
             [ sh:datatype rdf:langString; ]
         );
         sh:maxCount 1;
@@ -107,7 +113,10 @@ imas-shape:IdolShape a sh:NodeShape;
         rdfs:comment "何人かのアイドルは胸囲が数値じゃない";
         sh:path imas:Bust;
         sh:xone (
-            [ sh:datatype xsd:float; ]
+            [
+                sh:datatype xsd:float;
+                sh:minExclusive 0;
+            ]
             [ sh:datatype rdf:langString; ]
         );
         sh:maxCount 1;
@@ -117,7 +126,10 @@ imas-shape:IdolShape a sh:NodeShape;
         rdfs:comment "何人かのアイドルは腹囲が数値じゃない";
         sh:path imas:Waist;
         sh:xone (
-            [ sh:datatype xsd:float; ]
+            [
+                sh:datatype xsd:float;
+                sh:minExclusive 0;
+            ]
             [ sh:datatype rdf:langString; ]
         );
         sh:maxCount 1;
@@ -127,7 +139,10 @@ imas-shape:IdolShape a sh:NodeShape;
         rdfs:comment "何人かのアイドルは腰囲が数値じゃない";
         sh:path imas:Hip;
         sh:xone (
-            [ sh:datatype xsd:float; ]
+            [
+                sh:datatype xsd:float;
+                sh:minExclusive 0;
+            ]
             [ sh:datatype rdf:langString; ]
         );
         sh:maxCount 1;
@@ -156,7 +171,10 @@ imas-shape:IdolShape a sh:NodeShape;
         rdfs:comment "何人かのアイドルは年齢が数値じゃない";
         sh:path foaf:age;
         sh:xone (
-            [ sh:datatype xsd:integer; ]
+            [
+                sh:datatype xsd:integer;
+                sh:minInclusive 0;
+            ]
             [ sh:datatype rdf:langString; ]
         );
         sh:maxCount 1;

--- a/constrains/idol.ttl
+++ b/constrains/idol.ttl
@@ -10,66 +10,65 @@ PREFIX sh: <http://www.w3.org/ns/shacl#>
 imas-shape:IdolShape a sh:NodeShape;
     sh:targetClass imas:Idol;
     sh:property [
-        # アイドルの登場するコンテンツのタイトル
+        rdfs:label "アイドルの登場するコンテンツのタイトルの制約";
         sh:path imas:Title;
         sh:datatype rdf:langString;
         sh:minCount 1;
     ];
     sh:property [
-        # アイドルのプロフィール等に書かれている名前(ロコはロコで伴田路子ではない)
-        # 絶対に一つだけ存在する(maxCount 1, minCount 1)
+        rdfs:label "アイドルのプロフィール等に書かれている名前の制約";
+        rdfs:comment "絶対に一つだけ存在する(maxCount 1, minCount 1)、ロコはロコであって伴田路子ではない";
         sh:path rdfs:label;
         sh:datatype xsd:string;
         sh:minCount 1;
         sh:maxCount 1;
     ];
     sh:property [
-        # アイドルの本名
-        # ジュリア、アスラン=BBⅡ世とか本名がわかってないアイドルが何人かいるため数の制限はない
-        # 日本語、英語表記一つづつ存在する想定のため、uniqueLang=true
+        rdfs:label "アイドルの本名の制約";
+        rdfs:comment "ジュリア、アスラン=BBⅡ世とか本名がわかってないアイドルが何人かいるため数の制限はなく、日本語と英語表記一つづつ存在する想定のため、uniqueLang=true";
         sh:path schema:name;
         sh:datatype rdf:langString;
         sh:uniqueLang true;
     ];
     sh:property [
-        # 本名の仮名
-        # 仮名は日本語なのでlang=ja
+        rdfs:label "本名の仮名の制約";
+        rdfs:comment "仮名は日本語なのでlang=ja";
         sh:path imas:nameKana;
         sh:datatype rdf:langString;
         sh:languageIn ("ja");
         sh:maxCount 1;
     ];
     sh:property [
-        # 下の名前
-        # 日本語、英語表記一つづつ存在する想定のため、uniqueLang=true
+        rdfs:label "下の名前の制約";
+        rdfs:comment "日本語、英語表記一つづつ存在する想定のため、uniqueLang=true";
         sh:path schema:givenName;
         sh:datatype rdf:langString;
         sh:uniqueLang true;
     ];
     sh:property [
-        # 上の名前
-        # 日本語、英語表記一つづつ存在する想定のため、uniqueLang=true
+        rdfs:label "上の名前の制約";
+        rdfs:comment "日本語、英語表記一つづつ存在する想定のため、uniqueLang=true";
         sh:path schema:familyName;
         sh:datatype rdf:langString;
         sh:uniqueLang true;
     ];
     sh:property [
-        # 下の名前の読み
-        # 仮名は日本語なのでlang=ja
+        rdfs:label "下の名前の仮名の制約";
+        rdfs:comment "仮名は日本語なのでlang=ja";
         sh:path imas:givenNameKana;
         sh:datatype rdf:langString;
         sh:languageIn ("ja");
     ];
     sh:property [
-        # 上の名前の読み
-        # 仮名は日本語なのでlang=ja
+        rdfs:label "上の名前の仮名の制約";
+        rdfs:comment "仮名は日本語なのでlang=ja";
         sh:path imas:familyNameKana;
         sh:datatype rdf:langString;
         sh:languageIn ("ja");
     ];
     sh:property [
-        # 性別
-        # femaleかmaleのみで、性別は必ず一つだけ存在する
+        rdfs:label "性別の制約";
+        rdfs:comment "femaleかmaleのみで、性別は必ず一つだけ存在する";
         sh:path schema:gender;
         sh:datatype xsd:string;
         sh:in ("female" "male");
@@ -77,15 +76,15 @@ imas-shape:IdolShape a sh:NodeShape;
         sh:maxCount 1;
     ];
     sh:property [
-        # テーマカラー
-        # 最大一つだけ存在して、目的語の型はhexBinary
+        rdfs:label "テーマカラーの制約";
+        rdfs:comment "最大一つだけ存在して、目的語の型はhexBinary";
         sh:path imas:Color;
         sh:datatype xsd:hexBinary;
         sh:maxCount 1;
     ];
     sh:property [
-        # 体重
-        # 何人かのアイドルは体重が数値じゃない
+        rdfs:label "体重の制約";
+        rdfs:comment "何人かのアイドルは体重が数値じゃない";
         sh:path schema:weight;
         sh:xone (
             [ sh:datatype xsd:float; ]
@@ -94,8 +93,8 @@ imas-shape:IdolShape a sh:NodeShape;
         sh:maxCount 1;
     ];
     sh:property [
-        # 身長
-        # 何人かのアイドルは数値じゃない
+        rdfs:label "身長の制約";
+        rdfs:comment "何人かのアイドルは身長が数値じゃない";
         sh:path schema:height;
         sh:xone (
             [ sh:datatype xsd:float; ]
@@ -104,8 +103,8 @@ imas-shape:IdolShape a sh:NodeShape;
         sh:maxCount 1;
     ];
     sh:property [
-        # 胸囲
-        # 何人かのアイドルは数値じゃない
+        rdfs:label "胸囲の制約";
+        rdfs:comment "何人かのアイドルは胸囲が数値じゃない";
         sh:path imas:Bust;
         sh:xone (
             [ sh:datatype xsd:float; ]
@@ -114,8 +113,8 @@ imas-shape:IdolShape a sh:NodeShape;
         sh:maxCount 1;
     ];
     sh:property [
-        # 腹囲
-        # 何人かのアイドルは数値じゃない
+        rdfs:label "腹囲の制約";
+        rdfs:comment "何人かのアイドルは腹囲が数値じゃない";
         sh:path imas:Waist;
         sh:xone (
             [ sh:datatype xsd:float; ]
@@ -124,8 +123,8 @@ imas-shape:IdolShape a sh:NodeShape;
         sh:maxCount 1;
     ];
     sh:property [
-        # 腰囲
-        # 何人かのアイドルは数値じゃない
+        rdfs:label "腰囲の制約";
+        rdfs:comment "何人かのアイドルは腰囲が数値じゃない";
         sh:path imas:Hip;
         sh:xone (
             [ sh:datatype xsd:float; ]
@@ -134,28 +133,27 @@ imas-shape:IdolShape a sh:NodeShape;
         sh:maxCount 1;
     ];
     sh:property [
-        # 特技
-        # 今の所英語で特技を書くアイドルはいないので日本語のみ受け入れ
-        # アイドルによっては複数あるので数の制限はない
+        rdfs:label "特技の制約";
+        rdfs:comment "今の所英語で特技を書くアイドルはいないので日本語のみ受け入れ、アイドルによっては複数あるので数の制限はない";
         sh:path imas:Talent;
         sh:datatype rdf:langString;
         sh:languageIn ("ja");
     ];
     sh:property [
-        # 誕生日
+        rdfs:label "誕生日の制約";
         sh:path schema:birthDate;
         sh:datatype xsd:gMonthDay;
         sh:maxCount 1;
     ];
     sh:property [
-        # 出身
+        rdfs:label "出身の制約";
         sh:path schema:birthPlace;
         sh:datatype rdf:langString;
         sh:maxCount 1;
     ];
     sh:property [
-        # 年齢
-        # 何人かのアイドルは数字じゃない
+        rdfs:label "年齢の制約";
+        rdfs:comment "何人かのアイドルは年齢が数値じゃない";
         sh:path foaf:age;
         sh:xone (
             [ sh:datatype xsd:integer; ]
@@ -164,23 +162,24 @@ imas-shape:IdolShape a sh:NodeShape;
         sh:maxCount 1;
     ];
     sh:property [
-        # 血液型
-        # 牙崎漣が血液型不明なので、仕方なく「不明」も許容
+        rdfs:label "血液型の制約";
+        rdfs:comment "牙崎漣が血液型不明なので、仕方なく「不明」も許容";
         sh:path imas:BloodType;
         sh:datatype xsd:string;
         sh:in ("A" "B" "O" "AB" "不明");
         sh:maxCount 1;
     ];
     sh:property [
-        # 利き手
-        # 両手利きもいるのでbothも許容
+        rdfs:label "利き手の制約";
+        rdfs:comment "両手利きもいるのでbothも許容";
         sh:path imas:Handedness;
         sh:datatype xsd:string;
         sh:in ("right" "left" "both");
         sh:maxCount 1;
     ];
     sh:property [
-        # 星座
+        rdfs:label "星座の制約";
+        rdfs:comment "今の所変なことを書いてるのは双葉杏だけ、増えてきたらちょっと考える";
         sh:path imas:Constellation;
         sh:datatype rdf:langString;
         sh:in (
@@ -203,15 +202,15 @@ imas-shape:IdolShape a sh:NodeShape;
         sh:maxCount 1;
     ];
     sh:property [
-        # 趣味
-        # アイドルによっては複数あるので数の制限はない
+        rdfs:label "趣味の制約";
+        rdfs:comment "アイドルによっては複数あるので数の制限はない";
         sh:path imas:Hobby;
         sh:datatype rdf:langString;
         sh:languageIn ("ja");
     ];
     sh:property [
-        # 所属ユニット
-        # 目的語はimas:Unit
+        rdfs:label "所属ユニットの制約";
+        rdfs:comment "目的語はimas:Unit";
         sh:path schema:memberOf;
         sh:class imas:Unit;
     ];

--- a/constrains/idol.ttl
+++ b/constrains/idol.ttl
@@ -190,6 +190,7 @@ imas:IdolShape a sh:NodeShape;
         sh:path imas:Constellation;
         sh:datatype rdf:langString;
         sh:pattern "(牡羊座|牡牛座|双子座|蟹座|獅子座|乙女座|天秤座|蠍座|射手座|山羊座|水瓶座|魚座)";
+        sh:languageIn ("ja");
         sh:maxCount 1;
     ];
     sh:property [
@@ -197,6 +198,7 @@ imas:IdolShape a sh:NodeShape;
         # アイドルによっては複数あるので数の制限はない
         sh:path imas:Hobby;
         sh:datatype rdf:langString;
+        sh:languageIn ("ja");
     ];
     sh:property [
         # 所属ユニット

--- a/constrains/idol.ttl
+++ b/constrains/idol.ttl
@@ -1,3 +1,4 @@
+PREFIX imas-shape: <https://sparql.crssnky.xyz/imasrdf/constrains/>
 PREFIX schema: <http://schema.org/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX imas: <https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#>
@@ -6,7 +7,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 
-imas:IdolShape a sh:NodeShape;
+imas-shape:IdolShape a sh:NodeShape;
     sh:targetClass imas:Idol;
     sh:property [
         # アイドルの登場するコンテンツのタイトル

--- a/constrains/idol.ttl
+++ b/constrains/idol.ttl
@@ -168,7 +168,7 @@ imas-shape:IdolShape a sh:NodeShape;
         # 牙崎漣が血液型不明なので、仕方なく「不明」も許容
         sh:path imas:BloodType;
         sh:datatype xsd:string;
-        sh:pattern "^(A|B|O|AB|不明)$";
+        sh:in ("A" "B" "O" "AB" "不明");
         sh:maxCount 1;
     ];
     sh:property [

--- a/constrains/idol.ttl
+++ b/constrains/idol.ttl
@@ -181,10 +181,24 @@ imas-shape:IdolShape a sh:NodeShape;
     ];
     sh:property [
         # 星座
-        # 杏が「花も恥じらう乙女座」となっているので、文頭/文末一致がない
         sh:path imas:Constellation;
         sh:datatype rdf:langString;
-        sh:pattern "(牡羊座|牡牛座|双子座|蟹座|獅子座|乙女座|天秤座|蠍座|射手座|山羊座|水瓶座|魚座)";
+        sh:in (
+            "牡羊座"@ja
+            "牡牛座"@ja
+            "双子座"@ja
+            "蟹座"@ja
+            "獅子座"@ja
+            "乙女座"@ja
+            "天秤座"@ja
+            "蠍座"@ja
+            "射手座"@ja
+            "山羊座"@ja
+            "水瓶座"@ja
+            "魚座"@ja
+            # ここから例外パターン
+            "花も恥じらう乙女座"@ja
+        );
         sh:languageIn ("ja");
         sh:maxCount 1;
     ];

--- a/constrains/idol.ttl
+++ b/constrains/idol.ttl
@@ -232,4 +232,10 @@ imas-shape:IdolShape a sh:NodeShape;
         sh:path schema:memberOf;
         sh:class imas:Unit;
     ];
+    sh:property [
+        rdfs:label "衣装の制約";
+        rdfs:comment "目的語はimas:Clothes";
+        sh:path schema:owns;
+        sh:class imas:Clothes;
+    ];
     sh:closed false.


### PR DESCRIPTION
ref #294 

`imas:Idol` に対する制約をかける `imas:IdolShape` を追加しました
まずは #294 で上がった述語に対しての制約だけです