### PR TITLE
アイドル名鑑のアイドル毎URLを追加

### DIFF
--- a/RDFs/1stVision.rdf
+++ b/RDFs/1stVision.rdf
@@ -4,6 +4,7 @@
     xmlns:foaf="http://xmlns.com/foaf/0.1/"
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xmlns:imas="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
     xml:base="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/"
     >
 
@@ -36,6 +37,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10002"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kisaragi_Chihaya_1st">
@@ -66,6 +68,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10005"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hoshii_Miki_1st">
@@ -97,6 +100,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10011"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hagiwara_Yukiho_1st">
@@ -128,6 +132,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10008"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takatsuki_Yayoi_1st">
@@ -158,6 +163,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10007"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kikuchi_Makoto_1st">
@@ -188,6 +194,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10004"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Minase_Iori_1st">
@@ -219,6 +226,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10013"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shijou_Takane_1st">
@@ -250,6 +258,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10006"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akizuki_Ritsuko_1st">
@@ -281,6 +290,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10001"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Miura_Azusa_1st">
@@ -311,6 +321,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10012"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Futami_Ami_1st">
@@ -342,6 +353,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10009"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Futami_Mami_1st">
@@ -373,6 +385,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10010"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ganaha_Hibiki_1st">
@@ -402,5 +415,6 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10003"/>
   </rdf:Description>
 </rdf:RDF>

--- a/RDFs/1stVision.rdf
+++ b/RDFs/1stVision.rdf
@@ -37,7 +37,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10002"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10002"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kisaragi_Chihaya_1st">
@@ -68,7 +68,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10005"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10005"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hoshii_Miki_1st">
@@ -100,7 +100,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10011"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10011"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hagiwara_Yukiho_1st">
@@ -132,7 +132,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10008"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10008"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takatsuki_Yayoi_1st">
@@ -163,7 +163,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10007"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10007"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kikuchi_Makoto_1st">
@@ -194,7 +194,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10004"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10004"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Minase_Iori_1st">
@@ -226,7 +226,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10013"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10013"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shijou_Takane_1st">
@@ -258,7 +258,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10006"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10006"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akizuki_Ritsuko_1st">
@@ -290,7 +290,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10001"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10001"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Miura_Azusa_1st">
@@ -321,7 +321,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10012"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10012"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Futami_Ami_1st">
@@ -353,7 +353,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10009"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10009"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Futami_Mami_1st">
@@ -385,7 +385,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10010"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10010"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ganaha_Hibiki_1st">
@@ -415,6 +415,6 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10003"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10003"/>
   </rdf:Description>
 </rdf:RDF>

--- a/RDFs/1stVision.rdf
+++ b/RDFs/1stVision.rdf
@@ -37,7 +37,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10002"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10002"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kisaragi_Chihaya_1st">
@@ -68,7 +68,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10005"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10005"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hoshii_Miki_1st">
@@ -100,7 +100,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10011"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10011"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hagiwara_Yukiho_1st">
@@ -132,7 +132,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10008"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10008"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takatsuki_Yayoi_1st">
@@ -163,7 +163,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10007"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10007"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kikuchi_Makoto_1st">
@@ -194,7 +194,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10004"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10004"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Minase_Iori_1st">
@@ -226,7 +226,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10013"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10013"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shijou_Takane_1st">
@@ -258,7 +258,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10006"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10006"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akizuki_Ritsuko_1st">
@@ -290,7 +290,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10001"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10001"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Miura_Azusa_1st">
@@ -321,7 +321,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10012"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10012"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Futami_Ami_1st">
@@ -353,7 +353,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10009"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10009"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Futami_Mami_1st">
@@ -385,7 +385,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10010"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10010"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ganaha_Hibiki_1st">
@@ -415,6 +415,6 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">1st Vision</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10003"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10003"/>
   </rdf:Description>
 </rdf:RDF>

--- a/RDFs/283.rdf
+++ b/RDFs/283.rdf
@@ -4,6 +4,7 @@
     xmlns:foaf="http://xmlns.com/foaf/0.1/"
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xmlns:imas="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
     xml:base="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/"
     >
 
@@ -40,6 +41,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">ほんわかした癒し系の女の子で、心優しい性格。見ていて守りたくなるタイプで、一緒にいるだけで何となく幸せな気持ちになる。高校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50011"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hachimiya_Meguru">
@@ -75,6 +77,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">天真爛漫な性格で、誰にでも積極的に話しかける。とにかく元気で友達想いの女の子。日本人の父とアメリカ人の母を持つ。高校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50017"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kazano_Hiori">
@@ -112,6 +115,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">後ろでまとめた黒髪が印象的な、クール系美少女。自分が納得するまで努力を欠かさないストイックな性格の持ち主。高校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50007"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tsukioka_Kogane">
@@ -146,6 +150,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">自信たっぷりで何があってもポジティブな性格。スタイルもよく人目を引く可愛さだが、よく転ぶ、ダンスを間違えるなどのドジな一面も併せ持つ。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50016"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mitsumine_Yuika">
@@ -185,6 +190,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">自由奔放で掴みどころのないサブカル系眼鏡女子。美人でノリもよく、初対面の人に対しても気後れせずに話しができる。大学1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50021"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shirase_Sakuya">
@@ -219,6 +225,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">女子校に通い、スポーツ万能、学業優秀、容姿端麗なモデル系美人。立ち居振舞いも王子様のようにかっこよく、女子からの人気が高い。高校3年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50012"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tanaka_Mamimi">
@@ -254,6 +261,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">ダウナー系で、面倒なことが嫌いなパンキッシュガール。顔もスタイルも抜群の美少女だが、自分の興味を持ったこと以外には無頓着な性格。高校3年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50015"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yukoku_Kiriko">
@@ -292,6 +300,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">ミステリアスな雰囲気を醸し出す銀髪の女の子。儚げな雰囲気とぐるぐると巻いた包帯が特徴的。口数は少ないが、心優しい性格。高校2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50023"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kuwayama_Chiyuki">
@@ -327,6 +336,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">優しい笑顔が印象的な、事務所のお姉さん的存在。母性溢れる落ち着いた佇まいが特徴。手先が器用で、かわいい小物を作るのが趣味。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50008"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Osaki_Tenka">
@@ -364,6 +374,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">大崎姉妹の双子の姉。幼い頃から妹の甘奈に面倒を見てもらっている。人と話すのが苦手で、アニメやゲームなど、インドアな趣味が多い。高校2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50006"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Osaki_Amana">
@@ -401,6 +412,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">大崎姉妹の双子の妹。誰とでも分け隔てなく接する天真爛漫なギャル。今しかできないことを全力で楽しみたい今ドキの女の子。高校2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50005"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Komiya_Kaho">
@@ -436,6 +448,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">大人びた容姿と高い身長が特徴の女の子。何にでも興味津々で純粋な様子は、まるで子犬のよう。特撮モノが大好きでヒーローに憧れている。小学6年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50009"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Saijo_Juri">
@@ -472,6 +485,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">ボーイッシュでクールな女の子。言葉遣いが乱暴なので人に怖がられることが多いが、根は純情で、素直になれないタイプ。高校2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50010"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Arisugawa_Natsuha">
@@ -507,6 +521,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">裕福な家庭に生まれた社長令嬢。家名に誇りを持ち、自らもその肩書に恥じぬよう日々鍛錬を積んでいる。スタイルがよく、引き締まっている。大学2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50002"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Morino_Rinze">
@@ -543,6 +558,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">落ち着いた佇まいの大和撫子。常に礼儀正しく、一歩引いて相手を立てる性格。少女漫画好きという意外な趣味を持つ。高校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50022"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sonoda_Chiyoko">
@@ -577,6 +593,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">クラスに一人はいるごく普通の女の子。明るく親しみやすい性格で、甘いものが大好き。名前にちなんで、チョコ好きアイドルを売りにしている。高校2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50014"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mayuzumi_Fuyuko">
@@ -611,6 +628,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">常に控えめな笑顔で、清楚に見える女の子。可愛いものが大好きで、周囲への気配りをするなど人に好かれるように振る舞う。専門学校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50020"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Serizawa_Asahi">
@@ -646,6 +664,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">常に面白いことを探し、じっとしていることがない、探究心の強い女の子。興味を持ったら一直線だが、飽きっぽい一面も持つ中学2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50013"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Izumi_Mei">
@@ -681,6 +700,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">ノリがよく、楽天的で大雑把な性格の女の子。難しいことを考えるのは苦手だが、親しみやすい高校3年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50003"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Asakura_Toru">
@@ -715,6 +735,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">自然体で飾らない性格。周囲からどう見られるかということを気にせず、おおらかでマイペース。しかしその透明感あふれる佇まいには誰をも惹きつけるオーラがある。高校2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50001"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Higuchi_Madoka">
@@ -749,6 +770,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">クールでシニカルな高校2年生。涼しげな目元と泣きぼくろが特徴。プロデューサーに冷たい態度を取る。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50018"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Fukumaru_Koito">
@@ -783,6 +805,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">内弁慶な小動物系の女の子。真面目な努力家で、勉強が得意。騙されやすく、幼なじみによくからかわれている。高校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50019"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ichikawa_Hinana">
@@ -817,5 +840,6 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">自分の「しあわせ」に向かって突き進む、奔放な女の子。幼馴染みで先輩の透を慕っている。高校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50004"/>
   </rdf:Description>
 </rdf:RDF>

--- a/RDFs/283.rdf
+++ b/RDFs/283.rdf
@@ -41,7 +41,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">ほんわかした癒し系の女の子で、心優しい性格。見ていて守りたくなるタイプで、一緒にいるだけで何となく幸せな気持ちになる。高校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50011"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/50011"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hachimiya_Meguru">
@@ -77,7 +77,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">天真爛漫な性格で、誰にでも積極的に話しかける。とにかく元気で友達想いの女の子。日本人の父とアメリカ人の母を持つ。高校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50017"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/50017"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kazano_Hiori">
@@ -115,7 +115,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">後ろでまとめた黒髪が印象的な、クール系美少女。自分が納得するまで努力を欠かさないストイックな性格の持ち主。高校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50007"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/50007"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tsukioka_Kogane">
@@ -150,7 +150,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">自信たっぷりで何があってもポジティブな性格。スタイルもよく人目を引く可愛さだが、よく転ぶ、ダンスを間違えるなどのドジな一面も併せ持つ。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50016"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/50016"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mitsumine_Yuika">
@@ -190,7 +190,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">自由奔放で掴みどころのないサブカル系眼鏡女子。美人でノリもよく、初対面の人に対しても気後れせずに話しができる。大学1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50021"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/50021"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shirase_Sakuya">
@@ -225,7 +225,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">女子校に通い、スポーツ万能、学業優秀、容姿端麗なモデル系美人。立ち居振舞いも王子様のようにかっこよく、女子からの人気が高い。高校3年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50012"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/50012"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tanaka_Mamimi">
@@ -261,7 +261,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">ダウナー系で、面倒なことが嫌いなパンキッシュガール。顔もスタイルも抜群の美少女だが、自分の興味を持ったこと以外には無頓着な性格。高校3年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50015"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/50015"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yukoku_Kiriko">
@@ -300,7 +300,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">ミステリアスな雰囲気を醸し出す銀髪の女の子。儚げな雰囲気とぐるぐると巻いた包帯が特徴的。口数は少ないが、心優しい性格。高校2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50023"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/50023"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kuwayama_Chiyuki">
@@ -336,7 +336,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">優しい笑顔が印象的な、事務所のお姉さん的存在。母性溢れる落ち着いた佇まいが特徴。手先が器用で、かわいい小物を作るのが趣味。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50008"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/50008"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Osaki_Tenka">
@@ -374,7 +374,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">大崎姉妹の双子の姉。幼い頃から妹の甘奈に面倒を見てもらっている。人と話すのが苦手で、アニメやゲームなど、インドアな趣味が多い。高校2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50006"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/50006"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Osaki_Amana">
@@ -412,7 +412,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">大崎姉妹の双子の妹。誰とでも分け隔てなく接する天真爛漫なギャル。今しかできないことを全力で楽しみたい今ドキの女の子。高校2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50005"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/50005"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Komiya_Kaho">
@@ -448,7 +448,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">大人びた容姿と高い身長が特徴の女の子。何にでも興味津々で純粋な様子は、まるで子犬のよう。特撮モノが大好きでヒーローに憧れている。小学6年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50009"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/50009"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Saijo_Juri">
@@ -485,7 +485,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">ボーイッシュでクールな女の子。言葉遣いが乱暴なので人に怖がられることが多いが、根は純情で、素直になれないタイプ。高校2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50010"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/50010"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Arisugawa_Natsuha">
@@ -521,7 +521,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">裕福な家庭に生まれた社長令嬢。家名に誇りを持ち、自らもその肩書に恥じぬよう日々鍛錬を積んでいる。スタイルがよく、引き締まっている。大学2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50002"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/50002"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Morino_Rinze">
@@ -558,7 +558,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">落ち着いた佇まいの大和撫子。常に礼儀正しく、一歩引いて相手を立てる性格。少女漫画好きという意外な趣味を持つ。高校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50022"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/50022"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sonoda_Chiyoko">
@@ -593,7 +593,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">クラスに一人はいるごく普通の女の子。明るく親しみやすい性格で、甘いものが大好き。名前にちなんで、チョコ好きアイドルを売りにしている。高校2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50014"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/50014"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mayuzumi_Fuyuko">
@@ -628,7 +628,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">常に控えめな笑顔で、清楚に見える女の子。可愛いものが大好きで、周囲への気配りをするなど人に好かれるように振る舞う。専門学校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50020"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/50020"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Serizawa_Asahi">
@@ -664,7 +664,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">常に面白いことを探し、じっとしていることがない、探究心の強い女の子。興味を持ったら一直線だが、飽きっぽい一面も持つ中学2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50013"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/50013"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Izumi_Mei">
@@ -700,7 +700,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">ノリがよく、楽天的で大雑把な性格の女の子。難しいことを考えるのは苦手だが、親しみやすい高校3年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50003"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/50003"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Asakura_Toru">
@@ -735,7 +735,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">自然体で飾らない性格。周囲からどう見られるかということを気にせず、おおらかでマイペース。しかしその透明感あふれる佇まいには誰をも惹きつけるオーラがある。高校2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50001"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/50001"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Higuchi_Madoka">
@@ -770,7 +770,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">クールでシニカルな高校2年生。涼しげな目元と泣きぼくろが特徴。プロデューサーに冷たい態度を取る。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50018"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/50018"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Fukumaru_Koito">
@@ -805,7 +805,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">内弁慶な小動物系の女の子。真面目な努力家で、勉強が得意。騙されやすく、幼なじみによくからかわれている。高校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50019"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/50019"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ichikawa_Hinana">
@@ -840,6 +840,6 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">自分の「しあわせ」に向かって突き進む、奔放な女の子。幼馴染みで先輩の透を慕っている。高校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50004"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/50004"/>
   </rdf:Description>
 </rdf:RDF>

--- a/RDFs/283.rdf
+++ b/RDFs/283.rdf
@@ -41,7 +41,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">ほんわかした癒し系の女の子で、心優しい性格。見ていて守りたくなるタイプで、一緒にいるだけで何となく幸せな気持ちになる。高校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50011"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50011"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hachimiya_Meguru">
@@ -77,7 +77,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">天真爛漫な性格で、誰にでも積極的に話しかける。とにかく元気で友達想いの女の子。日本人の父とアメリカ人の母を持つ。高校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50017"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50017"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kazano_Hiori">
@@ -115,7 +115,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">後ろでまとめた黒髪が印象的な、クール系美少女。自分が納得するまで努力を欠かさないストイックな性格の持ち主。高校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50007"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50007"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tsukioka_Kogane">
@@ -150,7 +150,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">自信たっぷりで何があってもポジティブな性格。スタイルもよく人目を引く可愛さだが、よく転ぶ、ダンスを間違えるなどのドジな一面も併せ持つ。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50016"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50016"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mitsumine_Yuika">
@@ -190,7 +190,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">自由奔放で掴みどころのないサブカル系眼鏡女子。美人でノリもよく、初対面の人に対しても気後れせずに話しができる。大学1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50021"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50021"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shirase_Sakuya">
@@ -225,7 +225,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">女子校に通い、スポーツ万能、学業優秀、容姿端麗なモデル系美人。立ち居振舞いも王子様のようにかっこよく、女子からの人気が高い。高校3年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50012"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50012"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tanaka_Mamimi">
@@ -261,7 +261,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">ダウナー系で、面倒なことが嫌いなパンキッシュガール。顔もスタイルも抜群の美少女だが、自分の興味を持ったこと以外には無頓着な性格。高校3年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50015"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50015"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yukoku_Kiriko">
@@ -300,7 +300,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">ミステリアスな雰囲気を醸し出す銀髪の女の子。儚げな雰囲気とぐるぐると巻いた包帯が特徴的。口数は少ないが、心優しい性格。高校2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50023"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50023"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kuwayama_Chiyuki">
@@ -336,7 +336,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">優しい笑顔が印象的な、事務所のお姉さん的存在。母性溢れる落ち着いた佇まいが特徴。手先が器用で、かわいい小物を作るのが趣味。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50008"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50008"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Osaki_Tenka">
@@ -374,7 +374,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">大崎姉妹の双子の姉。幼い頃から妹の甘奈に面倒を見てもらっている。人と話すのが苦手で、アニメやゲームなど、インドアな趣味が多い。高校2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50006"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50006"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Osaki_Amana">
@@ -412,7 +412,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">大崎姉妹の双子の妹。誰とでも分け隔てなく接する天真爛漫なギャル。今しかできないことを全力で楽しみたい今ドキの女の子。高校2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50005"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50005"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Komiya_Kaho">
@@ -448,7 +448,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">大人びた容姿と高い身長が特徴の女の子。何にでも興味津々で純粋な様子は、まるで子犬のよう。特撮モノが大好きでヒーローに憧れている。小学6年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50009"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50009"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Saijo_Juri">
@@ -485,7 +485,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">ボーイッシュでクールな女の子。言葉遣いが乱暴なので人に怖がられることが多いが、根は純情で、素直になれないタイプ。高校2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50010"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50010"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Arisugawa_Natsuha">
@@ -521,7 +521,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">裕福な家庭に生まれた社長令嬢。家名に誇りを持ち、自らもその肩書に恥じぬよう日々鍛錬を積んでいる。スタイルがよく、引き締まっている。大学2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50002"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50002"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Morino_Rinze">
@@ -558,7 +558,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">落ち着いた佇まいの大和撫子。常に礼儀正しく、一歩引いて相手を立てる性格。少女漫画好きという意外な趣味を持つ。高校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50022"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50022"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sonoda_Chiyoko">
@@ -593,7 +593,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">クラスに一人はいるごく普通の女の子。明るく親しみやすい性格で、甘いものが大好き。名前にちなんで、チョコ好きアイドルを売りにしている。高校2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50014"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50014"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mayuzumi_Fuyuko">
@@ -628,7 +628,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">常に控えめな笑顔で、清楚に見える女の子。可愛いものが大好きで、周囲への気配りをするなど人に好かれるように振る舞う。専門学校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50020"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50020"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Serizawa_Asahi">
@@ -664,7 +664,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">常に面白いことを探し、じっとしていることがない、探究心の強い女の子。興味を持ったら一直線だが、飽きっぽい一面も持つ中学2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50013"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50013"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Izumi_Mei">
@@ -700,7 +700,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">ノリがよく、楽天的で大雑把な性格の女の子。難しいことを考えるのは苦手だが、親しみやすい高校3年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50003"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50003"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Asakura_Toru">
@@ -735,7 +735,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">自然体で飾らない性格。周囲からどう見られるかということを気にせず、おおらかでマイペース。しかしその透明感あふれる佇まいには誰をも惹きつけるオーラがある。高校2年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50001"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50001"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Higuchi_Madoka">
@@ -770,7 +770,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">クールでシニカルな高校2年生。涼しげな目元と泣きぼくろが特徴。プロデューサーに冷たい態度を取る。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50018"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50018"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Fukumaru_Koito">
@@ -805,7 +805,7 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">内弁慶な小動物系の女の子。真面目な努力家で、勉強が得意。騙されやすく、幼なじみによくからかわれている。高校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50019"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50019"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ichikawa_Hinana">
@@ -840,6 +840,6 @@
     <imas:Title xml:lang="en">283Pro</imas:Title>
     <schema:description xml:lang="ja">自分の「しあわせ」に向かって突き進む、奔放な女の子。幼馴染みで先輩の透を慕っている。高校1年生。</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50004"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/50004"/>
   </rdf:Description>
 </rdf:RDF>

--- a/RDFs/765AS.rdf
+++ b/RDFs/765AS.rdf
@@ -4,6 +4,7 @@
     xmlns:foaf="http://xmlns.com/foaf/0.1/"
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xmlns:imas="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
     xml:base="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/"
     >
 
@@ -43,6 +44,7 @@
     <imas:Division xml:lang="en">Princess</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cu</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10002"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kisaragi_Chihaya">
@@ -80,6 +82,7 @@
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Co</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10005"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hoshii_Miki">
@@ -119,6 +122,7 @@
     <imas:Division xml:lang="en">Angel</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pa</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10011"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hagiwara_Yukiho">
@@ -156,6 +160,7 @@
     <imas:Division xml:lang="en">Princess</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pa</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10008"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takatsuki_Yayoi">
@@ -195,6 +200,7 @@
     <imas:Division xml:lang="en">Angel</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cu</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10007"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kikuchi_Makoto">
@@ -233,6 +239,7 @@
     <imas:Division xml:lang="en">Princess</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cu</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10004"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Minase_Iori">
@@ -271,6 +278,7 @@
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pa</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10013"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shijou_Takane">
@@ -309,6 +317,7 @@
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Co</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10006"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akizuki_Ritsuko">
@@ -347,6 +356,7 @@
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Co</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10001"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Miura_Azusa">
@@ -384,6 +394,7 @@
     <imas:Division xml:lang="en">Angel</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Co</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10012"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Futami_Ami">
@@ -422,6 +433,7 @@
     <imas:Division xml:lang="en">Angel</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pa</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10009"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Futami_Mami">
@@ -460,6 +472,7 @@
     <imas:Division xml:lang="en">Angel</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pa</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10010"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ganaha_Hibiki">
@@ -499,5 +512,6 @@
     <imas:Division xml:lang="en">Princess</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cu</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10003"/>
   </rdf:Description>
 </rdf:RDF>

