### PR TITLE
高橋未奈美さんが髙橋ミナミさんに改名

### DIFF
--- a/RDFs/765MillionStars.rdf
+++ b/RDFs/765MillionStars.rdf
@@ -965,7 +965,7 @@
     <imas:Talent xml:lang="ja">麻雀</imas:Talent>
     <imas:Favorite xml:lang="ja">日本酒</imas:Favorite>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F1BECB</imas:Color>
-    <imas:cv xml:lang="ja">高橋未奈美</imas:cv>
+    <imas:cv xml:lang="ja">髙橋ミナミ</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/高橋未奈美"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q14756009"/>
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>


### PR DESCRIPTION
高橋未奈美→髙橋ミナミさんの改名を受けて更新しました。Merge or Close のタイミングはおまかせします。

- DBpedia の URL はそのままにしてあります（「髙橋ミナミ」に情報がないため）。
- Live_2019.rdf にある名前はそのままにしてあります（当時は「高橋未奈美」だったため）。

参考
- https://twitter.com/_agson_/status/1340294711458742272
- https://twitter.com/miiiiiina_cat/status/1340307929115709441
- https://twitter.com/miiiiiina_cat/status/1340310933562769409