### PR TITLE
ゆきぽのCVに落合祐里香を追加

### DIFF
--- a/RDFs/765AS.rdf
+++ b/RDFs/765AS.rdf
@@ -159,6 +159,9 @@
     <imas:Talent xml:lang="ja">日本茶をいれること</imas:Talent>
     <imas:Favorite xml:lang="ja">ブログ</imas:Favorite>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D3DDE9</imas:Color>
+    <imas:cv xml:lang="ja">落合祐里香</imas:cv>
+    <imas:cv rdf:resource="http://ja.dbpedia.org/resource/落合祐里香"/>
+    <imas:cv rdf:resource="http://www.wikidata.org/entity/Q541307"/>
     <imas:cv xml:lang="ja">浅倉杏美</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/浅倉杏美"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q8191313"/>


### PR DESCRIPTION
CVが変更されたアイドルの扱いと、時期によって芸名の異なる声優の扱いに対する問題提起的なPRです。