--- a/RDFs/765AS.rdf
+++ b/RDFs/765AS.rdf
@@ -44,7 +44,7 @@
     <imas:Division xml:lang="en">Princess</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cu</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10002"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10002"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kisaragi_Chihaya">
@@ -82,7 +82,7 @@
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Co</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10005"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10005"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hoshii_Miki">
@@ -122,7 +122,7 @@
     <imas:Division xml:lang="en">Angel</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pa</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10011"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10011"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hagiwara_Yukiho">
@@ -160,7 +160,7 @@
     <imas:Division xml:lang="en">Princess</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pa</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10008"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10008"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takatsuki_Yayoi">
@@ -200,7 +200,7 @@
     <imas:Division xml:lang="en">Angel</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cu</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10007"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10007"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kikuchi_Makoto">
@@ -239,7 +239,7 @@
     <imas:Division xml:lang="en">Princess</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cu</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10004"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10004"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Minase_Iori">
@@ -278,7 +278,7 @@
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pa</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10013"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10013"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shijou_Takane">
@@ -317,7 +317,7 @@
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Co</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10006"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10006"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akizuki_Ritsuko">
@@ -356,7 +356,7 @@
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Co</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10001"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10001"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Miura_Azusa">
@@ -394,7 +394,7 @@
     <imas:Division xml:lang="en">Angel</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Co</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10012"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10012"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Futami_Ami">
@@ -433,7 +433,7 @@
     <imas:Division xml:lang="en">Angel</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pa</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10009"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10009"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Futami_Mami">
@@ -472,7 +472,7 @@
     <imas:Division xml:lang="en">Angel</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pa</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10010"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10010"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ganaha_Hibiki">
@@ -512,6 +512,6 @@
     <imas:Division xml:lang="en">Princess</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cu</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10003"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/10003"/>
   </rdf:Description>
 </rdf:RDF>

--- a/RDFs/765AS.rdf
+++ b/RDFs/765AS.rdf
@@ -44,7 +44,7 @@
     <imas:Division xml:lang="en">Princess</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cu</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10002"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10002"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kisaragi_Chihaya">
@@ -82,7 +82,7 @@
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Co</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10005"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10005"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hoshii_Miki">
@@ -122,7 +122,7 @@
     <imas:Division xml:lang="en">Angel</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pa</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10011"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10011"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hagiwara_Yukiho">
@@ -160,7 +160,7 @@
     <imas:Division xml:lang="en">Princess</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pa</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10008"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10008"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takatsuki_Yayoi">
@@ -200,7 +200,7 @@
     <imas:Division xml:lang="en">Angel</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cu</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10007"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10007"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kikuchi_Makoto">
@@ -239,7 +239,7 @@
     <imas:Division xml:lang="en">Princess</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cu</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10004"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10004"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Minase_Iori">
@@ -278,7 +278,7 @@
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pa</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10013"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10013"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shijou_Takane">
@@ -317,7 +317,7 @@
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Co</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10006"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10006"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akizuki_Ritsuko">
@@ -356,7 +356,7 @@
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Co</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10001"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10001"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Miura_Azusa">
@@ -394,7 +394,7 @@
     <imas:Division xml:lang="en">Angel</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Co</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10012"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10012"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Futami_Ami">
@@ -433,7 +433,7 @@
     <imas:Division xml:lang="en">Angel</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pa</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10009"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10009"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Futami_Mami">
@@ -472,7 +472,7 @@
     <imas:Division xml:lang="en">Angel</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pa</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10010"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10010"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ganaha_Hibiki">
@@ -512,6 +512,6 @@
     <imas:Division xml:lang="en">Princess</imas:Division>
     <imas:Type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cu</imas:Type>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10003"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/10003"/>
   </rdf:Description>
 </rdf:RDF>

--- a/RDFs/765MillionStars.rdf
+++ b/RDFs/765MillionStars.rdf
@@ -4,6 +4,7 @@
     xmlns:foaf="http://xmlns.com/foaf/0.1/"
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xmlns:imas="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
     xml:base="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/"
   >
 
@@ -41,6 +42,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30004"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mogami_Shizuka">
@@ -77,6 +79,7 @@
     <schema:birthPlace xml:lang="ja">埼玉</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30034"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ibuki_Tsubasa">
@@ -113,6 +116,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30001"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tanaka_Kotoha">
@@ -149,6 +153,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30017"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shimabara_Elena">
@@ -185,6 +190,7 @@
     <schema:birthPlace xml:lang="ja">ブラジル</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30012"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Satake_Minako">
@@ -221,6 +227,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30010"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tokoro_Megumi">
@@ -257,6 +264,7 @@
     <schema:birthPlace xml:lang="ja">埼玉</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30020"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tokugawa_Matsuri">
@@ -294,6 +302,7 @@
     <schema:birthPlace xml:lang="ja">愛知</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30019"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hakozaki_Serika">
@@ -331,6 +340,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30027"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nonohara_Akane">
@@ -367,6 +377,7 @@
     <schema:birthPlace xml:lang="ja">埼玉</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30026"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mochizuki_Anna">
@@ -403,6 +414,7 @@
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30035"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Handa_Roco">
@@ -442,6 +454,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30039"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nanao_Yuriko">
@@ -478,6 +491,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30024"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takayama_Sayoko">
@@ -515,6 +529,7 @@
     <schema:birthPlace xml:lang="ja">茨城</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30016"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Matsuda_Arisa">
@@ -551,6 +566,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30032"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kousaka_Umi">
@@ -587,6 +603,7 @@
     <schema:birthPlace xml:lang="ja">千葉</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30008"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nakatani_Iku">
@@ -623,6 +640,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30022"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tenkubashi_Tomoka">
@@ -659,6 +677,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30018"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Emily_Stewart">
@@ -695,6 +714,7 @@
     <schema:birthPlace xml:lang="ja">イギリス</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30002"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kitazawa_Shiho">
@@ -732,6 +752,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30006"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Maihama_Ayumu">
@@ -768,6 +789,7 @@
     <schema:birthPlace xml:lang="ja">愛媛</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30030"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kinoshita_Hinata">
@@ -804,6 +826,7 @@
     <schema:birthPlace xml:lang="ja">北海道</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30007"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yabuki_Kana">
@@ -840,6 +863,7 @@
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30037"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yokoyama_Nao">
@@ -876,6 +900,7 @@
     <schema:birthPlace xml:lang="ja">大阪</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30038"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nikaido_Chizuru">
@@ -912,6 +937,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30025"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Baba_Konomi">
@@ -948,6 +974,7 @@
     <schema:birthPlace xml:lang="ja">山口</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30028"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ogami_Tamaki">
@@ -984,6 +1011,7 @@
     <schema:birthPlace xml:lang="ja">香川</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30003"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Toyokawa_Fuka">
@@ -1020,6 +1048,7 @@
     <schema:birthPlace xml:lang="ja">千葉</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30021"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Miyao_Miya">
@@ -1057,6 +1086,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30033"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Fukuda_Noriko">
@@ -1093,6 +1123,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30029"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Makabe_Mizuki">
@@ -1129,6 +1160,7 @@
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30031"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shinomiya_Karen">
@@ -1165,6 +1197,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30011"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Momose_Rio">
@@ -1201,6 +1234,7 @@
     <schema:birthPlace xml:lang="ja">広島</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30036"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nagayoshi_Subaru">
@@ -1237,6 +1271,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30023"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kitakami_Reika">
@@ -1273,6 +1308,7 @@
     <schema:birthPlace xml:lang="ja">長野</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30005"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Suou_Momoko">
@@ -1309,6 +1345,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30015"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Julia">
@@ -1339,6 +1376,7 @@
     <schema:birthPlace xml:lang="ja">福岡</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30013"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shiraishi_Tsumugi">
@@ -1377,6 +1415,7 @@
     <schema:birthPlace xml:lang="ja">石川</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30014"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sakuramori_Kaori">
@@ -1415,5 +1454,6 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30009"/>
   </rdf:Description>
 </rdf:RDF>

--- a/RDFs/765MillionStars.rdf
+++ b/RDFs/765MillionStars.rdf
@@ -42,7 +42,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30004"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30004"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mogami_Shizuka">
@@ -79,7 +79,7 @@
     <schema:birthPlace xml:lang="ja">埼玉</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30034"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30034"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ibuki_Tsubasa">
@@ -116,7 +116,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30001"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30001"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tanaka_Kotoha">
@@ -153,7 +153,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30017"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30017"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shimabara_Elena">
@@ -190,7 +190,7 @@
     <schema:birthPlace xml:lang="ja">ブラジル</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30012"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30012"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Satake_Minako">
@@ -227,7 +227,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30010"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30010"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tokoro_Megumi">
@@ -264,7 +264,7 @@
     <schema:birthPlace xml:lang="ja">埼玉</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30020"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30020"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tokugawa_Matsuri">
@@ -302,7 +302,7 @@
     <schema:birthPlace xml:lang="ja">愛知</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30019"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30019"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hakozaki_Serika">
@@ -340,7 +340,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30027"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30027"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nonohara_Akane">
@@ -377,7 +377,7 @@
     <schema:birthPlace xml:lang="ja">埼玉</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30026"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30026"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mochizuki_Anna">
@@ -414,7 +414,7 @@
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30035"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30035"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Handa_Roco">
@@ -454,7 +454,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30039"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30039"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nanao_Yuriko">
@@ -491,7 +491,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30024"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30024"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takayama_Sayoko">
@@ -529,7 +529,7 @@
     <schema:birthPlace xml:lang="ja">茨城</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30016"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30016"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Matsuda_Arisa">
@@ -566,7 +566,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30032"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30032"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kousaka_Umi">
@@ -603,7 +603,7 @@
     <schema:birthPlace xml:lang="ja">千葉</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30008"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30008"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nakatani_Iku">
@@ -640,7 +640,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30022"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30022"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tenkubashi_Tomoka">
@@ -677,7 +677,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30018"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30018"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Emily_Stewart">
@@ -714,7 +714,7 @@
     <schema:birthPlace xml:lang="ja">イギリス</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30002"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30002"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kitazawa_Shiho">
@@ -752,7 +752,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30006"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30006"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Maihama_Ayumu">
@@ -789,7 +789,7 @@
     <schema:birthPlace xml:lang="ja">愛媛</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30030"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30030"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kinoshita_Hinata">
@@ -826,7 +826,7 @@
     <schema:birthPlace xml:lang="ja">北海道</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30007"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30007"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yabuki_Kana">
@@ -863,7 +863,7 @@
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30037"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30037"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yokoyama_Nao">
@@ -900,7 +900,7 @@
     <schema:birthPlace xml:lang="ja">大阪</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30038"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30038"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nikaido_Chizuru">
@@ -937,7 +937,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30025"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30025"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Baba_Konomi">
@@ -974,7 +974,7 @@
     <schema:birthPlace xml:lang="ja">山口</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30028"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30028"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ogami_Tamaki">
@@ -1011,7 +1011,7 @@
     <schema:birthPlace xml:lang="ja">香川</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30003"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30003"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Toyokawa_Fuka">
@@ -1048,7 +1048,7 @@
     <schema:birthPlace xml:lang="ja">千葉</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30021"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30021"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Miyao_Miya">
@@ -1086,7 +1086,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30033"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30033"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Fukuda_Noriko">
@@ -1123,7 +1123,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30029"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30029"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Makabe_Mizuki">
@@ -1160,7 +1160,7 @@
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30031"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30031"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shinomiya_Karen">
@@ -1197,7 +1197,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30011"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30011"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Momose_Rio">
@@ -1234,7 +1234,7 @@
     <schema:birthPlace xml:lang="ja">広島</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30036"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30036"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nagayoshi_Subaru">
@@ -1271,7 +1271,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30023"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30023"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kitakami_Reika">
@@ -1308,7 +1308,7 @@
     <schema:birthPlace xml:lang="ja">長野</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30005"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30005"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Suou_Momoko">
@@ -1345,7 +1345,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30015"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30015"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Julia">
@@ -1376,7 +1376,7 @@
     <schema:birthPlace xml:lang="ja">福岡</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30013"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30013"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shiraishi_Tsumugi">
@@ -1415,7 +1415,7 @@
     <schema:birthPlace xml:lang="ja">石川</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30014"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30014"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sakuramori_Kaori">
@@ -1454,6 +1454,6 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30009"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/30009"/>
   </rdf:Description>
 </rdf:RDF>

--- a/RDFs/765MillionStars.rdf
+++ b/RDFs/765MillionStars.rdf
@@ -42,7 +42,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30004"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30004"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mogami_Shizuka">
@@ -79,7 +79,7 @@
     <schema:birthPlace xml:lang="ja">埼玉</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30034"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30034"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ibuki_Tsubasa">
@@ -116,7 +116,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30001"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30001"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tanaka_Kotoha">
@@ -153,7 +153,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30017"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30017"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shimabara_Elena">
@@ -190,7 +190,7 @@
     <schema:birthPlace xml:lang="ja">ブラジル</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30012"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30012"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Satake_Minako">
@@ -227,7 +227,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30010"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30010"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tokoro_Megumi">
@@ -264,7 +264,7 @@
     <schema:birthPlace xml:lang="ja">埼玉</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30020"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30020"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tokugawa_Matsuri">
@@ -302,7 +302,7 @@
     <schema:birthPlace xml:lang="ja">愛知</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30019"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30019"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hakozaki_Serika">
@@ -340,7 +340,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30027"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30027"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nonohara_Akane">
@@ -377,7 +377,7 @@
     <schema:birthPlace xml:lang="ja">埼玉</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30026"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30026"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mochizuki_Anna">
@@ -414,7 +414,7 @@
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30035"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30035"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Handa_Roco">
@@ -454,7 +454,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30039"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30039"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nanao_Yuriko">
@@ -491,7 +491,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30024"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30024"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takayama_Sayoko">
@@ -529,7 +529,7 @@
     <schema:birthPlace xml:lang="ja">茨城</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30016"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30016"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Matsuda_Arisa">
@@ -566,7 +566,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30032"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30032"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kousaka_Umi">
@@ -603,7 +603,7 @@
     <schema:birthPlace xml:lang="ja">千葉</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30008"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30008"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nakatani_Iku">
@@ -640,7 +640,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30022"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30022"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tenkubashi_Tomoka">
@@ -677,7 +677,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30018"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30018"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Emily_Stewart">
@@ -714,7 +714,7 @@
     <schema:birthPlace xml:lang="ja">イギリス</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30002"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30002"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kitazawa_Shiho">
@@ -752,7 +752,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30006"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30006"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Maihama_Ayumu">
@@ -789,7 +789,7 @@
     <schema:birthPlace xml:lang="ja">愛媛</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30030"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30030"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kinoshita_Hinata">
@@ -826,7 +826,7 @@
     <schema:birthPlace xml:lang="ja">北海道</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30007"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30007"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yabuki_Kana">
@@ -863,7 +863,7 @@
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30037"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30037"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yokoyama_Nao">
@@ -900,7 +900,7 @@
     <schema:birthPlace xml:lang="ja">大阪</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30038"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30038"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nikaido_Chizuru">
@@ -937,7 +937,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30025"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30025"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Baba_Konomi">
@@ -974,7 +974,7 @@
     <schema:birthPlace xml:lang="ja">山口</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30028"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30028"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ogami_Tamaki">
@@ -1011,7 +1011,7 @@
     <schema:birthPlace xml:lang="ja">香川</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30003"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30003"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Toyokawa_Fuka">
@@ -1048,7 +1048,7 @@
     <schema:birthPlace xml:lang="ja">千葉</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30021"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30021"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Miyao_Miya">
@@ -1086,7 +1086,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30033"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30033"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Fukuda_Noriko">
@@ -1123,7 +1123,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30029"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30029"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Makabe_Mizuki">
@@ -1160,7 +1160,7 @@
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30031"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30031"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shinomiya_Karen">
@@ -1197,7 +1197,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30011"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30011"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Momose_Rio">
@@ -1234,7 +1234,7 @@
     <schema:birthPlace xml:lang="ja">広島</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30036"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30036"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nagayoshi_Subaru">
@@ -1271,7 +1271,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30023"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30023"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kitakami_Reika">
@@ -1308,7 +1308,7 @@
     <schema:birthPlace xml:lang="ja">長野</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30005"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30005"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Suou_Momoko">
@@ -1345,7 +1345,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30015"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30015"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Julia">
@@ -1376,7 +1376,7 @@
     <schema:birthPlace xml:lang="ja">福岡</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30013"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30013"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shiraishi_Tsumugi">
@@ -1415,7 +1415,7 @@
     <schema:birthPlace xml:lang="ja">石川</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30014"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30014"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sakuramori_Kaori">
@@ -1454,6 +1454,6 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30009"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/30009"/>
   </rdf:Description>
 </rdf:RDF>

--- a/RDFs/876.rdf
+++ b/RDFs/876.rdf
@@ -4,6 +4,7 @@
     xmlns:foaf="http://xmlns.com/foaf/0.1/"
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xmlns:imas="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
     xml:base="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/"
     >
 
@@ -37,6 +38,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">DearlyStars</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/210001"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mizutani_Eri">
@@ -69,6 +71,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">DearlyStars</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/210002"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akizuki_Ryo_876">
@@ -101,6 +104,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">DearlyStars</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40004"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sakurai_Yumeko">

--- a/RDFs/876.rdf
+++ b/RDFs/876.rdf
@@ -38,7 +38,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">DearlyStars</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/210001"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/210001"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mizutani_Eri">
@@ -71,7 +71,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">DearlyStars</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/210002"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/210002"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akizuki_Ryo_876">
@@ -104,7 +104,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">DearlyStars</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40004"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40004"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sakurai_Yumeko">

--- a/RDFs/876.rdf
+++ b/RDFs/876.rdf
@@ -38,7 +38,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">DearlyStars</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/210001"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/210001"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mizutani_Eri">
@@ -71,7 +71,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">DearlyStars</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/210002"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/210002"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akizuki_Ryo_876">
@@ -104,7 +104,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">DearlyStars</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40004"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40004"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sakurai_Yumeko">

--- a/RDFs/961.rdf
+++ b/RDFs/961.rdf
@@ -21,7 +21,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">961ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/220001"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/220001"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shika">
@@ -50,6 +50,6 @@
     <imas:Title xml:lang="en">961ProIdols</imas:Title>
     <schema:birthPlace xml:lang="ja">オーストリア</schema:birthPlace>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/230001"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/230001"/>
   </rdf:Description>
 </rdf:RDF>

--- a/RDFs/961.rdf
+++ b/RDFs/961.rdf
@@ -21,7 +21,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">961ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/220001"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/220001"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shika">
@@ -50,6 +50,6 @@
     <imas:Title xml:lang="en">961ProIdols</imas:Title>
     <schema:birthPlace xml:lang="ja">オーストリア</schema:birthPlace>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/230001"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/230001"/>
   </rdf:Description>
 </rdf:RDF>

--- a/RDFs/961.rdf
+++ b/RDFs/961.rdf
@@ -4,6 +4,7 @@
     xmlns:foaf="http://xmlns.com/foaf/0.1/"
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xmlns:imas="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
     xml:base="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/"
     >
 
@@ -20,6 +21,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Title xml:lang="en">961ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/220001"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shika">
@@ -48,5 +50,6 @@
     <imas:Title xml:lang="en">961ProIdols</imas:Title>
     <schema:birthPlace xml:lang="ja">オーストリア</schema:birthPlace>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/230001"/>
   </rdf:Description>
 </rdf:RDF>

--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -40,7 +40,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EC7092</imas:Color>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Hobby xml:lang="ja">友達と長電話</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20084"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20084"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nakano_Yuka">
@@ -74,7 +74,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17159583"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">CB78B0</imas:Color>
     <imas:Hobby xml:lang="ja">空手</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20112"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20112"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mizumoto_Yukari">
@@ -108,7 +108,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17211589"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E8BAD6</imas:Color>
     <imas:Hobby xml:lang="ja">フルート</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20159"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20159"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Fukuyama_Mai">
@@ -138,7 +138,7 @@
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">兵庫</schema:birthPlace>
     <imas:Hobby xml:lang="ja">一輪車</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20136"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20136"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shiina_Noriko">
@@ -172,7 +172,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17161754"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EA495B</imas:Color>
     <imas:Hobby xml:lang="ja">新作ドーナツの試食</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20080"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20080"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Imai_Kana">
@@ -202,7 +202,7 @@
     <imas:Constellation xml:lang="ja">魚座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">高知</schema:birthPlace>
     <imas:Hobby xml:lang="ja">友達とおしゃべり</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20021"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20021"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mochida_Arisa">
@@ -232,7 +232,7 @@
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">長野</schema:birthPlace>
     <imas:Hobby xml:lang="ja">子供と遊ぶこと</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20169"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20169"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mimura_Kanako">
@@ -266,7 +266,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q3211762"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F4ABB4</imas:Color>
     <imas:Hobby xml:lang="ja">お菓子作り</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20161"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20161"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Okuyama_Saori">
@@ -296,7 +296,7 @@
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">秋田</schema:birthPlace>
     <imas:Hobby xml:lang="ja">読書</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20038"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20038"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Manaka_Misato">
@@ -326,7 +326,7 @@
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">旅行</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20155"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20155"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kohinata_Miho">
@@ -360,7 +360,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q901835"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">C64796</imas:Color>
     <imas:Hobby xml:lang="ja">ひなたぼっこ</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20065"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20065"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ogata_Chieri">
@@ -394,7 +394,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q15731362"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">69B64C</imas:Color>
     <imas:Hobby xml:lang="ja">四葉のクローバー集め</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20037"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20037"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Igarashi_Kyoko">
@@ -428,7 +428,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q3183413"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F567C6</imas:Color>
     <imas:Hobby xml:lang="ja">家事全般</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20016"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20016"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yanase_Miyuki">
@@ -458,7 +458,7 @@
     <imas:Constellation xml:lang="ja">魚座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">北海道</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ぬいぐるみ集め</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20178"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20178"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sakurai_Momoka">
@@ -492,7 +492,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11567752"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EF93BC</imas:Color>
     <imas:Hobby xml:lang="ja">ティータイム</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20075"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20075"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Egami_Tsubaki">
@@ -522,7 +522,7 @@
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">新潟</schema:birthPlace>
     <imas:Hobby xml:lang="ja">写真を撮ること</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20026"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20026"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nagatomi_Hasumi">
@@ -553,7 +553,7 @@
     <schema:birthPlace xml:lang="ja">島根</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ボウリング</imas:Hobby>
     <imas:Hobby xml:lang="ja">古着屋巡り</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20111"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20111"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yokoyama_Chika">
@@ -583,7 +583,7 @@
     <imas:Constellation xml:lang="ja">射手座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">宮崎</schema:birthPlace>
     <imas:Hobby xml:lang="ja">魔法少女ごっこ</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20183"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20183"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Seki_Hiromi">
@@ -617,7 +617,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q41585491"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F8C5C1</imas:Color>
     <imas:Hobby xml:lang="ja">アクセサリー作り</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20094"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20094"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ohta_Yuu">
@@ -648,7 +648,7 @@
     <schema:birthPlace xml:lang="ja">千葉</schema:birthPlace>
     <imas:Hobby xml:lang="ja">犬のトリミング</imas:Hobby>
     <imas:Hobby xml:lang="ja">美容</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20031"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20031"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Munakata_Atsumi">
@@ -682,7 +682,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q56118632"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">C82F7F</imas:Color>
     <imas:Hobby xml:lang="ja">指の運動</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20165"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20165"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Fujimoto_Rina">
@@ -717,7 +717,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">653A2A</imas:Color>
     <imas:Hobby xml:lang="ja">単車乗り</imas:Hobby>
     <imas:Hobby xml:lang="ja">コンビニで立ち読み</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20138"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20138"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ohara_Michiru">
@@ -747,7 +747,7 @@
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">福井</schema:birthPlace>
     <imas:Hobby xml:lang="ja">食べること</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20035"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20035"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yusa_Kozue">
@@ -780,7 +780,7 @@
     <!-- <imas:cv rdf:resource="http://ja.dbpedia.org/page/花谷麻妃"/> -->
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q24873835"/>
     <imas:Hobby xml:lang="ja">しゅみってなぁに？</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20181"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20181"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ohnuma_Kurumi">
@@ -811,7 +811,7 @@
     <schema:birthPlace xml:lang="ja">石川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ポケットティッシュ収集</imas:Hobby>
     <imas:Hobby xml:lang="ja">お風呂に入ること</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20034"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20034"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ichinose_Shiki">
@@ -847,7 +847,7 @@
     <imas:Hobby xml:lang="ja">失踪</imas:Hobby>
     <imas:Hobby xml:lang="ja">アヤしい科学実験</imas:Hobby>
     <imas:Hobby xml:lang="ja">観察</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20019"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20019"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Maekawa_Miku">
@@ -881,7 +881,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1107456"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">CA113A</imas:Color>
     <imas:Hobby xml:lang="ja">猫カフェ巡り</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20147"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20147"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akanishi_Erika">
@@ -911,7 +911,7 @@
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">岡山</schema:birthPlace>
     <imas:Hobby xml:lang="ja">漫才鑑賞</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20006"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20006"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Matsubara_Saya">
@@ -941,7 +941,7 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">兵庫</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ブログ</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20151"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20151"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Aihara_Yukino">
@@ -971,7 +971,7 @@
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">秋田</schema:birthPlace>
     <imas:Hobby xml:lang="ja">紅茶</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20004"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20004"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Miyamoto_Frederica">
@@ -1005,7 +1005,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q62024404"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">9E1861</imas:Color>
     <imas:Hobby xml:lang="ja">ファッション</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20162"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20162"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kobayakawa_Sae">
@@ -1039,7 +1039,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q9046310"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D967A3</imas:Color>
     <imas:Hobby xml:lang="ja">日本舞踊</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20064"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20064"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Saionji_Kotoka">
@@ -1069,7 +1069,7 @@
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Hobby xml:lang="ja">押し花作り</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20068"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20068"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Futaba_Anzu">
@@ -1103,7 +1103,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q5770504"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F19DB4</imas:Color>
     <imas:Hobby xml:lang="ja">なし</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20140"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20140"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yao_Fueifuei">
@@ -1133,7 +1133,7 @@
     <imas:Constellation xml:lang="ja">天秤座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">香港</schema:birthPlace>
     <imas:Hobby xml:lang="ja">料理</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20174"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20174"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Momoi_Azuki">
@@ -1163,7 +1163,7 @@
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">長野</schema:birthPlace>
     <imas:Hobby xml:lang="ja">金魚すくい</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20171"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20171"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Suzumiya_Seika">
@@ -1193,7 +1193,7 @@
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">岐阜</schema:birthPlace>
     <imas:Hobby xml:lang="ja">バイオリン</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20092"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20092"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tsukimiya_Miyabi">
@@ -1223,7 +1223,7 @@
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ママとショッピング</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20105"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20105"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hyodo_Rena">
@@ -1253,7 +1253,7 @@
     <imas:Constellation xml:lang="ja">天秤座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Hobby xml:lang="ja">トランプ</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20135"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20135"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Niwa_Hitomi">
@@ -1284,7 +1284,7 @@
     <schema:birthPlace xml:lang="ja">名古屋</schema:birthPlace>
     <imas:Hobby xml:lang="ja">史跡巡り</imas:Hobby>
     <imas:Hobby xml:lang="ja">武将グッズ収集</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20122"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20122"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Domyoji_Karin">
@@ -1318,7 +1318,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17212219"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">CC252D</imas:Color>
     <imas:Hobby xml:lang="ja">境内のお掃除</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20109"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20109"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yanagi_Kiyora">
@@ -1348,7 +1348,7 @@
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">愛媛</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ドキュメンタリー番組鑑賞</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20177"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20177"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Imura_Setsuna">
@@ -1378,7 +1378,7 @@
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">秋田</schema:birthPlace>
     <imas:Hobby xml:lang="ja">メイク小物集め</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20022"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20022"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kusakabe_Wakaba">
@@ -1408,7 +1408,7 @@
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">群馬</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ジグソーパズル</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20054"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20054"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sakakibara_Satomi">
@@ -1438,7 +1438,7 @@
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">山形</schema:birthPlace>
     <imas:Hobby xml:lang="ja">甘いお菓子を食べること</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20072"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20072"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Koshimizu_Sachiko">
@@ -1472,7 +1472,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1204576"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">CCAACF</imas:Color>
     <imas:Hobby xml:lang="ja">勉強ノートの清書</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20062"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20062"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Anzai_Miyako">
@@ -1503,7 +1503,7 @@
     <schema:birthPlace xml:lang="ja">福井</schema:birthPlace>
     <imas:Hobby xml:lang="ja">探偵ドラマ</imas:Hobby>
     <imas:Hobby xml:lang="ja">推理小説を見ること</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20014"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20014"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Asano_Fuka">
@@ -1533,7 +1533,7 @@
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">滋賀</schema:birthPlace>
     <imas:Hobby xml:lang="ja">小説を書くこと</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20007"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20007"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ohnishi_Yuriko">
@@ -1564,7 +1564,7 @@
     <schema:birthPlace xml:lang="ja">香川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ネットサーフィン</imas:Hobby>
     <imas:Hobby xml:lang="ja">読書</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20033"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20033"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Abe_Nana">
@@ -1598,7 +1598,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q6127820"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E64A79</imas:Color>
     <imas:Hobby xml:lang="ja">ウサミン星との交信</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20010"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20010"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kudo_Shinobu">
@@ -1628,7 +1628,7 @@
     <imas:Constellation xml:lang="ja">魚座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">青森</schema:birthPlace>
     <imas:Hobby xml:lang="ja">おまけ集め</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20055"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20055"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kurihara_Nene">
@@ -1659,7 +1659,7 @@
     <schema:birthPlace xml:lang="ja">群馬</schema:birthPlace>
     <imas:Hobby xml:lang="ja">テレビ鑑賞</imas:Hobby>
     <imas:Hobby xml:lang="ja">健康作り</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20057"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20057"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Koga_Koharu">
@@ -1690,7 +1690,7 @@
     <schema:birthPlace xml:lang="ja">佐賀</schema:birthPlace>
     <imas:Hobby xml:lang="ja">イグアナのヒョウくんと遊ぶこと</imas:Hobby>
     <imas:Hobby xml:lang="ja">家のお手伝い</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20061"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20061"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Clarice">
@@ -1714,7 +1714,7 @@
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">兵庫</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ボランティア</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20056"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20056"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sakuma_Mayu">
@@ -1749,7 +1749,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D1197B</imas:Color>
     <imas:Hobby xml:lang="ja">お料理</imas:Hobby>
     <imas:Hobby xml:lang="ja">編み物</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20074"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20074"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Muramatsu_Sakura">
@@ -1779,7 +1779,7 @@
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">静岡</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ピンクのもの集め</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20167"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20167"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shiragiku_Hotaru">
@@ -1814,7 +1814,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D162CB</imas:Color>
     <imas:Hobby xml:lang="ja">アイドルレッスン</imas:Hobby>
     <imas:Hobby xml:lang="ja">笑顔の練習</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20088"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20088"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hayasaka_Mirei">
@@ -1848,7 +1848,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17685820"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">B72089</imas:Color>
     <imas:Hobby xml:lang="ja">ぬいぐるみ集め</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20127"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20127"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ariura_Kanna">
@@ -1878,7 +1878,7 @@
     <imas:Constellation xml:lang="ja">魚座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">長崎</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ラブ＆ピース</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20013"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20013"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Otokura_Yuuki">
@@ -1913,7 +1913,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F2C0C1</imas:Color>
     <imas:Hobby xml:lang="ja">ミックスジュース作り</imas:Hobby>
     <imas:Hobby xml:lang="ja">スクラップブック作り</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20039"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20039"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Harada_Miyo">
@@ -1944,7 +1944,7 @@
     <schema:birthPlace xml:lang="ja">石川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">バイクいじり</imas:Hobby>
     <imas:Hobby xml:lang="ja">クルマ</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20129"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20129"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ikebukuro_Akiha">
@@ -1974,7 +1974,7 @@
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ロボット制作</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20017"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20017"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tsujino_Akari">
@@ -2005,7 +2005,7 @@
     <schema:birthPlace xml:lang="ja">山形</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ラーメン</imas:Hobby>
     <imas:Hobby xml:lang="ja">編み物</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20106"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20106"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shirayuki_Chiyo">
@@ -2039,7 +2039,7 @@
     <schema:birthPlace xml:lang="ja">北海道</schema:birthPlace>
     <imas:Hobby xml:lang="ja">料理</imas:Hobby>
     <imas:Hobby xml:lang="ja">睡眠</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20090"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20090"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kurosaki_Chitose">
@@ -2073,7 +2073,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Hobby xml:lang="ja">美味しいものを食べること</imas:Hobby>
     <imas:Hobby xml:lang="ja">月光浴</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20059"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20059"/>
   </rdf:Description>
 
   <!--Cool-->
@@ -2108,7 +2108,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11591879"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">1C90CD</imas:Color>
     <imas:Hobby xml:lang="ja">犬の散歩</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20083"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20083"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kurokawa_Chiaki">
@@ -2138,7 +2138,7 @@
     <imas:Constellation xml:lang="ja">魚座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">北海道</schema:birthPlace>
     <imas:Hobby xml:lang="ja">クラシック鑑賞</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20058"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20058"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Matsumoto_Sarina">
@@ -2168,7 +2168,7 @@
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ショッピング</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20152"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20152"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kirino_Aya">
@@ -2198,7 +2198,7 @@
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">福岡</schema:birthPlace>
     <imas:Hobby xml:lang="ja">格闘技観戦</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20052"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20052"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takahashi_Reiko">
@@ -2228,7 +2228,7 @@
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">パーティーに行くこと</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20099"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20099"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Aikawa_Chinatsu">
@@ -2258,7 +2258,7 @@
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">北海道</schema:birthPlace>
     <imas:Hobby xml:lang="ja">カフェで読書</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20001"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20001"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kawashima_Mizuki">
@@ -2293,7 +2293,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">3F59A6</imas:Color>
     <imas:Hobby xml:lang="ja">掃除</imas:Hobby>
     <imas:Hobby xml:lang="ja">洗濯</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20043"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20043"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kamiya_Nao">
@@ -2327,7 +2327,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11529115"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">8D75B3</imas:Color>
     <imas:Hobby xml:lang="ja">アニメ鑑賞</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20042"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20042"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kamijo_Haruna">
@@ -2361,7 +2361,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q20041809"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">59B7DB</imas:Color>
     <imas:Hobby xml:lang="ja">猫と縁側でお昼寝</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20041"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20041"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Araki_Hina">
@@ -2395,7 +2395,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q16336231"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">80C260</imas:Color>
     <imas:Hobby xml:lang="ja">漫画描く</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20012"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20012"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Togo_Ai">
@@ -2425,7 +2425,7 @@
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">福島</schema:birthPlace>
     <imas:Hobby xml:lang="ja">サックス</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20108"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20108"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tada_Rina">
@@ -2459,7 +2459,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11661791"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">006DB2</imas:Color>
     <imas:Hobby xml:lang="ja">音楽鑑賞</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20103"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20103"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mizuki_Seira">
@@ -2489,7 +2489,7 @@
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">茨城</schema:birthPlace>
     <imas:Hobby xml:lang="ja">犬の散歩</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20157"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20157"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sasaki_Chie">
@@ -2523,7 +2523,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q8972760"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">006AB6</imas:Color>
     <imas:Hobby xml:lang="ja">裁縫</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20076"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20076"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mifune_Miyu">
@@ -2557,7 +2557,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q27507360"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">01AAA5</imas:Color>
     <imas:Hobby xml:lang="ja">アロマテラピー</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20160"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20160"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hattori_Toko">
@@ -2588,7 +2588,7 @@
     <schema:birthPlace xml:lang="ja">大分</schema:birthPlace>
     <imas:Hobby xml:lang="ja">熱帯魚観賞</imas:Hobby>
     <imas:Hobby xml:lang="ja">温泉めぐり</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20124"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20124"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kiba_Manami">
@@ -2619,7 +2619,7 @@
     <schema:birthPlace xml:lang="ja">長崎</schema:birthPlace>
     <imas:Hobby xml:lang="ja">料理</imas:Hobby>
     <imas:Hobby xml:lang="ja">筋トレ</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20049"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20049"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Fujiwara_Hajime">
@@ -2654,7 +2654,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">7271B3</imas:Color>
     <imas:Hobby xml:lang="ja">陶芸</imas:Hobby>
     <imas:Hobby xml:lang="ja">釣り</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20139"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20139"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nitta_Minami">
@@ -2689,7 +2689,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">6DBCDB</imas:Color>
     <imas:Hobby xml:lang="ja">ラクロス</imas:Hobby>
     <imas:Hobby xml:lang="ja">資格取得</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20120"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20120"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mizuno_Midori">
@@ -2719,7 +2719,7 @@
     <imas:Constellation xml:lang="ja">射手座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">愛知</schema:birthPlace>
     <imas:Hobby xml:lang="ja">弓道</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20158"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20158"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Furusawa_Yoriko">
@@ -2750,7 +2750,7 @@
     <schema:birthPlace xml:lang="ja">茨城</schema:birthPlace>
     <imas:Hobby xml:lang="ja">博物展観覧</imas:Hobby>
     <imas:Hobby xml:lang="ja">美術展</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20141"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20141"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tachibana_Arisu">
@@ -2785,7 +2785,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">5881C1</imas:Color>
     <imas:Hobby xml:lang="ja">読書（ミステリー）</imas:Hobby>
     <imas:Hobby xml:lang="ja">ゲーム</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20104"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20104"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sagisawa_Fumika">
@@ -2819,7 +2819,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1186964"/>
     <imas:Hobby xml:lang="ja">本屋めぐり</imas:Hobby>
     <imas:Hobby xml:lang="ja">栞作り</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20073"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20073"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yagami_Makino">
@@ -2849,7 +2849,7 @@
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">岐阜</schema:birthPlace>
     <imas:Hobby xml:lang="ja">諜報活動</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20175"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20175"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Layla">
@@ -2873,7 +2873,7 @@
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">ドバイ</schema:birthPlace>
     <imas:Hobby xml:lang="ja">公園で知らない人とおしゃべり</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20186"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20186"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Asari_Nanami">
@@ -2904,7 +2904,7 @@
     <schema:birthPlace xml:lang="ja">青森</schema:birthPlace>
     <imas:Hobby xml:lang="ja">絵日記</imas:Hobby>
     <imas:Hobby xml:lang="ja">釣り</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20008"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20008"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Helen">
@@ -2928,7 +2928,7 @@
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">海の向こう</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ＤＶＤ鑑賞</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20142"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20142"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Matsunaga_Ryo">
@@ -2962,7 +2962,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q6356324"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">202449</imas:Color>
     <imas:Hobby xml:lang="ja">ホラー映画鑑賞</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20150"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20150"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Komuro_Chinami">
@@ -2992,7 +2992,7 @@
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">愛知</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ダーツ</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20067"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20067"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takamine_Noa">
@@ -3022,7 +3022,7 @@
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">奈良</schema:birthPlace>
     <imas:Hobby xml:lang="ja">天体観測</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20101"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20101"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takagaki_Kaede">
@@ -3056,7 +3056,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1153079"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">33D5AC</imas:Color>
     <imas:Hobby xml:lang="ja">温泉めぐり</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20098"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20098"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kanzaki_Ranko">
@@ -3090,7 +3090,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q44552"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">7E3188</imas:Color>
     <imas:Hobby xml:lang="ja">絵を描くこと</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20044"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20044"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ijuin_Megumi">
@@ -3120,7 +3120,7 @@
     <imas:Constellation xml:lang="ja">天秤座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Hobby xml:lang="ja">一人旅</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20018"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20018"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hiiragi_Shino">
@@ -3150,7 +3150,7 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">山梨</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ワインツーリズム（産地巡り）</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20130"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20130"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hojo_Karen">
@@ -3184,7 +3184,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q9307208"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">38BAB8</imas:Color>
     <imas:Hobby xml:lang="ja">ネイル</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20143"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20143"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kate">
@@ -3208,7 +3208,7 @@
     <imas:Constellation xml:lang="ja">獅子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">イギリス</schema:birthPlace>
     <imas:Hobby xml:lang="ja">日本の雑誌を見るコト</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20060"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20060"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sena_Shiori">
@@ -3238,7 +3238,7 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">沖縄</schema:birthPlace>
     <imas:Hobby xml:lang="ja">海沿いを散歩</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20095"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20095"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ayase_Honoka">
@@ -3268,7 +3268,7 @@
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">宮城</schema:birthPlace>
     <imas:Hobby xml:lang="ja">バレエ</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20011"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20011"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sajo_Yukimi">
@@ -3301,7 +3301,7 @@
     <!-- <imas:cv rdf:resource="http://ja.dbpedia.org/resource/中澤ミナ"/> -->
     <!-- <imas:cv rdf:resource="http://www.wikidata.org/entity/Q0000000"/> -->
     <imas:Hobby xml:lang="ja">ペット（黒猫）と会話</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20077"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20077"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shinohara_Rei">
@@ -3331,7 +3331,7 @@
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">宮崎</schema:birthPlace>
     <imas:Hobby xml:lang="ja">社交ダンス</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20082"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20082"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Wakui_Rumi">
@@ -3361,7 +3361,7 @@
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">広島</schema:birthPlace>
     <imas:Hobby xml:lang="ja">仕事</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20190"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20190"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yoshioka_Saki">
@@ -3391,7 +3391,7 @@
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ストリートアート</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20184"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20184"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Umeki_Otoha">
@@ -3422,7 +3422,7 @@
     <schema:birthPlace xml:lang="ja">北海道</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ピアノ</imas:Hobby>
     <imas:Hobby xml:lang="ja">森林浴</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20025"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20025"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shirasaka_Koume">
@@ -3457,7 +3457,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">AAC5E2</imas:Color>
     <imas:Hobby xml:lang="ja">心霊スポット巡り</imas:Hobby>
     <imas:Hobby xml:lang="ja">ホラー・スプラッタ映画鑑賞</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20089"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20089"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kishibe_Ayaka">
@@ -3489,7 +3489,7 @@
     <imas:Hobby xml:lang="ja">ネイルアート</imas:Hobby>
     <imas:Hobby xml:lang="ja">エステ</imas:Hobby>
     <imas:Hobby xml:lang="ja">岩盤浴</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20045"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20045"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ujiie_Mutsumi">
@@ -3520,7 +3520,7 @@
     <schema:birthPlace xml:lang="ja">栃木</schema:birthPlace>
     <imas:Hobby xml:lang="ja">冒険小説を読む</imas:Hobby>
     <imas:Hobby xml:lang="ja">冒険映画を見る事</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20024"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20024"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nishikawa_Honami">
@@ -3551,7 +3551,7 @@
     <schema:birthPlace xml:lang="ja">兵庫</schema:birthPlace>
     <imas:Hobby xml:lang="ja">オペラ鑑賞</imas:Hobby>
     <imas:Hobby xml:lang="ja">宝塚鑑賞</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20118"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20118"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Narumiya_Yume">
@@ -3582,7 +3582,7 @@
     <schema:birthPlace xml:lang="ja">滋賀</schema:birthPlace>
     <imas:Hobby xml:lang="ja">水彩画</imas:Hobby>
     <imas:Hobby xml:lang="ja">写生</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20115"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20115"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Fujii_Tomo">
@@ -3612,7 +3612,7 @@
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">滋賀</schema:birthPlace>
     <imas:Hobby xml:lang="ja">占い</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20137"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20137"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shiomi_Syuko">
@@ -3647,7 +3647,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">DEE2EB</imas:Color>
     <imas:Hobby xml:lang="ja">献血</imas:Hobby>
     <imas:Hobby xml:lang="ja">ダーツ</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20081"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20081"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Wakiyama_Tamami">
@@ -3682,7 +3682,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">3A75BB</imas:Color>
     <imas:Hobby xml:lang="ja">時代小説を読むこと</imas:Hobby>
     <imas:Hobby xml:lang="ja">剣道</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20189"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20189"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Okazaki_Yasuha">
@@ -3712,7 +3712,7 @@
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">長崎</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ドールハウス作り</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20036"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20036"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hayami_Kanade">
@@ -3746,7 +3746,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11666486"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">0D386D</imas:Color>
     <imas:Hobby xml:lang="ja">映画鑑賞</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20128"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20128"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ohishi_Izumi">
@@ -3776,7 +3776,7 @@
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">静岡</schema:birthPlace>
     <imas:Hobby xml:lang="ja">プログラミング</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20030"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20030"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Matsuo_Chizuru">
@@ -3807,7 +3807,7 @@
     <schema:birthPlace xml:lang="ja">福岡</schema:birthPlace>
     <imas:Hobby xml:lang="ja">勉強</imas:Hobby>
     <imas:Hobby xml:lang="ja">習字</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20149"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20149"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Morikubo_Nono">
@@ -3842,7 +3842,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">97D3D3</imas:Color>
     <imas:Hobby xml:lang="ja">ポエム作り</imas:Hobby>
     <imas:Hobby xml:lang="ja">少女漫画集め</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20172"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20172"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Anastasia">
@@ -3871,7 +3871,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">B0C5E4</imas:Color>
     <imas:Hobby xml:lang="ja">ホームパーティ</imas:Hobby>
     <imas:Hobby xml:lang="ja">天体観測</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20009"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20009"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yamato_Aki">
@@ -3906,7 +3906,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">276E4E</imas:Color>
     <imas:Hobby xml:lang="ja">サバゲー</imas:Hobby>
     <imas:Hobby xml:lang="ja">プラモ収集</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20179"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20179"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yuuki_Haru">
@@ -3940,7 +3940,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q20039931"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">45BDB4</imas:Color>
     <imas:Hobby xml:lang="ja">サッカー</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20180"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20180"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ninomiya_Asuka">
@@ -3976,7 +3976,7 @@
     <imas:Hobby xml:lang="ja">ヘアアレンジ</imas:Hobby>
     <imas:Hobby xml:lang="ja">ラジオを聴くこと</imas:Hobby>
     <imas:Hobby xml:lang="ja">漫画を描くこと</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20121"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20121"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kiryu_Tsukasa">
@@ -4008,7 +4008,7 @@
     <imas:Hobby xml:lang="ja">異業種交流</imas:Hobby>
     <imas:Hobby xml:lang="ja">ホットヨガ</imas:Hobby>
     <imas:Hobby xml:lang="ja">ぬか床の世話</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20053"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20053"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mochizuki_Hijiri">
@@ -4038,7 +4038,7 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">長野</schema:birthPlace>
     <imas:Hobby xml:lang="ja">歌を口ずさむこと</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20170"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20170"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takafuji_Kako">
@@ -4072,7 +4072,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q55875405"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">5C068F</imas:Color>
     <imas:Hobby xml:lang="ja">隠し芸</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20100"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20100"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sunazuka_Akira">
@@ -4104,7 +4104,7 @@
     <imas:Hobby xml:lang="ja">ファッション</imas:Hobby>
     <imas:Hobby xml:lang="ja">動画配信</imas:Hobby>
     <imas:Hobby xml:lang="ja">FPS</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20093"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20093"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hisakawa_Hayate">
@@ -4139,7 +4139,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">7ADAD6</imas:Color>
     <imas:Hobby xml:lang="ja">ファッション</imas:Hobby>
     <imas:Hobby xml:lang="ja">流行りの店巡り</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20132"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20132"/>
   </rdf:Description>
 
   <!--Passion-->
@@ -4174,7 +4174,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q333320"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F6B128</imas:Color>
     <imas:Hobby xml:lang="ja">ショッピング</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20146"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20146"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takamori_Aiko">
@@ -4208,7 +4208,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q4358562"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">C5DD7F</imas:Color>
     <imas:Hobby xml:lang="ja">近所の公園をお散歩</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20102"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20102"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Namiki_Meiko">
@@ -4238,7 +4238,7 @@
     <imas:Constellation xml:lang="ja">天秤座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">和歌山</schema:birthPlace>
     <imas:Hobby xml:lang="ja">旅行</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20114"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20114"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ryuzaki_Kaoru">
@@ -4272,7 +4272,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q24875141"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F4D956</imas:Color>
     <imas:Hobby xml:lang="ja">料理</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20187"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20187"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kimura_Natsuki">
@@ -4306,7 +4306,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11451654"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">55565A</imas:Color>
     <imas:Hobby xml:lang="ja">ツーリング</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20050"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20050"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Matsuyama_Kumiko">
@@ -4336,7 +4336,7 @@
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ピアノ</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20153"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20153"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Saito_Yoko">
@@ -4366,7 +4366,7 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">福岡</schema:birthPlace>
     <imas:Hobby xml:lang="ja">半身浴</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20070"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20070"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sawada_Marina">
@@ -4396,7 +4396,7 @@
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">長野</schema:birthPlace>
     <imas:Hobby xml:lang="ja">サーフィン</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20079"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20079"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yaguchi_Miu">
@@ -4426,7 +4426,7 @@
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">千葉</schema:birthPlace>
     <imas:Hobby xml:lang="ja">メール</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20176"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20176"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akagi_Miria">
@@ -4460,7 +4460,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1955926"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F8C715</imas:Color>
     <imas:Hobby xml:lang="ja">おしゃべり</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20005"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20005"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Aino_Nagisa">
@@ -4490,7 +4490,7 @@
     <imas:Constellation xml:lang="ja">獅子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">愛知</schema:birthPlace>
     <imas:Hobby xml:lang="ja">バスケットボール</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20002"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20002"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Manabe_Itsuki">
@@ -4520,7 +4520,7 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">石川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">とにかく運動</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20156"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20156"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ohtsuki_Yui">
@@ -4554,7 +4554,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17223371"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EFB817</imas:Color>
     <imas:Hobby xml:lang="ja">カラオケ</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20032"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20032"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Himekawa_Yuki">
@@ -4588,7 +4588,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11523609"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E9870C</imas:Color>
     <imas:Hobby xml:lang="ja">野球観戦</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20134"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20134"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kitami_Yuzu">
@@ -4622,7 +4622,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q40039788"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EADC62</imas:Color>
     <imas:Hobby xml:lang="ja">バドミントン</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20048"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20048"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ueda_Suzuho">
@@ -4656,7 +4656,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q18818006"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">C9870F</imas:Color>
     <imas:Hobby xml:lang="ja">裁縫</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20023"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20023"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ebihara_Naho">
@@ -4687,7 +4687,7 @@
     <schema:birthPlace xml:lang="ja">熊本</schema:birthPlace>
     <imas:Hobby xml:lang="ja">散歩</imas:Hobby>
     <imas:Hobby xml:lang="ja">和菓子屋さん巡り</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20028"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20028"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Oikawa_Shizuku">
@@ -4722,7 +4722,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">FFFFFF</imas:Color>
     <imas:Hobby xml:lang="ja">乳搾り</imas:Hobby>
     <imas:Hobby xml:lang="ja">トラクターの運転</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20029"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20029"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Koseki_Reina">
@@ -4755,7 +4755,7 @@
     <!--<imas:cv rdf:resource="http://ja.dbpedia.org/resource/長野佑紀"/>-->
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q30108577"/>
     <imas:Hobby xml:lang="ja">いたずら</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20063"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20063"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Etou_Misaki">
@@ -4786,7 +4786,7 @@
     <schema:birthPlace xml:lang="ja">大分</schema:birthPlace>
     <imas:Hobby xml:lang="ja">女子力アップ</imas:Hobby>
     <imas:Hobby xml:lang="ja">携帯小説</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20027"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20027"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hoshi_Syoko">
@@ -4820,7 +4820,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17230362"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">A21D3C</imas:Color>
     <imas:Hobby xml:lang="ja">キノコ栽培</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20144"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20144"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Katagiri_Sanae">
@@ -4855,7 +4855,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E94D1A</imas:Color>
     <imas:Hobby xml:lang="ja">マッサージ</imas:Hobby>
     <imas:Hobby xml:lang="ja">スーパー銭湯</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20040"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20040"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hori_Yuko">
@@ -4889,7 +4889,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17160003"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E89B55</imas:Color>
     <imas:Hobby xml:lang="ja">サイキックトレーニング</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20145"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20145"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nishijima_Kai">
@@ -4919,7 +4919,7 @@
     <imas:Constellation xml:lang="ja">獅子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">大阪</schema:birthPlace>
     <imas:Hobby xml:lang="ja">水族館巡り</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20119"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20119"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Matoba_Risa">
@@ -4953,7 +4953,7 @@
     <!-- <imas:cv rdf:resource="http://www.wikidata.org/entity/Q0000000"/> -->
     <imas:Hobby xml:lang="ja">ダンス</imas:Hobby>
     <imas:Hobby xml:lang="ja">パパとデート</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20154"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20154"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Zaizen_Tokiko">
@@ -4984,7 +4984,7 @@
     <schema:birthPlace xml:lang="ja">名古屋</schema:birthPlace>
     <imas:Hobby xml:lang="ja">豚を料理すること</imas:Hobby>
     <imas:Hobby xml:lang="ja">お仕置き</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20069"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20069"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yorita_Yoshino">
@@ -5020,7 +5020,7 @@
     <imas:Hobby xml:lang="ja">悩み事解決</imas:Hobby>
     <imas:Hobby xml:lang="ja">石ころ集め</imas:Hobby>
     <imas:Hobby xml:lang="ja">失せ物探し</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20185"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20185"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Aiba_Yumi">
@@ -5054,7 +5054,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q18048266"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EAE28D</imas:Color>
     <imas:Hobby xml:lang="ja">ガーデニング</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20003"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20003"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nonomura_Sora">
@@ -5084,7 +5084,7 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">福岡</schema:birthPlace>
     <imas:Hobby xml:lang="ja">友達と電話</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20123"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20123"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hamakawa_Ayuna">
@@ -5114,7 +5114,7 @@
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">大阪</schema:birthPlace>
     <imas:Hobby xml:lang="ja">乗馬</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20125"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20125"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Wakabayashi_Tomoka">
@@ -5144,7 +5144,7 @@
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">鹿児島</schema:birthPlace>
     <imas:Hobby xml:lang="ja">チアリーディング</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20188"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20188"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Jougasaki_Mika">
@@ -5178,7 +5178,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11385438"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F4982B</imas:Color>
     <imas:Hobby xml:lang="ja">カラオケ</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20086"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20086"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Jougasaki_Rika">
@@ -5212,7 +5212,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q9080262"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F7D30D</imas:Color>
     <imas:Hobby xml:lang="ja">シール集め</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20087"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20087"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Senzaki_Ema">
@@ -5242,7 +5242,7 @@
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">大阪</schema:birthPlace>
     <imas:Hobby xml:lang="ja">革小物集め</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20096"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20096"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hino_Akane">
@@ -5276,7 +5276,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q5100189"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EA4F21</imas:Color>
     <imas:Hobby xml:lang="ja">ラグビー観戦</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20133"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20133"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Moroboshi_Kirari">
@@ -5310,7 +5310,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q391799"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F8CA02</imas:Color>
     <imas:Hobby xml:lang="ja">かわいい物集め</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20173"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20173"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Totoki_Airi">
@@ -5344,7 +5344,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1046994"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E9425C</imas:Color>
     <imas:Hobby xml:lang="ja">ケーキ作り</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20110"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20110"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Natalia">
@@ -5371,7 +5371,7 @@
     <!--<imas:cv rdf:resource="http://ja.dbpedia.org/resource/生田輝"/>-->
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q66736457"/>
     <imas:Hobby xml:lang="ja">ベリーダンス</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20113"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20113"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Souma_Natsumi">
@@ -5401,7 +5401,7 @@
     <imas:Constellation xml:lang="ja">獅子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">京都</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ランニング</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20097"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20097"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Makihara_Shiho">
@@ -5431,7 +5431,7 @@
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">三重</schema:birthPlace>
     <imas:Hobby xml:lang="ja">スイーツめぐり</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20148"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20148"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mukai_Takumi">
@@ -5465,7 +5465,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17221306"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">A90582</imas:Color>
     <imas:Hobby xml:lang="ja">バイクいじり</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20164"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20164"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ichihara_Nina">
@@ -5499,7 +5499,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11369771"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F7DE8C</imas:Color>
     <imas:Hobby xml:lang="ja">着ぐるみ集め</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20020"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20020"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kita_Hinako">
@@ -5533,7 +5533,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17209690"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F4D059</imas:Color>
     <imas:Hobby xml:lang="ja">妄想</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20046"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20046"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sugisaka_Umi">
@@ -5563,7 +5563,7 @@
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">山口</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ウインドサーフィン</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20091"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20091"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kitagawa_Mahiro">
@@ -5595,7 +5595,7 @@
     <imas:Hobby xml:lang="ja">走ること</imas:Hobby>
     <imas:Hobby xml:lang="ja">食べること</imas:Hobby>
     <imas:Hobby xml:lang="ja">寝ること</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20047"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20047"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mary_Cochran">
@@ -5626,7 +5626,7 @@
     <schema:birthPlace xml:lang="ja">サンフランシスコ</schema:birthPlace>
     <imas:Hobby xml:lang="ja">女磨き</imas:Hobby>
     <imas:Hobby xml:lang="ja">グルメツアー</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20168"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20168"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Komatsu_Ibuki">
@@ -5658,7 +5658,7 @@
     <imas:Hobby xml:lang="ja">ストリートダンス</imas:Hobby>
     <imas:Hobby xml:lang="ja">スケボー</imas:Hobby>
     <imas:Hobby xml:lang="ja">恋愛映画を見る事</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20066"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20066"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Miyoshi_Sana">
@@ -5689,7 +5689,7 @@
     <schema:birthPlace xml:lang="ja">香川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ＴＶゲーム</imas:Hobby>
     <imas:Hobby xml:lang="ja">夜更かし</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20163"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20163"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Cathy_Graham">
@@ -5720,7 +5720,7 @@
     <schema:birthPlace xml:lang="ja">ニューヨーク</schema:birthPlace>
     <imas:Hobby xml:lang="ja">インラインスケート</imas:Hobby>
     <imas:Hobby xml:lang="ja">ダンス</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20051"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20051"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Namba_Emi">
@@ -5755,7 +5755,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E9463D</imas:Color>
     <imas:Hobby xml:lang="ja">お笑いライブ巡り</imas:Hobby>
     <imas:Hobby xml:lang="ja">モノマネ</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20117"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20117"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hamaguchi_Ayame">
@@ -5791,7 +5791,7 @@
     <imas:Hobby xml:lang="ja">撮影所巡り</imas:Hobby>
     <imas:Hobby xml:lang="ja">忍者グッズ収集</imas:Hobby>
     <imas:Hobby xml:lang="ja">時代劇鑑賞</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20126"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20126"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Murakami_Tomoe">
@@ -5826,7 +5826,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D42E38</imas:Color>
     <imas:Hobby xml:lang="ja">演歌</imas:Hobby>
     <imas:Hobby xml:lang="ja">将棋</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20166"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20166"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tsuchiya_Ako">
@@ -5857,7 +5857,7 @@
     <schema:birthPlace xml:lang="ja">静岡</schema:birthPlace>
     <imas:Hobby xml:lang="ja">食べること</imas:Hobby>
     <imas:Hobby xml:lang="ja">貯金</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20107"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20107"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shuto_Aoi">
@@ -5887,7 +5887,7 @@
     <imas:Constellation xml:lang="ja">獅子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">大分</schema:birthPlace>
     <imas:Hobby xml:lang="ja">魚さばき</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20085"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20085"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Saejima_Kiyomi">
@@ -5919,7 +5919,7 @@
     <imas:Hobby xml:lang="ja">掃除</imas:Hobby>
     <imas:Hobby xml:lang="ja">整理整頓</imas:Hobby>
     <imas:Hobby xml:lang="ja">腕章作り</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20071"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20071"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sato_Shin">
@@ -5954,7 +5954,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E44E8E</imas:Color>
     <imas:Hobby xml:lang="ja">ドレスアップ</imas:Hobby>
     <imas:Hobby xml:lang="ja">衣装作り</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20078"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20078"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nanjo_Hikaru">
@@ -5989,7 +5989,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">ED0829</imas:Color>
     <imas:Hobby xml:lang="ja">特撮番組鑑賞</imas:Hobby>
     <imas:Hobby xml:lang="ja">特撮ごっこ</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20116"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20116"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Eve_Santaclaus">
@@ -6019,7 +6019,7 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">グリーンランド</schema:birthPlace>
     <imas:Hobby xml:lang="ja">煙突探し</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20015"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20015"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yumemi_Riamu">
@@ -6053,7 +6053,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q35172322"/>
     <imas:Hobby xml:lang="ja">夜中の意味深ポエム</imas:Hobby>
     <imas:Hobby xml:lang="ja">現場参戦</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20182"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20182"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hisakawa_Nagi">
@@ -6089,7 +6089,7 @@
     <imas:Hobby xml:lang="ja">写真</imas:Hobby>
     <imas:Hobby xml:lang="ja">ポエム</imas:Hobby>
     <imas:Hobby xml:lang="ja">読書（新書）</imas:Hobby>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20131"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/20131"/>
   </rdf:Description>
 
 </rdf:RDF>

--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -40,7 +40,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EC7092</imas:Color>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Hobby xml:lang="ja">友達と長電話</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20084"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20084"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nakano_Yuka">
@@ -74,7 +74,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17159583"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">CB78B0</imas:Color>
     <imas:Hobby xml:lang="ja">空手</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20112"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20112"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mizumoto_Yukari">
@@ -108,7 +108,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17211589"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E8BAD6</imas:Color>
     <imas:Hobby xml:lang="ja">フルート</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20159"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20159"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Fukuyama_Mai">
@@ -138,7 +138,7 @@
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">兵庫</schema:birthPlace>
     <imas:Hobby xml:lang="ja">一輪車</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20136"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20136"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shiina_Noriko">
@@ -172,7 +172,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17161754"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EA495B</imas:Color>
     <imas:Hobby xml:lang="ja">新作ドーナツの試食</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20080"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20080"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Imai_Kana">
@@ -202,7 +202,7 @@
     <imas:Constellation xml:lang="ja">魚座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">高知</schema:birthPlace>
     <imas:Hobby xml:lang="ja">友達とおしゃべり</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20021"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20021"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mochida_Arisa">
@@ -232,7 +232,7 @@
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">長野</schema:birthPlace>
     <imas:Hobby xml:lang="ja">子供と遊ぶこと</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20169"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20169"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mimura_Kanako">
@@ -266,7 +266,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q3211762"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F4ABB4</imas:Color>
     <imas:Hobby xml:lang="ja">お菓子作り</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20161"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20161"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Okuyama_Saori">
@@ -296,7 +296,7 @@
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">秋田</schema:birthPlace>
     <imas:Hobby xml:lang="ja">読書</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20038"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20038"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Manaka_Misato">
@@ -326,7 +326,7 @@
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">旅行</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20155"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20155"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kohinata_Miho">
@@ -360,7 +360,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q901835"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">C64796</imas:Color>
     <imas:Hobby xml:lang="ja">ひなたぼっこ</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20065"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20065"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ogata_Chieri">
@@ -394,7 +394,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q15731362"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">69B64C</imas:Color>
     <imas:Hobby xml:lang="ja">四葉のクローバー集め</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20037"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20037"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Igarashi_Kyoko">
@@ -428,7 +428,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q3183413"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F567C6</imas:Color>
     <imas:Hobby xml:lang="ja">家事全般</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20016"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20016"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yanase_Miyuki">
@@ -458,7 +458,7 @@
     <imas:Constellation xml:lang="ja">魚座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">北海道</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ぬいぐるみ集め</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20178"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20178"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sakurai_Momoka">
@@ -492,7 +492,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11567752"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EF93BC</imas:Color>
     <imas:Hobby xml:lang="ja">ティータイム</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20075"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20075"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Egami_Tsubaki">
@@ -522,7 +522,7 @@
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">新潟</schema:birthPlace>
     <imas:Hobby xml:lang="ja">写真を撮ること</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20026"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20026"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nagatomi_Hasumi">
@@ -553,7 +553,7 @@
     <schema:birthPlace xml:lang="ja">島根</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ボウリング</imas:Hobby>
     <imas:Hobby xml:lang="ja">古着屋巡り</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20111"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20111"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yokoyama_Chika">
@@ -583,7 +583,7 @@
     <imas:Constellation xml:lang="ja">射手座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">宮崎</schema:birthPlace>
     <imas:Hobby xml:lang="ja">魔法少女ごっこ</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20183"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20183"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Seki_Hiromi">
@@ -617,7 +617,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q41585491"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F8C5C1</imas:Color>
     <imas:Hobby xml:lang="ja">アクセサリー作り</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20094"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20094"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ohta_Yuu">
@@ -648,7 +648,7 @@
     <schema:birthPlace xml:lang="ja">千葉</schema:birthPlace>
     <imas:Hobby xml:lang="ja">犬のトリミング</imas:Hobby>
     <imas:Hobby xml:lang="ja">美容</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20031"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20031"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Munakata_Atsumi">
@@ -682,7 +682,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q56118632"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">C82F7F</imas:Color>
     <imas:Hobby xml:lang="ja">指の運動</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20165"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20165"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Fujimoto_Rina">
@@ -717,7 +717,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">653A2A</imas:Color>
     <imas:Hobby xml:lang="ja">単車乗り</imas:Hobby>
     <imas:Hobby xml:lang="ja">コンビニで立ち読み</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20138"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20138"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ohara_Michiru">
@@ -747,7 +747,7 @@
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">福井</schema:birthPlace>
     <imas:Hobby xml:lang="ja">食べること</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20035"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20035"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yusa_Kozue">
@@ -780,7 +780,7 @@
     <!-- <imas:cv rdf:resource="http://ja.dbpedia.org/page/花谷麻妃"/> -->
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q24873835"/>
     <imas:Hobby xml:lang="ja">しゅみってなぁに？</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20181"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20181"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ohnuma_Kurumi">
@@ -811,7 +811,7 @@
     <schema:birthPlace xml:lang="ja">石川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ポケットティッシュ収集</imas:Hobby>
     <imas:Hobby xml:lang="ja">お風呂に入ること</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20034"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20034"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ichinose_Shiki">
@@ -847,7 +847,7 @@
     <imas:Hobby xml:lang="ja">失踪</imas:Hobby>
     <imas:Hobby xml:lang="ja">アヤしい科学実験</imas:Hobby>
     <imas:Hobby xml:lang="ja">観察</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20019"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20019"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Maekawa_Miku">
@@ -881,7 +881,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1107456"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">CA113A</imas:Color>
     <imas:Hobby xml:lang="ja">猫カフェ巡り</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20147"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20147"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akanishi_Erika">
@@ -911,7 +911,7 @@
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">岡山</schema:birthPlace>
     <imas:Hobby xml:lang="ja">漫才鑑賞</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20006"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20006"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Matsubara_Saya">
@@ -941,7 +941,7 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">兵庫</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ブログ</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20151"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20151"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Aihara_Yukino">
@@ -971,7 +971,7 @@
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">秋田</schema:birthPlace>
     <imas:Hobby xml:lang="ja">紅茶</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20004"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20004"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Miyamoto_Frederica">
@@ -1005,7 +1005,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q62024404"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">9E1861</imas:Color>
     <imas:Hobby xml:lang="ja">ファッション</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20162"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20162"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kobayakawa_Sae">
@@ -1039,7 +1039,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q9046310"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D967A3</imas:Color>
     <imas:Hobby xml:lang="ja">日本舞踊</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20064"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20064"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Saionji_Kotoka">
@@ -1069,7 +1069,7 @@
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Hobby xml:lang="ja">押し花作り</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20068"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20068"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Futaba_Anzu">
@@ -1103,7 +1103,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q5770504"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F19DB4</imas:Color>
     <imas:Hobby xml:lang="ja">なし</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20140"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20140"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yao_Fueifuei">
@@ -1133,7 +1133,7 @@
     <imas:Constellation xml:lang="ja">天秤座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">香港</schema:birthPlace>
     <imas:Hobby xml:lang="ja">料理</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20174"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20174"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Momoi_Azuki">
@@ -1163,7 +1163,7 @@
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">長野</schema:birthPlace>
     <imas:Hobby xml:lang="ja">金魚すくい</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20171"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20171"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Suzumiya_Seika">
@@ -1193,7 +1193,7 @@
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">岐阜</schema:birthPlace>
     <imas:Hobby xml:lang="ja">バイオリン</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20092"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20092"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tsukimiya_Miyabi">
@@ -1223,7 +1223,7 @@
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ママとショッピング</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20105"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20105"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hyodo_Rena">
@@ -1253,7 +1253,7 @@
     <imas:Constellation xml:lang="ja">天秤座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Hobby xml:lang="ja">トランプ</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20135"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20135"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Niwa_Hitomi">
@@ -1284,7 +1284,7 @@
     <schema:birthPlace xml:lang="ja">名古屋</schema:birthPlace>
     <imas:Hobby xml:lang="ja">史跡巡り</imas:Hobby>
     <imas:Hobby xml:lang="ja">武将グッズ収集</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20122"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20122"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Domyoji_Karin">
@@ -1318,7 +1318,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17212219"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">CC252D</imas:Color>
     <imas:Hobby xml:lang="ja">境内のお掃除</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20109"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20109"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yanagi_Kiyora">
@@ -1348,7 +1348,7 @@
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">愛媛</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ドキュメンタリー番組鑑賞</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20177"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20177"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Imura_Setsuna">
@@ -1378,7 +1378,7 @@
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">秋田</schema:birthPlace>
     <imas:Hobby xml:lang="ja">メイク小物集め</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20022"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20022"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kusakabe_Wakaba">
@@ -1408,7 +1408,7 @@
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">群馬</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ジグソーパズル</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20054"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20054"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sakakibara_Satomi">
@@ -1438,7 +1438,7 @@
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">山形</schema:birthPlace>
     <imas:Hobby xml:lang="ja">甘いお菓子を食べること</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20072"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20072"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Koshimizu_Sachiko">
@@ -1472,7 +1472,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1204576"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">CCAACF</imas:Color>
     <imas:Hobby xml:lang="ja">勉強ノートの清書</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20062"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20062"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Anzai_Miyako">
@@ -1503,7 +1503,7 @@
     <schema:birthPlace xml:lang="ja">福井</schema:birthPlace>
     <imas:Hobby xml:lang="ja">探偵ドラマ</imas:Hobby>
     <imas:Hobby xml:lang="ja">推理小説を見ること</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20014"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20014"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Asano_Fuka">
@@ -1533,7 +1533,7 @@
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">滋賀</schema:birthPlace>
     <imas:Hobby xml:lang="ja">小説を書くこと</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20007"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20007"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ohnishi_Yuriko">
@@ -1564,7 +1564,7 @@
     <schema:birthPlace xml:lang="ja">香川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ネットサーフィン</imas:Hobby>
     <imas:Hobby xml:lang="ja">読書</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20033"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20033"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Abe_Nana">
@@ -1598,7 +1598,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q6127820"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E64A79</imas:Color>
     <imas:Hobby xml:lang="ja">ウサミン星との交信</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20010"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20010"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kudo_Shinobu">
@@ -1628,7 +1628,7 @@
     <imas:Constellation xml:lang="ja">魚座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">青森</schema:birthPlace>
     <imas:Hobby xml:lang="ja">おまけ集め</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20055"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20055"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kurihara_Nene">
@@ -1659,7 +1659,7 @@
     <schema:birthPlace xml:lang="ja">群馬</schema:birthPlace>
     <imas:Hobby xml:lang="ja">テレビ鑑賞</imas:Hobby>
     <imas:Hobby xml:lang="ja">健康作り</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20057"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20057"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Koga_Koharu">
@@ -1690,7 +1690,7 @@
     <schema:birthPlace xml:lang="ja">佐賀</schema:birthPlace>
     <imas:Hobby xml:lang="ja">イグアナのヒョウくんと遊ぶこと</imas:Hobby>
     <imas:Hobby xml:lang="ja">家のお手伝い</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20061"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20061"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Clarice">
@@ -1714,7 +1714,7 @@
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">兵庫</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ボランティア</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20056"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20056"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sakuma_Mayu">
@@ -1749,7 +1749,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D1197B</imas:Color>
     <imas:Hobby xml:lang="ja">お料理</imas:Hobby>
     <imas:Hobby xml:lang="ja">編み物</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20074"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20074"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Muramatsu_Sakura">
@@ -1779,7 +1779,7 @@
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">静岡</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ピンクのもの集め</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20167"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20167"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shiragiku_Hotaru">
@@ -1814,7 +1814,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D162CB</imas:Color>
     <imas:Hobby xml:lang="ja">アイドルレッスン</imas:Hobby>
     <imas:Hobby xml:lang="ja">笑顔の練習</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20088"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20088"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hayasaka_Mirei">
@@ -1848,7 +1848,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17685820"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">B72089</imas:Color>
     <imas:Hobby xml:lang="ja">ぬいぐるみ集め</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20127"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20127"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ariura_Kanna">
@@ -1878,7 +1878,7 @@
     <imas:Constellation xml:lang="ja">魚座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">長崎</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ラブ＆ピース</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20013"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20013"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Otokura_Yuuki">
@@ -1913,7 +1913,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F2C0C1</imas:Color>
     <imas:Hobby xml:lang="ja">ミックスジュース作り</imas:Hobby>
     <imas:Hobby xml:lang="ja">スクラップブック作り</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20039"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20039"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Harada_Miyo">
@@ -1944,7 +1944,7 @@
     <schema:birthPlace xml:lang="ja">石川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">バイクいじり</imas:Hobby>
     <imas:Hobby xml:lang="ja">クルマ</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20129"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20129"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ikebukuro_Akiha">
@@ -1974,7 +1974,7 @@
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ロボット制作</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20017"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20017"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tsujino_Akari">
@@ -2005,7 +2005,7 @@
     <schema:birthPlace xml:lang="ja">山形</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ラーメン</imas:Hobby>
     <imas:Hobby xml:lang="ja">編み物</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20106"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20106"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shirayuki_Chiyo">
@@ -2039,7 +2039,7 @@
     <schema:birthPlace xml:lang="ja">北海道</schema:birthPlace>
     <imas:Hobby xml:lang="ja">料理</imas:Hobby>
     <imas:Hobby xml:lang="ja">睡眠</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20090"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20090"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kurosaki_Chitose">
@@ -2073,7 +2073,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Hobby xml:lang="ja">美味しいものを食べること</imas:Hobby>
     <imas:Hobby xml:lang="ja">月光浴</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20059"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20059"/>
   </rdf:Description>
 
   <!--Cool-->
@@ -2108,7 +2108,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11591879"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">1C90CD</imas:Color>
     <imas:Hobby xml:lang="ja">犬の散歩</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20083"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20083"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kurokawa_Chiaki">
@@ -2138,7 +2138,7 @@
     <imas:Constellation xml:lang="ja">魚座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">北海道</schema:birthPlace>
     <imas:Hobby xml:lang="ja">クラシック鑑賞</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20058"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20058"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Matsumoto_Sarina">
@@ -2168,7 +2168,7 @@
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ショッピング</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20152"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20152"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kirino_Aya">
@@ -2198,7 +2198,7 @@
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">福岡</schema:birthPlace>
     <imas:Hobby xml:lang="ja">格闘技観戦</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20052"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20052"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takahashi_Reiko">
@@ -2228,7 +2228,7 @@
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">パーティーに行くこと</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20099"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20099"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Aikawa_Chinatsu">
@@ -2258,7 +2258,7 @@
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">北海道</schema:birthPlace>
     <imas:Hobby xml:lang="ja">カフェで読書</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20001"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20001"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kawashima_Mizuki">
@@ -2293,7 +2293,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">3F59A6</imas:Color>
     <imas:Hobby xml:lang="ja">掃除</imas:Hobby>
     <imas:Hobby xml:lang="ja">洗濯</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20043"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20043"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kamiya_Nao">
@@ -2327,7 +2327,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11529115"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">8D75B3</imas:Color>
     <imas:Hobby xml:lang="ja">アニメ鑑賞</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20042"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20042"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kamijo_Haruna">
@@ -2361,7 +2361,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q20041809"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">59B7DB</imas:Color>
     <imas:Hobby xml:lang="ja">猫と縁側でお昼寝</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20041"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20041"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Araki_Hina">
@@ -2395,7 +2395,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q16336231"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">80C260</imas:Color>
     <imas:Hobby xml:lang="ja">漫画描く</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20012"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20012"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Togo_Ai">
@@ -2425,7 +2425,7 @@
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">福島</schema:birthPlace>
     <imas:Hobby xml:lang="ja">サックス</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20108"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20108"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tada_Rina">
@@ -2459,7 +2459,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11661791"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">006DB2</imas:Color>
     <imas:Hobby xml:lang="ja">音楽鑑賞</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20103"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20103"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mizuki_Seira">
@@ -2489,7 +2489,7 @@
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">茨城</schema:birthPlace>
     <imas:Hobby xml:lang="ja">犬の散歩</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20157"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20157"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sasaki_Chie">
@@ -2523,7 +2523,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q8972760"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">006AB6</imas:Color>
     <imas:Hobby xml:lang="ja">裁縫</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20076"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20076"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mifune_Miyu">
@@ -2557,7 +2557,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q27507360"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">01AAA5</imas:Color>
     <imas:Hobby xml:lang="ja">アロマテラピー</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20160"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20160"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hattori_Toko">
@@ -2588,7 +2588,7 @@
     <schema:birthPlace xml:lang="ja">大分</schema:birthPlace>
     <imas:Hobby xml:lang="ja">熱帯魚観賞</imas:Hobby>
     <imas:Hobby xml:lang="ja">温泉めぐり</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20124"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20124"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kiba_Manami">
@@ -2619,7 +2619,7 @@
     <schema:birthPlace xml:lang="ja">長崎</schema:birthPlace>
     <imas:Hobby xml:lang="ja">料理</imas:Hobby>
     <imas:Hobby xml:lang="ja">筋トレ</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20049"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20049"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Fujiwara_Hajime">
@@ -2654,7 +2654,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">7271B3</imas:Color>
     <imas:Hobby xml:lang="ja">陶芸</imas:Hobby>
     <imas:Hobby xml:lang="ja">釣り</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20139"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20139"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nitta_Minami">
@@ -2689,7 +2689,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">6DBCDB</imas:Color>
     <imas:Hobby xml:lang="ja">ラクロス</imas:Hobby>
     <imas:Hobby xml:lang="ja">資格取得</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20120"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20120"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mizuno_Midori">
@@ -2719,7 +2719,7 @@
     <imas:Constellation xml:lang="ja">射手座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">愛知</schema:birthPlace>
     <imas:Hobby xml:lang="ja">弓道</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20158"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20158"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Furusawa_Yoriko">
@@ -2750,7 +2750,7 @@
     <schema:birthPlace xml:lang="ja">茨城</schema:birthPlace>
     <imas:Hobby xml:lang="ja">博物展観覧</imas:Hobby>
     <imas:Hobby xml:lang="ja">美術展</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20141"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20141"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tachibana_Arisu">
@@ -2785,7 +2785,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">5881C1</imas:Color>
     <imas:Hobby xml:lang="ja">読書（ミステリー）</imas:Hobby>
     <imas:Hobby xml:lang="ja">ゲーム</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20104"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20104"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sagisawa_Fumika">
@@ -2819,7 +2819,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1186964"/>
     <imas:Hobby xml:lang="ja">本屋めぐり</imas:Hobby>
     <imas:Hobby xml:lang="ja">栞作り</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20073"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20073"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yagami_Makino">
@@ -2849,7 +2849,7 @@
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">岐阜</schema:birthPlace>
     <imas:Hobby xml:lang="ja">諜報活動</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20175"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20175"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Layla">
@@ -2873,7 +2873,7 @@
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">ドバイ</schema:birthPlace>
     <imas:Hobby xml:lang="ja">公園で知らない人とおしゃべり</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20186"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20186"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Asari_Nanami">
@@ -2904,7 +2904,7 @@
     <schema:birthPlace xml:lang="ja">青森</schema:birthPlace>
     <imas:Hobby xml:lang="ja">絵日記</imas:Hobby>
     <imas:Hobby xml:lang="ja">釣り</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20008"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20008"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Helen">
@@ -2928,7 +2928,7 @@
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">海の向こう</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ＤＶＤ鑑賞</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20142"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20142"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Matsunaga_Ryo">
@@ -2962,7 +2962,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q6356324"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">202449</imas:Color>
     <imas:Hobby xml:lang="ja">ホラー映画鑑賞</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20150"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20150"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Komuro_Chinami">
@@ -2992,7 +2992,7 @@
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">愛知</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ダーツ</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20067"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20067"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takamine_Noa">
@@ -3022,7 +3022,7 @@
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">奈良</schema:birthPlace>
     <imas:Hobby xml:lang="ja">天体観測</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20101"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20101"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takagaki_Kaede">
@@ -3056,7 +3056,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1153079"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">33D5AC</imas:Color>
     <imas:Hobby xml:lang="ja">温泉めぐり</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20098"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20098"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kanzaki_Ranko">
@@ -3090,7 +3090,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q44552"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">7E3188</imas:Color>
     <imas:Hobby xml:lang="ja">絵を描くこと</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20044"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20044"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ijuin_Megumi">
@@ -3120,7 +3120,7 @@
     <imas:Constellation xml:lang="ja">天秤座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Hobby xml:lang="ja">一人旅</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20018"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20018"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hiiragi_Shino">
@@ -3150,7 +3150,7 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">山梨</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ワインツーリズム（産地巡り）</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20130"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20130"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hojo_Karen">
@@ -3184,7 +3184,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q9307208"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">38BAB8</imas:Color>
     <imas:Hobby xml:lang="ja">ネイル</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20143"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20143"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kate">
@@ -3208,7 +3208,7 @@
     <imas:Constellation xml:lang="ja">獅子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">イギリス</schema:birthPlace>
     <imas:Hobby xml:lang="ja">日本の雑誌を見るコト</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20060"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20060"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sena_Shiori">
@@ -3238,7 +3238,7 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">沖縄</schema:birthPlace>
     <imas:Hobby xml:lang="ja">海沿いを散歩</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20095"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20095"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ayase_Honoka">
@@ -3268,7 +3268,7 @@
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">宮城</schema:birthPlace>
     <imas:Hobby xml:lang="ja">バレエ</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20011"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20011"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sajo_Yukimi">
@@ -3301,7 +3301,7 @@
     <!-- <imas:cv rdf:resource="http://ja.dbpedia.org/resource/中澤ミナ"/> -->
     <!-- <imas:cv rdf:resource="http://www.wikidata.org/entity/Q0000000"/> -->
     <imas:Hobby xml:lang="ja">ペット（黒猫）と会話</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20077"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20077"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shinohara_Rei">
@@ -3331,7 +3331,7 @@
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">宮崎</schema:birthPlace>
     <imas:Hobby xml:lang="ja">社交ダンス</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20082"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20082"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Wakui_Rumi">
@@ -3361,7 +3361,7 @@
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">広島</schema:birthPlace>
     <imas:Hobby xml:lang="ja">仕事</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20190"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20190"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yoshioka_Saki">
@@ -3391,7 +3391,7 @@
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ストリートアート</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20184"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20184"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Umeki_Otoha">
@@ -3422,7 +3422,7 @@
     <schema:birthPlace xml:lang="ja">北海道</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ピアノ</imas:Hobby>
     <imas:Hobby xml:lang="ja">森林浴</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20025"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20025"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shirasaka_Koume">
@@ -3457,7 +3457,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">AAC5E2</imas:Color>
     <imas:Hobby xml:lang="ja">心霊スポット巡り</imas:Hobby>
     <imas:Hobby xml:lang="ja">ホラー・スプラッタ映画鑑賞</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20089"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20089"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kishibe_Ayaka">
@@ -3489,7 +3489,7 @@
     <imas:Hobby xml:lang="ja">ネイルアート</imas:Hobby>
     <imas:Hobby xml:lang="ja">エステ</imas:Hobby>
     <imas:Hobby xml:lang="ja">岩盤浴</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20045"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20045"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ujiie_Mutsumi">
@@ -3520,7 +3520,7 @@
     <schema:birthPlace xml:lang="ja">栃木</schema:birthPlace>
     <imas:Hobby xml:lang="ja">冒険小説を読む</imas:Hobby>
     <imas:Hobby xml:lang="ja">冒険映画を見る事</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20024"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20024"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nishikawa_Honami">
@@ -3551,7 +3551,7 @@
     <schema:birthPlace xml:lang="ja">兵庫</schema:birthPlace>
     <imas:Hobby xml:lang="ja">オペラ鑑賞</imas:Hobby>
     <imas:Hobby xml:lang="ja">宝塚鑑賞</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20118"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20118"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Narumiya_Yume">
@@ -3582,7 +3582,7 @@
     <schema:birthPlace xml:lang="ja">滋賀</schema:birthPlace>
     <imas:Hobby xml:lang="ja">水彩画</imas:Hobby>
     <imas:Hobby xml:lang="ja">写生</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20115"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20115"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Fujii_Tomo">
@@ -3612,7 +3612,7 @@
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">滋賀</schema:birthPlace>
     <imas:Hobby xml:lang="ja">占い</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20137"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20137"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shiomi_Syuko">
@@ -3647,7 +3647,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">DEE2EB</imas:Color>
     <imas:Hobby xml:lang="ja">献血</imas:Hobby>
     <imas:Hobby xml:lang="ja">ダーツ</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20081"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20081"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Wakiyama_Tamami">
@@ -3682,7 +3682,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">3A75BB</imas:Color>
     <imas:Hobby xml:lang="ja">時代小説を読むこと</imas:Hobby>
     <imas:Hobby xml:lang="ja">剣道</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20189"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20189"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Okazaki_Yasuha">
@@ -3712,7 +3712,7 @@
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">長崎</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ドールハウス作り</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20036"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20036"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hayami_Kanade">
@@ -3746,7 +3746,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11666486"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">0D386D</imas:Color>
     <imas:Hobby xml:lang="ja">映画鑑賞</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20128"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20128"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ohishi_Izumi">
@@ -3776,7 +3776,7 @@
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">静岡</schema:birthPlace>
     <imas:Hobby xml:lang="ja">プログラミング</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20030"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20030"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Matsuo_Chizuru">
@@ -3807,7 +3807,7 @@
     <schema:birthPlace xml:lang="ja">福岡</schema:birthPlace>
     <imas:Hobby xml:lang="ja">勉強</imas:Hobby>
     <imas:Hobby xml:lang="ja">習字</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20149"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20149"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Morikubo_Nono">
@@ -3842,7 +3842,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">97D3D3</imas:Color>
     <imas:Hobby xml:lang="ja">ポエム作り</imas:Hobby>
     <imas:Hobby xml:lang="ja">少女漫画集め</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20172"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20172"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Anastasia">
@@ -3871,7 +3871,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">B0C5E4</imas:Color>
     <imas:Hobby xml:lang="ja">ホームパーティ</imas:Hobby>
     <imas:Hobby xml:lang="ja">天体観測</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20009"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20009"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yamato_Aki">
@@ -3906,7 +3906,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">276E4E</imas:Color>
     <imas:Hobby xml:lang="ja">サバゲー</imas:Hobby>
     <imas:Hobby xml:lang="ja">プラモ収集</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20179"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20179"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yuuki_Haru">
@@ -3940,7 +3940,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q20039931"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">45BDB4</imas:Color>
     <imas:Hobby xml:lang="ja">サッカー</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20180"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20180"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ninomiya_Asuka">
@@ -3976,7 +3976,7 @@
     <imas:Hobby xml:lang="ja">ヘアアレンジ</imas:Hobby>
     <imas:Hobby xml:lang="ja">ラジオを聴くこと</imas:Hobby>
     <imas:Hobby xml:lang="ja">漫画を描くこと</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20121"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20121"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kiryu_Tsukasa">
@@ -4008,7 +4008,7 @@
     <imas:Hobby xml:lang="ja">異業種交流</imas:Hobby>
     <imas:Hobby xml:lang="ja">ホットヨガ</imas:Hobby>
     <imas:Hobby xml:lang="ja">ぬか床の世話</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20053"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20053"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mochizuki_Hijiri">
@@ -4038,7 +4038,7 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">長野</schema:birthPlace>
     <imas:Hobby xml:lang="ja">歌を口ずさむこと</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20170"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20170"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takafuji_Kako">
@@ -4072,7 +4072,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q55875405"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">5C068F</imas:Color>
     <imas:Hobby xml:lang="ja">隠し芸</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20100"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20100"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sunazuka_Akira">
@@ -4104,7 +4104,7 @@
     <imas:Hobby xml:lang="ja">ファッション</imas:Hobby>
     <imas:Hobby xml:lang="ja">動画配信</imas:Hobby>
     <imas:Hobby xml:lang="ja">FPS</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20093"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20093"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hisakawa_Hayate">
@@ -4139,7 +4139,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">7ADAD6</imas:Color>
     <imas:Hobby xml:lang="ja">ファッション</imas:Hobby>
     <imas:Hobby xml:lang="ja">流行りの店巡り</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20132"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20132"/>
   </rdf:Description>
 
   <!--Passion-->
@@ -4174,7 +4174,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q333320"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F6B128</imas:Color>
     <imas:Hobby xml:lang="ja">ショッピング</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20146"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20146"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takamori_Aiko">
@@ -4208,7 +4208,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q4358562"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">C5DD7F</imas:Color>
     <imas:Hobby xml:lang="ja">近所の公園をお散歩</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20102"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20102"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Namiki_Meiko">
@@ -4238,7 +4238,7 @@
     <imas:Constellation xml:lang="ja">天秤座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">和歌山</schema:birthPlace>
     <imas:Hobby xml:lang="ja">旅行</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20114"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20114"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ryuzaki_Kaoru">
@@ -4272,7 +4272,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q24875141"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F4D956</imas:Color>
     <imas:Hobby xml:lang="ja">料理</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20187"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20187"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kimura_Natsuki">
@@ -4306,7 +4306,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11451654"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">55565A</imas:Color>
     <imas:Hobby xml:lang="ja">ツーリング</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20050"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20050"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Matsuyama_Kumiko">
@@ -4336,7 +4336,7 @@
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ピアノ</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20153"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20153"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Saito_Yoko">
@@ -4366,7 +4366,7 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">福岡</schema:birthPlace>
     <imas:Hobby xml:lang="ja">半身浴</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20070"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20070"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sawada_Marina">
@@ -4396,7 +4396,7 @@
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">長野</schema:birthPlace>
     <imas:Hobby xml:lang="ja">サーフィン</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20079"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20079"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yaguchi_Miu">
@@ -4426,7 +4426,7 @@
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">千葉</schema:birthPlace>
     <imas:Hobby xml:lang="ja">メール</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20176"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20176"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akagi_Miria">
@@ -4460,7 +4460,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1955926"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F8C715</imas:Color>
     <imas:Hobby xml:lang="ja">おしゃべり</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20005"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20005"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Aino_Nagisa">
@@ -4490,7 +4490,7 @@
     <imas:Constellation xml:lang="ja">獅子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">愛知</schema:birthPlace>
     <imas:Hobby xml:lang="ja">バスケットボール</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20002"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20002"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Manabe_Itsuki">
@@ -4520,7 +4520,7 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">石川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">とにかく運動</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20156"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20156"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ohtsuki_Yui">
@@ -4554,7 +4554,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17223371"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EFB817</imas:Color>
     <imas:Hobby xml:lang="ja">カラオケ</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20032"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20032"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Himekawa_Yuki">
@@ -4588,7 +4588,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11523609"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E9870C</imas:Color>
     <imas:Hobby xml:lang="ja">野球観戦</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20134"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20134"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kitami_Yuzu">
@@ -4622,7 +4622,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q40039788"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EADC62</imas:Color>
     <imas:Hobby xml:lang="ja">バドミントン</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20048"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20048"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ueda_Suzuho">
@@ -4656,7 +4656,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q18818006"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">C9870F</imas:Color>
     <imas:Hobby xml:lang="ja">裁縫</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20023"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20023"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ebihara_Naho">
@@ -4687,7 +4687,7 @@
     <schema:birthPlace xml:lang="ja">熊本</schema:birthPlace>
     <imas:Hobby xml:lang="ja">散歩</imas:Hobby>
     <imas:Hobby xml:lang="ja">和菓子屋さん巡り</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20028"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20028"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Oikawa_Shizuku">
@@ -4722,7 +4722,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">FFFFFF</imas:Color>
     <imas:Hobby xml:lang="ja">乳搾り</imas:Hobby>
     <imas:Hobby xml:lang="ja">トラクターの運転</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20029"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20029"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Koseki_Reina">
@@ -4755,7 +4755,7 @@
     <!--<imas:cv rdf:resource="http://ja.dbpedia.org/resource/長野佑紀"/>-->
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q30108577"/>
     <imas:Hobby xml:lang="ja">いたずら</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20063"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20063"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Etou_Misaki">
@@ -4786,7 +4786,7 @@
     <schema:birthPlace xml:lang="ja">大分</schema:birthPlace>
     <imas:Hobby xml:lang="ja">女子力アップ</imas:Hobby>
     <imas:Hobby xml:lang="ja">携帯小説</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20027"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20027"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hoshi_Syoko">
@@ -4820,7 +4820,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17230362"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">A21D3C</imas:Color>
     <imas:Hobby xml:lang="ja">キノコ栽培</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20144"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20144"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Katagiri_Sanae">
@@ -4855,7 +4855,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E94D1A</imas:Color>
     <imas:Hobby xml:lang="ja">マッサージ</imas:Hobby>
     <imas:Hobby xml:lang="ja">スーパー銭湯</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20040"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20040"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hori_Yuko">
@@ -4889,7 +4889,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17160003"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E89B55</imas:Color>
     <imas:Hobby xml:lang="ja">サイキックトレーニング</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20145"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20145"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nishijima_Kai">
@@ -4919,7 +4919,7 @@
     <imas:Constellation xml:lang="ja">獅子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">大阪</schema:birthPlace>
     <imas:Hobby xml:lang="ja">水族館巡り</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20119"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20119"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Matoba_Risa">
@@ -4953,7 +4953,7 @@
     <!-- <imas:cv rdf:resource="http://www.wikidata.org/entity/Q0000000"/> -->
     <imas:Hobby xml:lang="ja">ダンス</imas:Hobby>
     <imas:Hobby xml:lang="ja">パパとデート</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20154"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20154"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Zaizen_Tokiko">
@@ -4984,7 +4984,7 @@
     <schema:birthPlace xml:lang="ja">名古屋</schema:birthPlace>
     <imas:Hobby xml:lang="ja">豚を料理すること</imas:Hobby>
     <imas:Hobby xml:lang="ja">お仕置き</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20069"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20069"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yorita_Yoshino">
@@ -5020,7 +5020,7 @@
     <imas:Hobby xml:lang="ja">悩み事解決</imas:Hobby>
     <imas:Hobby xml:lang="ja">石ころ集め</imas:Hobby>
     <imas:Hobby xml:lang="ja">失せ物探し</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20185"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20185"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Aiba_Yumi">
@@ -5054,7 +5054,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q18048266"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EAE28D</imas:Color>
     <imas:Hobby xml:lang="ja">ガーデニング</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20003"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20003"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nonomura_Sora">
@@ -5084,7 +5084,7 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">福岡</schema:birthPlace>
     <imas:Hobby xml:lang="ja">友達と電話</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20123"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20123"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hamakawa_Ayuna">
@@ -5114,7 +5114,7 @@
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">大阪</schema:birthPlace>
     <imas:Hobby xml:lang="ja">乗馬</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20125"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20125"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Wakabayashi_Tomoka">
@@ -5144,7 +5144,7 @@
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">鹿児島</schema:birthPlace>
     <imas:Hobby xml:lang="ja">チアリーディング</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20188"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20188"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Jougasaki_Mika">
@@ -5178,7 +5178,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11385438"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F4982B</imas:Color>
     <imas:Hobby xml:lang="ja">カラオケ</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20086"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20086"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Jougasaki_Rika">
@@ -5212,7 +5212,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q9080262"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F7D30D</imas:Color>
     <imas:Hobby xml:lang="ja">シール集め</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20087"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20087"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Senzaki_Ema">
@@ -5242,7 +5242,7 @@
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">大阪</schema:birthPlace>
     <imas:Hobby xml:lang="ja">革小物集め</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20096"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20096"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hino_Akane">
@@ -5276,7 +5276,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q5100189"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EA4F21</imas:Color>
     <imas:Hobby xml:lang="ja">ラグビー観戦</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20133"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20133"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Moroboshi_Kirari">
@@ -5310,7 +5310,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q391799"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F8CA02</imas:Color>
     <imas:Hobby xml:lang="ja">かわいい物集め</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20173"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20173"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Totoki_Airi">
@@ -5344,7 +5344,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1046994"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E9425C</imas:Color>
     <imas:Hobby xml:lang="ja">ケーキ作り</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20110"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20110"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Natalia">
@@ -5371,7 +5371,7 @@
     <!--<imas:cv rdf:resource="http://ja.dbpedia.org/resource/生田輝"/>-->
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q66736457"/>
     <imas:Hobby xml:lang="ja">ベリーダンス</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20113"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20113"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Souma_Natsumi">
@@ -5401,7 +5401,7 @@
     <imas:Constellation xml:lang="ja">獅子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">京都</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ランニング</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20097"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20097"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Makihara_Shiho">
@@ -5431,7 +5431,7 @@
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">三重</schema:birthPlace>
     <imas:Hobby xml:lang="ja">スイーツめぐり</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20148"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20148"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mukai_Takumi">
@@ -5465,7 +5465,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17221306"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">A90582</imas:Color>
     <imas:Hobby xml:lang="ja">バイクいじり</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20164"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20164"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ichihara_Nina">
@@ -5499,7 +5499,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11369771"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F7DE8C</imas:Color>
     <imas:Hobby xml:lang="ja">着ぐるみ集め</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20020"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20020"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kita_Hinako">
@@ -5533,7 +5533,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17209690"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F4D059</imas:Color>
     <imas:Hobby xml:lang="ja">妄想</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20046"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20046"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sugisaka_Umi">
@@ -5563,7 +5563,7 @@
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">山口</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ウインドサーフィン</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20091"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20091"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kitagawa_Mahiro">
@@ -5595,7 +5595,7 @@
     <imas:Hobby xml:lang="ja">走ること</imas:Hobby>
     <imas:Hobby xml:lang="ja">食べること</imas:Hobby>
     <imas:Hobby xml:lang="ja">寝ること</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20047"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20047"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mary_Cochran">
@@ -5626,7 +5626,7 @@
     <schema:birthPlace xml:lang="ja">サンフランシスコ</schema:birthPlace>
     <imas:Hobby xml:lang="ja">女磨き</imas:Hobby>
     <imas:Hobby xml:lang="ja">グルメツアー</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20168"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20168"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Komatsu_Ibuki">
@@ -5658,7 +5658,7 @@
     <imas:Hobby xml:lang="ja">ストリートダンス</imas:Hobby>
     <imas:Hobby xml:lang="ja">スケボー</imas:Hobby>
     <imas:Hobby xml:lang="ja">恋愛映画を見る事</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20066"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20066"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Miyoshi_Sana">
@@ -5689,7 +5689,7 @@
     <schema:birthPlace xml:lang="ja">香川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ＴＶゲーム</imas:Hobby>
     <imas:Hobby xml:lang="ja">夜更かし</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20163"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20163"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Cathy_Graham">
@@ -5720,7 +5720,7 @@
     <schema:birthPlace xml:lang="ja">ニューヨーク</schema:birthPlace>
     <imas:Hobby xml:lang="ja">インラインスケート</imas:Hobby>
     <imas:Hobby xml:lang="ja">ダンス</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20051"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20051"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Namba_Emi">
@@ -5755,7 +5755,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E9463D</imas:Color>
     <imas:Hobby xml:lang="ja">お笑いライブ巡り</imas:Hobby>
     <imas:Hobby xml:lang="ja">モノマネ</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20117"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20117"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hamaguchi_Ayame">
@@ -5791,7 +5791,7 @@
     <imas:Hobby xml:lang="ja">撮影所巡り</imas:Hobby>
     <imas:Hobby xml:lang="ja">忍者グッズ収集</imas:Hobby>
     <imas:Hobby xml:lang="ja">時代劇鑑賞</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20126"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20126"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Murakami_Tomoe">
@@ -5826,7 +5826,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D42E38</imas:Color>
     <imas:Hobby xml:lang="ja">演歌</imas:Hobby>
     <imas:Hobby xml:lang="ja">将棋</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20166"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20166"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tsuchiya_Ako">
@@ -5857,7 +5857,7 @@
     <schema:birthPlace xml:lang="ja">静岡</schema:birthPlace>
     <imas:Hobby xml:lang="ja">食べること</imas:Hobby>
     <imas:Hobby xml:lang="ja">貯金</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20107"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20107"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shuto_Aoi">
@@ -5887,7 +5887,7 @@
     <imas:Constellation xml:lang="ja">獅子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">大分</schema:birthPlace>
     <imas:Hobby xml:lang="ja">魚さばき</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20085"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20085"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Saejima_Kiyomi">
@@ -5919,7 +5919,7 @@
     <imas:Hobby xml:lang="ja">掃除</imas:Hobby>
     <imas:Hobby xml:lang="ja">整理整頓</imas:Hobby>
     <imas:Hobby xml:lang="ja">腕章作り</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20071"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20071"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sato_Shin">
@@ -5954,7 +5954,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E44E8E</imas:Color>
     <imas:Hobby xml:lang="ja">ドレスアップ</imas:Hobby>
     <imas:Hobby xml:lang="ja">衣装作り</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20078"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20078"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nanjo_Hikaru">
@@ -5989,7 +5989,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">ED0829</imas:Color>
     <imas:Hobby xml:lang="ja">特撮番組鑑賞</imas:Hobby>
     <imas:Hobby xml:lang="ja">特撮ごっこ</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20116"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20116"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Eve_Santaclaus">
@@ -6019,7 +6019,7 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">グリーンランド</schema:birthPlace>
     <imas:Hobby xml:lang="ja">煙突探し</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20015"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20015"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yumemi_Riamu">
@@ -6053,7 +6053,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q35172322"/>
     <imas:Hobby xml:lang="ja">夜中の意味深ポエム</imas:Hobby>
     <imas:Hobby xml:lang="ja">現場参戦</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20182"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20182"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hisakawa_Nagi">
@@ -6089,7 +6089,7 @@
     <imas:Hobby xml:lang="ja">写真</imas:Hobby>
     <imas:Hobby xml:lang="ja">ポエム</imas:Hobby>
     <imas:Hobby xml:lang="ja">読書（新書）</imas:Hobby>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20131"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20131"/>
   </rdf:Description>
 
 </rdf:RDF>

--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -4,6 +4,7 @@
     xmlns:foaf="http://xmlns.com/foaf/0.1/"
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xmlns:imas="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
     xml:base="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/"
   >
 
@@ -39,6 +40,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EC7092</imas:Color>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Hobby xml:lang="ja">友達と長電話</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20084"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nakano_Yuka">
@@ -72,6 +74,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17159583"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">CB78B0</imas:Color>
     <imas:Hobby xml:lang="ja">空手</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20112"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mizumoto_Yukari">
@@ -105,6 +108,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17211589"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E8BAD6</imas:Color>
     <imas:Hobby xml:lang="ja">フルート</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20159"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Fukuyama_Mai">
@@ -134,6 +138,7 @@
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">兵庫</schema:birthPlace>
     <imas:Hobby xml:lang="ja">一輪車</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20136"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shiina_Noriko">
@@ -167,6 +172,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17161754"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EA495B</imas:Color>
     <imas:Hobby xml:lang="ja">新作ドーナツの試食</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20080"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Imai_Kana">
@@ -196,6 +202,7 @@
     <imas:Constellation xml:lang="ja">魚座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">高知</schema:birthPlace>
     <imas:Hobby xml:lang="ja">友達とおしゃべり</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20021"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mochida_Arisa">
@@ -225,6 +232,7 @@
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">長野</schema:birthPlace>
     <imas:Hobby xml:lang="ja">子供と遊ぶこと</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20169"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mimura_Kanako">
@@ -258,6 +266,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q3211762"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F4ABB4</imas:Color>
     <imas:Hobby xml:lang="ja">お菓子作り</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20161"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Okuyama_Saori">
@@ -287,6 +296,7 @@
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">秋田</schema:birthPlace>
     <imas:Hobby xml:lang="ja">読書</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20038"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Manaka_Misato">
@@ -316,6 +326,7 @@
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">旅行</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20155"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kohinata_Miho">
@@ -349,6 +360,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q901835"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">C64796</imas:Color>
     <imas:Hobby xml:lang="ja">ひなたぼっこ</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20065"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ogata_Chieri">
@@ -382,6 +394,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q15731362"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">69B64C</imas:Color>
     <imas:Hobby xml:lang="ja">四葉のクローバー集め</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20037"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Igarashi_Kyoko">
@@ -415,6 +428,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q3183413"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F567C6</imas:Color>
     <imas:Hobby xml:lang="ja">家事全般</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20016"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yanase_Miyuki">
@@ -444,6 +458,7 @@
     <imas:Constellation xml:lang="ja">魚座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">北海道</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ぬいぐるみ集め</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20178"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sakurai_Momoka">
@@ -477,6 +492,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11567752"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EF93BC</imas:Color>
     <imas:Hobby xml:lang="ja">ティータイム</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20075"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Egami_Tsubaki">
@@ -506,6 +522,7 @@
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">新潟</schema:birthPlace>
     <imas:Hobby xml:lang="ja">写真を撮ること</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20026"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nagatomi_Hasumi">
@@ -536,6 +553,7 @@
     <schema:birthPlace xml:lang="ja">島根</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ボウリング</imas:Hobby>
     <imas:Hobby xml:lang="ja">古着屋巡り</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20111"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yokoyama_Chika">
@@ -565,6 +583,7 @@
     <imas:Constellation xml:lang="ja">射手座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">宮崎</schema:birthPlace>
     <imas:Hobby xml:lang="ja">魔法少女ごっこ</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20183"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Seki_Hiromi">
@@ -598,6 +617,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q41585491"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F8C5C1</imas:Color>
     <imas:Hobby xml:lang="ja">アクセサリー作り</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20094"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ohta_Yuu">
@@ -628,6 +648,7 @@
     <schema:birthPlace xml:lang="ja">千葉</schema:birthPlace>
     <imas:Hobby xml:lang="ja">犬のトリミング</imas:Hobby>
     <imas:Hobby xml:lang="ja">美容</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20031"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Munakata_Atsumi">
@@ -661,6 +682,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q56118632"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">C82F7F</imas:Color>
     <imas:Hobby xml:lang="ja">指の運動</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20165"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Fujimoto_Rina">
@@ -695,6 +717,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">653A2A</imas:Color>
     <imas:Hobby xml:lang="ja">単車乗り</imas:Hobby>
     <imas:Hobby xml:lang="ja">コンビニで立ち読み</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20138"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ohara_Michiru">
@@ -724,6 +747,7 @@
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">福井</schema:birthPlace>
     <imas:Hobby xml:lang="ja">食べること</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20035"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yusa_Kozue">
@@ -756,6 +780,7 @@
     <!-- <imas:cv rdf:resource="http://ja.dbpedia.org/page/花谷麻妃"/> -->
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q24873835"/>
     <imas:Hobby xml:lang="ja">しゅみってなぁに？</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20181"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ohnuma_Kurumi">
@@ -786,6 +811,7 @@
     <schema:birthPlace xml:lang="ja">石川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ポケットティッシュ収集</imas:Hobby>
     <imas:Hobby xml:lang="ja">お風呂に入ること</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20034"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ichinose_Shiki">
@@ -821,6 +847,7 @@
     <imas:Hobby xml:lang="ja">失踪</imas:Hobby>
     <imas:Hobby xml:lang="ja">アヤしい科学実験</imas:Hobby>
     <imas:Hobby xml:lang="ja">観察</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20019"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Maekawa_Miku">
@@ -854,6 +881,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1107456"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">CA113A</imas:Color>
     <imas:Hobby xml:lang="ja">猫カフェ巡り</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20147"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akanishi_Erika">
@@ -883,6 +911,7 @@
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">岡山</schema:birthPlace>
     <imas:Hobby xml:lang="ja">漫才鑑賞</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20006"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Matsubara_Saya">
@@ -912,6 +941,7 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">兵庫</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ブログ</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20151"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Aihara_Yukino">
@@ -941,6 +971,7 @@
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">秋田</schema:birthPlace>
     <imas:Hobby xml:lang="ja">紅茶</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20004"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Miyamoto_Frederica">
@@ -974,6 +1005,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q62024404"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">9E1861</imas:Color>
     <imas:Hobby xml:lang="ja">ファッション</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20162"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kobayakawa_Sae">
@@ -1007,6 +1039,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q9046310"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D967A3</imas:Color>
     <imas:Hobby xml:lang="ja">日本舞踊</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20064"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Saionji_Kotoka">
@@ -1036,6 +1069,7 @@
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Hobby xml:lang="ja">押し花作り</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20068"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Futaba_Anzu">
@@ -1069,6 +1103,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q5770504"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F19DB4</imas:Color>
     <imas:Hobby xml:lang="ja">なし</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20140"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yao_Fueifuei">
@@ -1098,6 +1133,7 @@
     <imas:Constellation xml:lang="ja">天秤座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">香港</schema:birthPlace>
     <imas:Hobby xml:lang="ja">料理</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20174"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Momoi_Azuki">
@@ -1127,6 +1163,7 @@
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">長野</schema:birthPlace>
     <imas:Hobby xml:lang="ja">金魚すくい</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20171"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Suzumiya_Seika">
@@ -1156,6 +1193,7 @@
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">岐阜</schema:birthPlace>
     <imas:Hobby xml:lang="ja">バイオリン</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20092"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tsukimiya_Miyabi">
@@ -1185,6 +1223,7 @@
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ママとショッピング</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20105"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hyodo_Rena">
@@ -1214,6 +1253,7 @@
     <imas:Constellation xml:lang="ja">天秤座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Hobby xml:lang="ja">トランプ</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20135"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Niwa_Hitomi">
@@ -1244,6 +1284,7 @@
     <schema:birthPlace xml:lang="ja">名古屋</schema:birthPlace>
     <imas:Hobby xml:lang="ja">史跡巡り</imas:Hobby>
     <imas:Hobby xml:lang="ja">武将グッズ収集</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20122"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Domyoji_Karin">
@@ -1277,6 +1318,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17212219"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">CC252D</imas:Color>
     <imas:Hobby xml:lang="ja">境内のお掃除</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20109"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yanagi_Kiyora">
@@ -1306,6 +1348,7 @@
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">愛媛</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ドキュメンタリー番組鑑賞</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20177"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Imura_Setsuna">
@@ -1335,6 +1378,7 @@
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">秋田</schema:birthPlace>
     <imas:Hobby xml:lang="ja">メイク小物集め</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20022"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kusakabe_Wakaba">
@@ -1364,6 +1408,7 @@
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">群馬</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ジグソーパズル</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20054"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sakakibara_Satomi">
@@ -1393,6 +1438,7 @@
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">山形</schema:birthPlace>
     <imas:Hobby xml:lang="ja">甘いお菓子を食べること</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20072"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Koshimizu_Sachiko">
@@ -1426,6 +1472,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1204576"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">CCAACF</imas:Color>
     <imas:Hobby xml:lang="ja">勉強ノートの清書</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20062"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Anzai_Miyako">
@@ -1456,6 +1503,7 @@
     <schema:birthPlace xml:lang="ja">福井</schema:birthPlace>
     <imas:Hobby xml:lang="ja">探偵ドラマ</imas:Hobby>
     <imas:Hobby xml:lang="ja">推理小説を見ること</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20014"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Asano_Fuka">
@@ -1485,6 +1533,7 @@
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">滋賀</schema:birthPlace>
     <imas:Hobby xml:lang="ja">小説を書くこと</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20007"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ohnishi_Yuriko">
@@ -1515,6 +1564,7 @@
     <schema:birthPlace xml:lang="ja">香川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ネットサーフィン</imas:Hobby>
     <imas:Hobby xml:lang="ja">読書</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20033"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Abe_Nana">
@@ -1548,6 +1598,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q6127820"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E64A79</imas:Color>
     <imas:Hobby xml:lang="ja">ウサミン星との交信</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20010"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kudo_Shinobu">
@@ -1577,6 +1628,7 @@
     <imas:Constellation xml:lang="ja">魚座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">青森</schema:birthPlace>
     <imas:Hobby xml:lang="ja">おまけ集め</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20055"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kurihara_Nene">
@@ -1607,6 +1659,7 @@
     <schema:birthPlace xml:lang="ja">群馬</schema:birthPlace>
     <imas:Hobby xml:lang="ja">テレビ鑑賞</imas:Hobby>
     <imas:Hobby xml:lang="ja">健康作り</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20057"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Koga_Koharu">
@@ -1637,6 +1690,7 @@
     <schema:birthPlace xml:lang="ja">佐賀</schema:birthPlace>
     <imas:Hobby xml:lang="ja">イグアナのヒョウくんと遊ぶこと</imas:Hobby>
     <imas:Hobby xml:lang="ja">家のお手伝い</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20061"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Clarice">
@@ -1660,6 +1714,7 @@
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">兵庫</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ボランティア</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20056"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sakuma_Mayu">
@@ -1694,6 +1749,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D1197B</imas:Color>
     <imas:Hobby xml:lang="ja">お料理</imas:Hobby>
     <imas:Hobby xml:lang="ja">編み物</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20074"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Muramatsu_Sakura">
@@ -1723,6 +1779,7 @@
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">静岡</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ピンクのもの集め</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20167"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shiragiku_Hotaru">
@@ -1757,6 +1814,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D162CB</imas:Color>
     <imas:Hobby xml:lang="ja">アイドルレッスン</imas:Hobby>
     <imas:Hobby xml:lang="ja">笑顔の練習</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20088"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hayasaka_Mirei">
@@ -1790,6 +1848,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17685820"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">B72089</imas:Color>
     <imas:Hobby xml:lang="ja">ぬいぐるみ集め</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20127"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ariura_Kanna">
@@ -1819,6 +1878,7 @@
     <imas:Constellation xml:lang="ja">魚座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">長崎</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ラブ＆ピース</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20013"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Otokura_Yuuki">
@@ -1853,6 +1913,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F2C0C1</imas:Color>
     <imas:Hobby xml:lang="ja">ミックスジュース作り</imas:Hobby>
     <imas:Hobby xml:lang="ja">スクラップブック作り</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20039"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Harada_Miyo">
@@ -1883,6 +1944,7 @@
     <schema:birthPlace xml:lang="ja">石川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">バイクいじり</imas:Hobby>
     <imas:Hobby xml:lang="ja">クルマ</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20129"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ikebukuro_Akiha">
@@ -1912,6 +1974,7 @@
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ロボット制作</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20017"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tsujino_Akari">
@@ -1942,6 +2005,7 @@
     <schema:birthPlace xml:lang="ja">山形</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ラーメン</imas:Hobby>
     <imas:Hobby xml:lang="ja">編み物</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20106"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shirayuki_Chiyo">
@@ -1975,6 +2039,7 @@
     <schema:birthPlace xml:lang="ja">北海道</schema:birthPlace>
     <imas:Hobby xml:lang="ja">料理</imas:Hobby>
     <imas:Hobby xml:lang="ja">睡眠</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20090"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kurosaki_Chitose">
@@ -2008,6 +2073,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Hobby xml:lang="ja">美味しいものを食べること</imas:Hobby>
     <imas:Hobby xml:lang="ja">月光浴</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20059"/>
   </rdf:Description>
 
   <!--Cool-->
@@ -2042,6 +2108,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11591879"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">1C90CD</imas:Color>
     <imas:Hobby xml:lang="ja">犬の散歩</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20083"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kurokawa_Chiaki">
@@ -2071,6 +2138,7 @@
     <imas:Constellation xml:lang="ja">魚座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">北海道</schema:birthPlace>
     <imas:Hobby xml:lang="ja">クラシック鑑賞</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20058"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Matsumoto_Sarina">
@@ -2100,6 +2168,7 @@
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ショッピング</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20152"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kirino_Aya">
@@ -2129,6 +2198,7 @@
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">福岡</schema:birthPlace>
     <imas:Hobby xml:lang="ja">格闘技観戦</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20052"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takahashi_Reiko">
@@ -2158,6 +2228,7 @@
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">パーティーに行くこと</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20099"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Aikawa_Chinatsu">
@@ -2187,6 +2258,7 @@
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">北海道</schema:birthPlace>
     <imas:Hobby xml:lang="ja">カフェで読書</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20001"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kawashima_Mizuki">
@@ -2221,6 +2293,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">3F59A6</imas:Color>
     <imas:Hobby xml:lang="ja">掃除</imas:Hobby>
     <imas:Hobby xml:lang="ja">洗濯</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20043"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kamiya_Nao">
@@ -2254,6 +2327,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11529115"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">8D75B3</imas:Color>
     <imas:Hobby xml:lang="ja">アニメ鑑賞</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20042"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kamijo_Haruna">
@@ -2287,6 +2361,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q20041809"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">59B7DB</imas:Color>
     <imas:Hobby xml:lang="ja">猫と縁側でお昼寝</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20041"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Araki_Hina">
@@ -2320,6 +2395,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q16336231"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">80C260</imas:Color>
     <imas:Hobby xml:lang="ja">漫画描く</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20012"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Togo_Ai">
@@ -2349,6 +2425,7 @@
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">福島</schema:birthPlace>
     <imas:Hobby xml:lang="ja">サックス</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20108"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tada_Rina">
@@ -2382,6 +2459,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11661791"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">006DB2</imas:Color>
     <imas:Hobby xml:lang="ja">音楽鑑賞</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20103"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mizuki_Seira">
@@ -2411,6 +2489,7 @@
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">茨城</schema:birthPlace>
     <imas:Hobby xml:lang="ja">犬の散歩</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20157"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sasaki_Chie">
@@ -2444,6 +2523,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q8972760"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">006AB6</imas:Color>
     <imas:Hobby xml:lang="ja">裁縫</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20076"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mifune_Miyu">
@@ -2477,6 +2557,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q27507360"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">01AAA5</imas:Color>
     <imas:Hobby xml:lang="ja">アロマテラピー</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20160"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hattori_Toko">
@@ -2507,6 +2588,7 @@
     <schema:birthPlace xml:lang="ja">大分</schema:birthPlace>
     <imas:Hobby xml:lang="ja">熱帯魚観賞</imas:Hobby>
     <imas:Hobby xml:lang="ja">温泉めぐり</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20124"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kiba_Manami">
@@ -2537,6 +2619,7 @@
     <schema:birthPlace xml:lang="ja">長崎</schema:birthPlace>
     <imas:Hobby xml:lang="ja">料理</imas:Hobby>
     <imas:Hobby xml:lang="ja">筋トレ</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20049"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Fujiwara_Hajime">
@@ -2571,6 +2654,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">7271B3</imas:Color>
     <imas:Hobby xml:lang="ja">陶芸</imas:Hobby>
     <imas:Hobby xml:lang="ja">釣り</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20139"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nitta_Minami">
@@ -2605,6 +2689,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">6DBCDB</imas:Color>
     <imas:Hobby xml:lang="ja">ラクロス</imas:Hobby>
     <imas:Hobby xml:lang="ja">資格取得</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20120"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mizuno_Midori">
@@ -2634,6 +2719,7 @@
     <imas:Constellation xml:lang="ja">射手座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">愛知</schema:birthPlace>
     <imas:Hobby xml:lang="ja">弓道</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20158"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Furusawa_Yoriko">
@@ -2664,6 +2750,7 @@
     <schema:birthPlace xml:lang="ja">茨城</schema:birthPlace>
     <imas:Hobby xml:lang="ja">博物展観覧</imas:Hobby>
     <imas:Hobby xml:lang="ja">美術展</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20141"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tachibana_Arisu">
@@ -2698,6 +2785,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">5881C1</imas:Color>
     <imas:Hobby xml:lang="ja">読書（ミステリー）</imas:Hobby>
     <imas:Hobby xml:lang="ja">ゲーム</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20104"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sagisawa_Fumika">
@@ -2731,6 +2819,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1186964"/>
     <imas:Hobby xml:lang="ja">本屋めぐり</imas:Hobby>
     <imas:Hobby xml:lang="ja">栞作り</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20073"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yagami_Makino">
@@ -2760,6 +2849,7 @@
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">岐阜</schema:birthPlace>
     <imas:Hobby xml:lang="ja">諜報活動</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20175"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Layla">
@@ -2783,6 +2873,7 @@
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">ドバイ</schema:birthPlace>
     <imas:Hobby xml:lang="ja">公園で知らない人とおしゃべり</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20186"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Asari_Nanami">
@@ -2813,6 +2904,7 @@
     <schema:birthPlace xml:lang="ja">青森</schema:birthPlace>
     <imas:Hobby xml:lang="ja">絵日記</imas:Hobby>
     <imas:Hobby xml:lang="ja">釣り</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20008"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Helen">
@@ -2836,6 +2928,7 @@
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">海の向こう</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ＤＶＤ鑑賞</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20142"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Matsunaga_Ryo">
@@ -2869,6 +2962,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q6356324"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">202449</imas:Color>
     <imas:Hobby xml:lang="ja">ホラー映画鑑賞</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20150"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Komuro_Chinami">
@@ -2898,6 +2992,7 @@
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">愛知</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ダーツ</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20067"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takamine_Noa">
@@ -2927,6 +3022,7 @@
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">奈良</schema:birthPlace>
     <imas:Hobby xml:lang="ja">天体観測</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20101"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takagaki_Kaede">
@@ -2960,6 +3056,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1153079"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">33D5AC</imas:Color>
     <imas:Hobby xml:lang="ja">温泉めぐり</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20098"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kanzaki_Ranko">
@@ -2993,6 +3090,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q44552"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">7E3188</imas:Color>
     <imas:Hobby xml:lang="ja">絵を描くこと</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20044"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ijuin_Megumi">
@@ -3022,6 +3120,7 @@
     <imas:Constellation xml:lang="ja">天秤座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Hobby xml:lang="ja">一人旅</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20018"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hiiragi_Shino">
@@ -3051,6 +3150,7 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">山梨</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ワインツーリズム（産地巡り）</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20130"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hojo_Karen">
@@ -3084,6 +3184,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q9307208"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">38BAB8</imas:Color>
     <imas:Hobby xml:lang="ja">ネイル</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20143"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kate">
@@ -3107,6 +3208,7 @@
     <imas:Constellation xml:lang="ja">獅子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">イギリス</schema:birthPlace>
     <imas:Hobby xml:lang="ja">日本の雑誌を見るコト</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20060"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sena_Shiori">
@@ -3136,6 +3238,7 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">沖縄</schema:birthPlace>
     <imas:Hobby xml:lang="ja">海沿いを散歩</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20095"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ayase_Honoka">
@@ -3165,6 +3268,7 @@
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">宮城</schema:birthPlace>
     <imas:Hobby xml:lang="ja">バレエ</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20011"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sajo_Yukimi">
@@ -3197,6 +3301,7 @@
     <!-- <imas:cv rdf:resource="http://ja.dbpedia.org/resource/中澤ミナ"/> -->
     <!-- <imas:cv rdf:resource="http://www.wikidata.org/entity/Q0000000"/> -->
     <imas:Hobby xml:lang="ja">ペット（黒猫）と会話</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20077"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shinohara_Rei">
@@ -3226,6 +3331,7 @@
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">宮崎</schema:birthPlace>
     <imas:Hobby xml:lang="ja">社交ダンス</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20082"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Wakui_Rumi">
@@ -3255,6 +3361,7 @@
     <imas:Constellation xml:lang="ja">牡羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">広島</schema:birthPlace>
     <imas:Hobby xml:lang="ja">仕事</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20190"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yoshioka_Saki">
@@ -3284,6 +3391,7 @@
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ストリートアート</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20184"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Umeki_Otoha">
@@ -3314,6 +3422,7 @@
     <schema:birthPlace xml:lang="ja">北海道</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ピアノ</imas:Hobby>
     <imas:Hobby xml:lang="ja">森林浴</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20025"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shirasaka_Koume">
@@ -3348,6 +3457,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">AAC5E2</imas:Color>
     <imas:Hobby xml:lang="ja">心霊スポット巡り</imas:Hobby>
     <imas:Hobby xml:lang="ja">ホラー・スプラッタ映画鑑賞</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20089"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kishibe_Ayaka">
@@ -3379,6 +3489,7 @@
     <imas:Hobby xml:lang="ja">ネイルアート</imas:Hobby>
     <imas:Hobby xml:lang="ja">エステ</imas:Hobby>
     <imas:Hobby xml:lang="ja">岩盤浴</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20045"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ujiie_Mutsumi">
@@ -3409,6 +3520,7 @@
     <schema:birthPlace xml:lang="ja">栃木</schema:birthPlace>
     <imas:Hobby xml:lang="ja">冒険小説を読む</imas:Hobby>
     <imas:Hobby xml:lang="ja">冒険映画を見る事</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20024"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nishikawa_Honami">
@@ -3439,6 +3551,7 @@
     <schema:birthPlace xml:lang="ja">兵庫</schema:birthPlace>
     <imas:Hobby xml:lang="ja">オペラ鑑賞</imas:Hobby>
     <imas:Hobby xml:lang="ja">宝塚鑑賞</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20118"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Narumiya_Yume">
@@ -3469,6 +3582,7 @@
     <schema:birthPlace xml:lang="ja">滋賀</schema:birthPlace>
     <imas:Hobby xml:lang="ja">水彩画</imas:Hobby>
     <imas:Hobby xml:lang="ja">写生</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20115"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Fujii_Tomo">
@@ -3498,6 +3612,7 @@
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">滋賀</schema:birthPlace>
     <imas:Hobby xml:lang="ja">占い</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20137"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shiomi_Syuko">
@@ -3532,6 +3647,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">DEE2EB</imas:Color>
     <imas:Hobby xml:lang="ja">献血</imas:Hobby>
     <imas:Hobby xml:lang="ja">ダーツ</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20081"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Wakiyama_Tamami">
@@ -3566,6 +3682,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">3A75BB</imas:Color>
     <imas:Hobby xml:lang="ja">時代小説を読むこと</imas:Hobby>
     <imas:Hobby xml:lang="ja">剣道</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20189"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Okazaki_Yasuha">
@@ -3595,6 +3712,7 @@
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">長崎</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ドールハウス作り</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20036"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hayami_Kanade">
@@ -3628,6 +3746,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11666486"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">0D386D</imas:Color>
     <imas:Hobby xml:lang="ja">映画鑑賞</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20128"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ohishi_Izumi">
@@ -3657,6 +3776,7 @@
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">静岡</schema:birthPlace>
     <imas:Hobby xml:lang="ja">プログラミング</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20030"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Matsuo_Chizuru">
@@ -3687,6 +3807,7 @@
     <schema:birthPlace xml:lang="ja">福岡</schema:birthPlace>
     <imas:Hobby xml:lang="ja">勉強</imas:Hobby>
     <imas:Hobby xml:lang="ja">習字</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20149"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Morikubo_Nono">
@@ -3721,6 +3842,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">97D3D3</imas:Color>
     <imas:Hobby xml:lang="ja">ポエム作り</imas:Hobby>
     <imas:Hobby xml:lang="ja">少女漫画集め</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20172"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Anastasia">
@@ -3749,6 +3871,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">B0C5E4</imas:Color>
     <imas:Hobby xml:lang="ja">ホームパーティ</imas:Hobby>
     <imas:Hobby xml:lang="ja">天体観測</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20009"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yamato_Aki">
@@ -3783,6 +3906,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">276E4E</imas:Color>
     <imas:Hobby xml:lang="ja">サバゲー</imas:Hobby>
     <imas:Hobby xml:lang="ja">プラモ収集</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20179"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yuuki_Haru">
@@ -3816,6 +3940,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q20039931"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">45BDB4</imas:Color>
     <imas:Hobby xml:lang="ja">サッカー</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20180"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ninomiya_Asuka">
@@ -3851,6 +3976,7 @@
     <imas:Hobby xml:lang="ja">ヘアアレンジ</imas:Hobby>
     <imas:Hobby xml:lang="ja">ラジオを聴くこと</imas:Hobby>
     <imas:Hobby xml:lang="ja">漫画を描くこと</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20121"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kiryu_Tsukasa">
@@ -3882,6 +4008,7 @@
     <imas:Hobby xml:lang="ja">異業種交流</imas:Hobby>
     <imas:Hobby xml:lang="ja">ホットヨガ</imas:Hobby>
     <imas:Hobby xml:lang="ja">ぬか床の世話</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20053"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mochizuki_Hijiri">
@@ -3911,6 +4038,7 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">長野</schema:birthPlace>
     <imas:Hobby xml:lang="ja">歌を口ずさむこと</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20170"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takafuji_Kako">
@@ -3944,6 +4072,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q55875405"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">5C068F</imas:Color>
     <imas:Hobby xml:lang="ja">隠し芸</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20100"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sunazuka_Akira">
@@ -3975,6 +4104,7 @@
     <imas:Hobby xml:lang="ja">ファッション</imas:Hobby>
     <imas:Hobby xml:lang="ja">動画配信</imas:Hobby>
     <imas:Hobby xml:lang="ja">FPS</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20093"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hisakawa_Hayate">
@@ -4009,6 +4139,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">7ADAD6</imas:Color>
     <imas:Hobby xml:lang="ja">ファッション</imas:Hobby>
     <imas:Hobby xml:lang="ja">流行りの店巡り</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20132"/>
   </rdf:Description>
 
   <!--Passion-->
@@ -4043,6 +4174,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q333320"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F6B128</imas:Color>
     <imas:Hobby xml:lang="ja">ショッピング</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20146"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takamori_Aiko">
@@ -4076,6 +4208,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q4358562"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">C5DD7F</imas:Color>
     <imas:Hobby xml:lang="ja">近所の公園をお散歩</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20102"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Namiki_Meiko">
@@ -4105,6 +4238,7 @@
     <imas:Constellation xml:lang="ja">天秤座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">和歌山</schema:birthPlace>
     <imas:Hobby xml:lang="ja">旅行</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20114"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ryuzaki_Kaoru">
@@ -4138,6 +4272,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q24875141"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F4D956</imas:Color>
     <imas:Hobby xml:lang="ja">料理</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20187"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kimura_Natsuki">
@@ -4171,6 +4306,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11451654"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">55565A</imas:Color>
     <imas:Hobby xml:lang="ja">ツーリング</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20050"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Matsuyama_Kumiko">
@@ -4200,6 +4336,7 @@
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">神奈川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ピアノ</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20153"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Saito_Yoko">
@@ -4229,6 +4366,7 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">福岡</schema:birthPlace>
     <imas:Hobby xml:lang="ja">半身浴</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20070"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sawada_Marina">
@@ -4258,6 +4396,7 @@
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">長野</schema:birthPlace>
     <imas:Hobby xml:lang="ja">サーフィン</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20079"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yaguchi_Miu">
@@ -4287,6 +4426,7 @@
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">千葉</schema:birthPlace>
     <imas:Hobby xml:lang="ja">メール</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20176"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akagi_Miria">
@@ -4320,6 +4460,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1955926"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F8C715</imas:Color>
     <imas:Hobby xml:lang="ja">おしゃべり</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20005"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Aino_Nagisa">
@@ -4349,6 +4490,7 @@
     <imas:Constellation xml:lang="ja">獅子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">愛知</schema:birthPlace>
     <imas:Hobby xml:lang="ja">バスケットボール</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20002"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Manabe_Itsuki">
@@ -4378,6 +4520,7 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">石川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">とにかく運動</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20156"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ohtsuki_Yui">
@@ -4411,6 +4554,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17223371"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EFB817</imas:Color>
     <imas:Hobby xml:lang="ja">カラオケ</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20032"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Himekawa_Yuki">
@@ -4444,6 +4588,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11523609"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E9870C</imas:Color>
     <imas:Hobby xml:lang="ja">野球観戦</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20134"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kitami_Yuzu">
@@ -4477,6 +4622,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q40039788"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EADC62</imas:Color>
     <imas:Hobby xml:lang="ja">バドミントン</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20048"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ueda_Suzuho">
@@ -4510,6 +4656,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q18818006"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">C9870F</imas:Color>
     <imas:Hobby xml:lang="ja">裁縫</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20023"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ebihara_Naho">
@@ -4540,6 +4687,7 @@
     <schema:birthPlace xml:lang="ja">熊本</schema:birthPlace>
     <imas:Hobby xml:lang="ja">散歩</imas:Hobby>
     <imas:Hobby xml:lang="ja">和菓子屋さん巡り</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20028"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Oikawa_Shizuku">
@@ -4574,6 +4722,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">FFFFFF</imas:Color>
     <imas:Hobby xml:lang="ja">乳搾り</imas:Hobby>
     <imas:Hobby xml:lang="ja">トラクターの運転</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20029"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Koseki_Reina">
@@ -4606,6 +4755,7 @@
     <!--<imas:cv rdf:resource="http://ja.dbpedia.org/resource/長野佑紀"/>-->
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q30108577"/>
     <imas:Hobby xml:lang="ja">いたずら</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20063"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Etou_Misaki">
@@ -4636,6 +4786,7 @@
     <schema:birthPlace xml:lang="ja">大分</schema:birthPlace>
     <imas:Hobby xml:lang="ja">女子力アップ</imas:Hobby>
     <imas:Hobby xml:lang="ja">携帯小説</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20027"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hoshi_Syoko">
@@ -4669,6 +4820,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17230362"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">A21D3C</imas:Color>
     <imas:Hobby xml:lang="ja">キノコ栽培</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20144"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Katagiri_Sanae">
@@ -4703,6 +4855,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E94D1A</imas:Color>
     <imas:Hobby xml:lang="ja">マッサージ</imas:Hobby>
     <imas:Hobby xml:lang="ja">スーパー銭湯</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20040"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hori_Yuko">
@@ -4736,6 +4889,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17160003"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E89B55</imas:Color>
     <imas:Hobby xml:lang="ja">サイキックトレーニング</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20145"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nishijima_Kai">
@@ -4765,6 +4919,7 @@
     <imas:Constellation xml:lang="ja">獅子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">大阪</schema:birthPlace>
     <imas:Hobby xml:lang="ja">水族館巡り</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20119"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Matoba_Risa">
@@ -4798,6 +4953,7 @@
     <!-- <imas:cv rdf:resource="http://www.wikidata.org/entity/Q0000000"/> -->
     <imas:Hobby xml:lang="ja">ダンス</imas:Hobby>
     <imas:Hobby xml:lang="ja">パパとデート</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20154"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Zaizen_Tokiko">
@@ -4828,6 +4984,7 @@
     <schema:birthPlace xml:lang="ja">名古屋</schema:birthPlace>
     <imas:Hobby xml:lang="ja">豚を料理すること</imas:Hobby>
     <imas:Hobby xml:lang="ja">お仕置き</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20069"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yorita_Yoshino">
@@ -4863,6 +5020,7 @@
     <imas:Hobby xml:lang="ja">悩み事解決</imas:Hobby>
     <imas:Hobby xml:lang="ja">石ころ集め</imas:Hobby>
     <imas:Hobby xml:lang="ja">失せ物探し</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20185"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Aiba_Yumi">
@@ -4896,6 +5054,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q18048266"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EAE28D</imas:Color>
     <imas:Hobby xml:lang="ja">ガーデニング</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20003"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nonomura_Sora">
@@ -4925,6 +5084,7 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">福岡</schema:birthPlace>
     <imas:Hobby xml:lang="ja">友達と電話</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20123"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hamakawa_Ayuna">
@@ -4954,6 +5114,7 @@
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">大阪</schema:birthPlace>
     <imas:Hobby xml:lang="ja">乗馬</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20125"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Wakabayashi_Tomoka">
@@ -4983,6 +5144,7 @@
     <imas:Constellation xml:lang="ja">乙女座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">鹿児島</schema:birthPlace>
     <imas:Hobby xml:lang="ja">チアリーディング</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20188"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Jougasaki_Mika">
@@ -5016,6 +5178,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11385438"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F4982B</imas:Color>
     <imas:Hobby xml:lang="ja">カラオケ</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20086"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Jougasaki_Rika">
@@ -5049,6 +5212,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q9080262"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F7D30D</imas:Color>
     <imas:Hobby xml:lang="ja">シール集め</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20087"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Senzaki_Ema">
@@ -5078,6 +5242,7 @@
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">大阪</schema:birthPlace>
     <imas:Hobby xml:lang="ja">革小物集め</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20096"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hino_Akane">
@@ -5111,6 +5276,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q5100189"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EA4F21</imas:Color>
     <imas:Hobby xml:lang="ja">ラグビー観戦</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20133"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Moroboshi_Kirari">
@@ -5144,6 +5310,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q391799"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F8CA02</imas:Color>
     <imas:Hobby xml:lang="ja">かわいい物集め</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20173"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Totoki_Airi">
@@ -5177,6 +5344,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1046994"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E9425C</imas:Color>
     <imas:Hobby xml:lang="ja">ケーキ作り</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20110"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Natalia">
@@ -5203,6 +5371,7 @@
     <!--<imas:cv rdf:resource="http://ja.dbpedia.org/resource/生田輝"/>-->
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q66736457"/>
     <imas:Hobby xml:lang="ja">ベリーダンス</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20113"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Souma_Natsumi">
@@ -5232,6 +5401,7 @@
     <imas:Constellation xml:lang="ja">獅子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">京都</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ランニング</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20097"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Makihara_Shiho">
@@ -5261,6 +5431,7 @@
     <imas:Constellation xml:lang="ja">牡牛座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">三重</schema:birthPlace>
     <imas:Hobby xml:lang="ja">スイーツめぐり</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20148"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mukai_Takumi">
@@ -5294,6 +5465,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17221306"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">A90582</imas:Color>
     <imas:Hobby xml:lang="ja">バイクいじり</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20164"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ichihara_Nina">
@@ -5327,6 +5499,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11369771"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F7DE8C</imas:Color>
     <imas:Hobby xml:lang="ja">着ぐるみ集め</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20020"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kita_Hinako">
@@ -5360,6 +5533,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17209690"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F4D059</imas:Color>
     <imas:Hobby xml:lang="ja">妄想</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20046"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sugisaka_Umi">
@@ -5389,6 +5563,7 @@
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">山口</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ウインドサーフィン</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20091"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kitagawa_Mahiro">
@@ -5420,6 +5595,7 @@
     <imas:Hobby xml:lang="ja">走ること</imas:Hobby>
     <imas:Hobby xml:lang="ja">食べること</imas:Hobby>
     <imas:Hobby xml:lang="ja">寝ること</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20047"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mary_Cochran">
@@ -5450,6 +5626,7 @@
     <schema:birthPlace xml:lang="ja">サンフランシスコ</schema:birthPlace>
     <imas:Hobby xml:lang="ja">女磨き</imas:Hobby>
     <imas:Hobby xml:lang="ja">グルメツアー</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20168"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Komatsu_Ibuki">
@@ -5481,6 +5658,7 @@
     <imas:Hobby xml:lang="ja">ストリートダンス</imas:Hobby>
     <imas:Hobby xml:lang="ja">スケボー</imas:Hobby>
     <imas:Hobby xml:lang="ja">恋愛映画を見る事</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20066"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Miyoshi_Sana">
@@ -5511,6 +5689,7 @@
     <schema:birthPlace xml:lang="ja">香川</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ＴＶゲーム</imas:Hobby>
     <imas:Hobby xml:lang="ja">夜更かし</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20163"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Cathy_Graham">
@@ -5541,6 +5720,7 @@
     <schema:birthPlace xml:lang="ja">ニューヨーク</schema:birthPlace>
     <imas:Hobby xml:lang="ja">インラインスケート</imas:Hobby>
     <imas:Hobby xml:lang="ja">ダンス</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20051"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Namba_Emi">
@@ -5575,6 +5755,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E9463D</imas:Color>
     <imas:Hobby xml:lang="ja">お笑いライブ巡り</imas:Hobby>
     <imas:Hobby xml:lang="ja">モノマネ</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20117"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hamaguchi_Ayame">
@@ -5610,6 +5791,7 @@
     <imas:Hobby xml:lang="ja">撮影所巡り</imas:Hobby>
     <imas:Hobby xml:lang="ja">忍者グッズ収集</imas:Hobby>
     <imas:Hobby xml:lang="ja">時代劇鑑賞</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20126"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Murakami_Tomoe">
@@ -5644,6 +5826,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D42E38</imas:Color>
     <imas:Hobby xml:lang="ja">演歌</imas:Hobby>
     <imas:Hobby xml:lang="ja">将棋</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20166"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tsuchiya_Ako">
@@ -5674,6 +5857,7 @@
     <schema:birthPlace xml:lang="ja">静岡</schema:birthPlace>
     <imas:Hobby xml:lang="ja">食べること</imas:Hobby>
     <imas:Hobby xml:lang="ja">貯金</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20107"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shuto_Aoi">
@@ -5703,6 +5887,7 @@
     <imas:Constellation xml:lang="ja">獅子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">大分</schema:birthPlace>
     <imas:Hobby xml:lang="ja">魚さばき</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20085"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Saejima_Kiyomi">
@@ -5734,6 +5919,7 @@
     <imas:Hobby xml:lang="ja">掃除</imas:Hobby>
     <imas:Hobby xml:lang="ja">整理整頓</imas:Hobby>
     <imas:Hobby xml:lang="ja">腕章作り</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20071"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sato_Shin">
@@ -5768,6 +5954,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E44E8E</imas:Color>
     <imas:Hobby xml:lang="ja">ドレスアップ</imas:Hobby>
     <imas:Hobby xml:lang="ja">衣装作り</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20078"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nanjo_Hikaru">
@@ -5802,6 +5989,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">ED0829</imas:Color>
     <imas:Hobby xml:lang="ja">特撮番組鑑賞</imas:Hobby>
     <imas:Hobby xml:lang="ja">特撮ごっこ</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20116"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Eve_Santaclaus">
@@ -5831,6 +6019,7 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">グリーンランド</schema:birthPlace>
     <imas:Hobby xml:lang="ja">煙突探し</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20015"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yumemi_Riamu">
@@ -5864,6 +6053,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q35172322"/>
     <imas:Hobby xml:lang="ja">夜中の意味深ポエム</imas:Hobby>
     <imas:Hobby xml:lang="ja">現場参戦</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20182"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hisakawa_Nagi">
@@ -5899,6 +6089,7 @@
     <imas:Hobby xml:lang="ja">写真</imas:Hobby>
     <imas:Hobby xml:lang="ja">ポエム</imas:Hobby>
     <imas:Hobby xml:lang="ja">読書（新書）</imas:Hobby>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/20131"/>
   </rdf:Description>
 
 </rdf:RDF>

--- a/RDFs/SideM.rdf
+++ b/RDFs/SideM.rdf
@@ -4,6 +4,7 @@
     xmlns:foaf="http://xmlns.com/foaf/0.1/"
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xmlns:imas="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
     xml:base="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/"
     >
   <rdf:Description rdf:about="Amagase_Toma">
@@ -38,6 +39,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40008"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mitarai_Shota">
@@ -71,6 +73,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40043"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ijuin_Hokuto">
@@ -105,6 +108,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40009"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tendo_Teru">
@@ -138,6 +142,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40034"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sakuraba_Kaoru">
@@ -170,6 +175,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40026"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kashiwagi_Tsubasa">
@@ -205,6 +211,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40015"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tsuzuki_Kei">
@@ -237,6 +244,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40033"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kagura_Rei">
@@ -269,6 +277,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40014"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takajo_Kyoji">
@@ -301,6 +310,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40030"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Pierre">
@@ -327,6 +337,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40038"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Watanabe_Minori">
@@ -359,6 +370,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40046"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Aoi_Yusuke">
@@ -391,6 +403,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40002"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Aoi_Kyosuke">
@@ -424,6 +437,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40001"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akuno_Hideo">
@@ -457,6 +471,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40006"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kimura_Ryu">
@@ -489,6 +504,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40020"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shingen_Seiji">
@@ -521,6 +537,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40028"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nekoyanagi_Kirio">
@@ -553,6 +570,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40035"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hanamura_Shoma">
@@ -585,6 +603,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40037"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kiyosumi_Kuro">
@@ -618,6 +637,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40021"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akiyama_Hayato">
@@ -651,6 +671,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40005"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Fuyumi_Jun">
@@ -683,6 +704,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40040"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sakaki_Natsuki">
@@ -716,6 +738,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40025"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Wakazato_Haruna">
@@ -748,6 +771,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40045"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Iseya_Shiki">
@@ -781,6 +805,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40010"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akai_Suzaku">
@@ -813,6 +838,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40003"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kurono_Genbu">
@@ -847,6 +873,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40023"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kamiya_Yukihiro">
@@ -881,6 +908,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40017"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shinonome_Soichiro">
@@ -915,6 +943,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40027"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Asselin_BB_2">
@@ -942,6 +971,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40007"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Uzuki_Makio">
@@ -975,6 +1005,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40011"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mizushima_Saki">
@@ -1007,6 +1038,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40042"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Okamura_Nao">
@@ -1039,6 +1071,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40013"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tachibana_Shiro">
@@ -1071,6 +1104,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40031"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Himeno_Kanon">
@@ -1103,6 +1137,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40039"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hazama_Michio">
@@ -1136,6 +1171,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40036"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Maita_Rui">
@@ -1170,6 +1206,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40041"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yamashita_Jiro">
@@ -1203,6 +1240,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40044"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Taiga_Takeru">
@@ -1237,6 +1275,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40029"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Enjoji_Michiru">
@@ -1269,6 +1308,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40012"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kizaki_Ren">
@@ -1301,6 +1341,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40018"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akizuki_Ryo_315">
@@ -1335,6 +1376,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40004"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kabuto_Daigo">
@@ -1368,6 +1410,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40016"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tsukumo_Kazuki">
@@ -1405,6 +1448,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40032"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kuzunoha_Amehiko">
@@ -1437,6 +1481,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40022"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kitamura_Sora">
@@ -1469,6 +1514,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40019"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Koron_Chris">
@@ -1501,6 +1547,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40024"/>
   </rdf:Description>
 
 </rdf:RDF>

--- a/RDFs/SideM.rdf
+++ b/RDFs/SideM.rdf
@@ -39,7 +39,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40008"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40008"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mitarai_Shota">
@@ -73,7 +73,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40043"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40043"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ijuin_Hokuto">
@@ -108,7 +108,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40009"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40009"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tendo_Teru">
@@ -142,7 +142,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40034"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40034"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sakuraba_Kaoru">
@@ -175,7 +175,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40026"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40026"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kashiwagi_Tsubasa">
@@ -211,7 +211,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40015"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40015"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tsuzuki_Kei">
@@ -244,7 +244,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40033"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40033"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kagura_Rei">
@@ -277,7 +277,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40014"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40014"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takajo_Kyoji">
@@ -310,7 +310,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40030"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40030"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Pierre">
@@ -337,7 +337,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40038"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40038"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Watanabe_Minori">
@@ -370,7 +370,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40046"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40046"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Aoi_Yusuke">
@@ -403,7 +403,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40002"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40002"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Aoi_Kyosuke">
@@ -437,7 +437,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40001"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40001"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akuno_Hideo">
@@ -471,7 +471,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40006"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40006"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kimura_Ryu">
@@ -504,7 +504,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40020"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40020"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shingen_Seiji">
@@ -537,7 +537,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40028"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40028"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nekoyanagi_Kirio">
@@ -570,7 +570,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40035"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40035"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hanamura_Shoma">
@@ -603,7 +603,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40037"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40037"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kiyosumi_Kuro">
@@ -637,7 +637,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40021"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40021"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akiyama_Hayato">
@@ -671,7 +671,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40005"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40005"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Fuyumi_Jun">
@@ -704,7 +704,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40040"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40040"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sakaki_Natsuki">
@@ -738,7 +738,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40025"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40025"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Wakazato_Haruna">
@@ -771,7 +771,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40045"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40045"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Iseya_Shiki">
@@ -805,7 +805,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40010"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40010"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akai_Suzaku">
@@ -838,7 +838,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40003"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40003"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kurono_Genbu">
@@ -873,7 +873,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40023"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40023"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kamiya_Yukihiro">
@@ -908,7 +908,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40017"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40017"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shinonome_Soichiro">
@@ -943,7 +943,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40027"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40027"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Asselin_BB_2">
@@ -971,7 +971,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40007"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40007"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Uzuki_Makio">
@@ -1005,7 +1005,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40011"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40011"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mizushima_Saki">
@@ -1038,7 +1038,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40042"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40042"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Okamura_Nao">
@@ -1071,7 +1071,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40013"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40013"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tachibana_Shiro">
@@ -1104,7 +1104,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40031"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40031"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Himeno_Kanon">
@@ -1137,7 +1137,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40039"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40039"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hazama_Michio">
@@ -1171,7 +1171,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40036"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40036"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Maita_Rui">
@@ -1206,7 +1206,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40041"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40041"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yamashita_Jiro">
@@ -1240,7 +1240,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40044"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40044"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Taiga_Takeru">
@@ -1275,7 +1275,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40029"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40029"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Enjoji_Michiru">
@@ -1308,7 +1308,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40012"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40012"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kizaki_Ren">
@@ -1341,7 +1341,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40018"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40018"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akizuki_Ryo_315">
@@ -1376,7 +1376,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40004"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40004"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kabuto_Daigo">
@@ -1410,7 +1410,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40016"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40016"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tsukumo_Kazuki">
@@ -1448,7 +1448,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40032"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40032"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kuzunoha_Amehiko">
@@ -1481,7 +1481,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40022"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40022"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kitamura_Sora">
@@ -1514,7 +1514,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40019"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40019"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Koron_Chris">
@@ -1547,7 +1547,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:idolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40024"/>
+    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40024"/>
   </rdf:Description>
 
 </rdf:RDF>

--- a/RDFs/SideM.rdf
+++ b/RDFs/SideM.rdf
@@ -39,7 +39,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40008"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40008"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mitarai_Shota">
@@ -73,7 +73,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40043"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40043"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Ijuin_Hokuto">
@@ -108,7 +108,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40009"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40009"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tendo_Teru">
@@ -142,7 +142,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40034"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40034"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sakuraba_Kaoru">
@@ -175,7 +175,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40026"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40026"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kashiwagi_Tsubasa">
@@ -211,7 +211,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40015"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40015"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tsuzuki_Kei">
@@ -244,7 +244,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40033"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40033"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kagura_Rei">
@@ -277,7 +277,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40014"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40014"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Takajo_Kyoji">
@@ -310,7 +310,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40030"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40030"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Pierre">
@@ -337,7 +337,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40038"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40038"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Watanabe_Minori">
@@ -370,7 +370,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40046"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40046"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Aoi_Yusuke">
@@ -403,7 +403,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40002"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40002"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Aoi_Kyosuke">
@@ -437,7 +437,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40001"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40001"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akuno_Hideo">
@@ -471,7 +471,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40006"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40006"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kimura_Ryu">
@@ -504,7 +504,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40020"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40020"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shingen_Seiji">
@@ -537,7 +537,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40028"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40028"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Nekoyanagi_Kirio">
@@ -570,7 +570,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40035"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40035"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hanamura_Shoma">
@@ -603,7 +603,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40037"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40037"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kiyosumi_Kuro">
@@ -637,7 +637,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40021"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40021"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akiyama_Hayato">
@@ -671,7 +671,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40005"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40005"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Fuyumi_Jun">
@@ -704,7 +704,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40040"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40040"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Sakaki_Natsuki">
@@ -738,7 +738,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40025"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40025"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Wakazato_Haruna">
@@ -771,7 +771,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40045"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40045"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Iseya_Shiki">
@@ -805,7 +805,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40010"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40010"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akai_Suzaku">
@@ -838,7 +838,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40003"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40003"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kurono_Genbu">
@@ -873,7 +873,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40023"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40023"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kamiya_Yukihiro">
@@ -908,7 +908,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40017"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40017"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Shinonome_Soichiro">
@@ -943,7 +943,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40027"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40027"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Asselin_BB_2">
@@ -971,7 +971,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40007"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40007"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Uzuki_Makio">
@@ -1005,7 +1005,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40011"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40011"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Mizushima_Saki">
@@ -1038,7 +1038,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40042"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40042"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Okamura_Nao">
@@ -1071,7 +1071,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40013"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40013"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tachibana_Shiro">
@@ -1104,7 +1104,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40031"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40031"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Himeno_Kanon">
@@ -1137,7 +1137,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40039"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40039"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Hazama_Michio">
@@ -1171,7 +1171,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40036"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40036"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Maita_Rui">
@@ -1206,7 +1206,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40041"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40041"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Yamashita_Jiro">
@@ -1240,7 +1240,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40044"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40044"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Taiga_Takeru">
@@ -1275,7 +1275,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40029"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40029"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Enjoji_Michiru">
@@ -1308,7 +1308,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40012"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40012"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kizaki_Ren">
@@ -1341,7 +1341,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40018"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40018"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Akizuki_Ryo_315">
@@ -1376,7 +1376,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40004"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40004"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kabuto_Daigo">
@@ -1410,7 +1410,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40016"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40016"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Tsukumo_Kazuki">
@@ -1448,7 +1448,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40032"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40032"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kuzunoha_Amehiko">
@@ -1481,7 +1481,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40022"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40022"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Kitamura_Sora">
@@ -1514,7 +1514,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40019"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40019"/>
   </rdf:Description>
 
   <rdf:Description rdf:about="Koron_Chris">
@@ -1547,7 +1547,7 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Title xml:lang="en">315ProIdols</imas:Title>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:IdolListURL xlink:href="https://idollist.idolmaster-official.jp/detail/40024"/>
+    <imas:IdolListURL xlink:type="simple" xlink:href="https://idollist.idolmaster-official.jp/detail/40024"/>
   </rdf:Description>
 
 </rdf:RDF>

--- a/URIs/imas-schema.ttl
+++ b/URIs/imas-schema.ttl
@@ -237,3 +237,7 @@ imas:Title                  a   rdf:Property ;
 imas:Whose                  a   rdf:Property ;
     rdfs:comment            "所有者を表すプロパティ" ;
     rdfs:label              "所有者"@ja .
+
+imas:idolListURL            a   rdf:Property ;
+    rdfs:comment            "アイドル名鑑のアイドル毎URL";
+    rdfs:label              "アイドル名鑑URL"@ja .

--- a/URIs/imas-schema.ttl
+++ b/URIs/imas-schema.ttl
@@ -238,6 +238,6 @@ imas:Whose                  a   rdf:Property ;
     rdfs:comment            "所有者を表すプロパティ" ;
     rdfs:label              "所有者"@ja .
 
-imas:idolListURL            a   rdf:Property ;
+imas:IdolListURL            a   rdf:Property ;
     rdfs:comment            "アイドル名鑑のアイドル毎URL";
     rdfs:label              "アイドル名鑑URL"@ja .


### PR DESCRIPTION
アイドル名鑑内のアイドル毎URLを追加しました。im@sparqlから何かしらをしてSNSに共有する際などに便利だと思います。

- `876.rdf` 内の一部のアイドルはアイドル名鑑に登録されていなかったためURLも追加していません
  - 桜井夢子
  - サイネリア
  - 東豪寺麗華
  - 朝比奈りん
  - 三条ともみ
- XML 及び RDF 初心者なので何かミスっているかもしれません (URLへのリンクは `xlink:href` でいいのかとか…)

**DISCLAIMER:** このデータは https://idollist.idolmaster-official.jp/search で devtools を開きDOM構造からURLとアイドル名をいい感じにダンプするJS(自作)を実行して得たJSONを元に生成しました
- これを受け入れるかどうかはいろいろな思想があると思われます
- あくまで私個人的には
  - 今回は元からロボットにも読まれがちな HTML がソースとなっているので、ゲームの内部データ等 (参考: https://github.com/imas/imasparql/issues/96#issuecomment-658114460 ) よりは白めだと考えています
  - 実際に Google にも既にインデックスされています https://www.google.com/search?q=site%3Aidollist.idolmaster-official.jp
  - が、 robots.txt はなんか書きミスみたいな感じなのでうーんという気もします https://idollist.idolmaster-official.jp/robots.txt
    - Google の robots.txt テスターでは `Disallow:` のようにパスなしでDisallowを書くとNOPになるようです
  - とはいえどちらにせよ Twitter で共有されているリンクをかき集めれば同等の物はある程度容易に生成できると思います
- スクリプトのバグや名前の正規化ミスによるURL入れ違いがあるかもしれません (が、私が手動でやったらもっとある自信があります)

参考までに: 使ったスクリプトはこちらです https://gist.github.com/rinsuki/88523b2b032c1b746f169ff62ec1a6f7