### PR TITLE
英語の名前表記を「名」→「姓」の順に変える

### DIFF
--- a/RDFs/1stVision.rdf
+++ b/RDFs/1stVision.rdf
@@ -17,7 +17,7 @@
     <imas:nameKana xml:lang="ja">あまみはるか</imas:nameKana>
     <schema:name xml:lang="ja">天海春香</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">天海春香</rdfs:label>
-    <schema:name xml:lang="en">Amami Haruka</schema:name>
+    <schema:name xml:lang="en">Haruka Amami</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">158.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
@@ -49,7 +49,7 @@
     <imas:nameKana xml:lang="ja">きさらぎちはや</imas:nameKana>
     <schema:name xml:lang="ja">如月千早</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">如月千早</rdfs:label>
-    <schema:name xml:lang="en">Kisaragi Chihaya</schema:name>
+    <schema:name xml:lang="en">Chihaya Kisaragi</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">162.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">41.0</schema:weight>
@@ -80,7 +80,7 @@
     <imas:nameKana xml:lang="ja">ほしいみき</imas:nameKana>
     <schema:name xml:lang="ja">星井美希</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">星井美希</rdfs:label>
-    <schema:name xml:lang="en">Hoshii Miki</schema:name>
+    <schema:name xml:lang="en">Miki Hoshii</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">159.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">44.0</schema:weight>
@@ -112,7 +112,7 @@
     <imas:nameKana xml:lang="ja">はぎわらゆきほ</imas:nameKana>
     <schema:name xml:lang="ja">萩原雪歩</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">萩原雪歩</rdfs:label>
-    <schema:name xml:lang="en">Hagiwara Yukiho</schema:name>
+    <schema:name xml:lang="en">Yukiho Hagiwara</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">154.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">40.0</schema:weight>
@@ -144,7 +144,7 @@
     <imas:nameKana xml:lang="ja">たかつきやよい</imas:nameKana>
     <schema:name xml:lang="ja">高槻やよい</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">高槻やよい</rdfs:label>
-    <schema:name xml:lang="en">Takatsuki Yayoi</schema:name>
+    <schema:name xml:lang="en">Yayoi Takatsuki</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">145.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">37.0</schema:weight>
@@ -175,7 +175,7 @@
     <imas:nameKana xml:lang="ja">きくちまこと</imas:nameKana>
     <schema:name xml:lang="ja">菊地真</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">菊地真</rdfs:label>
-    <schema:name xml:lang="en">Kikuchi Makoto</schema:name>
+    <schema:name xml:lang="en">Makoto Kikuchi</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">157.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
@@ -206,7 +206,7 @@
     <imas:nameKana xml:lang="ja">みなせいおり</imas:nameKana>
     <schema:name xml:lang="ja">水瀬伊織</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">水瀬伊織</rdfs:label>
-    <schema:name xml:lang="en">Minase Iori</schema:name>
+    <schema:name xml:lang="en">Iori Minase</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">150.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">39.0</schema:weight>
@@ -238,7 +238,7 @@
     <imas:nameKana xml:lang="ja">しじょうたかね</imas:nameKana>
     <schema:name xml:lang="ja">四条貴音</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">四条貴音</rdfs:label>
-    <schema:name xml:lang="en">Shijou Takane</schema:name>
+    <schema:name xml:lang="en">Takane Shijou</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">169.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">49.0</schema:weight>
@@ -270,7 +270,7 @@
     <imas:nameKana xml:lang="ja">あきづきりつこ</imas:nameKana>
     <schema:name xml:lang="ja">秋月律子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">秋月律子</rdfs:label>
-    <schema:name xml:lang="en">Akizuki Ritsuko</schema:name>
+    <schema:name xml:lang="en">Ritsuko Akizuki</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">156.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
@@ -302,7 +302,7 @@
     <imas:nameKana xml:lang="ja">みうらあずさ</imas:nameKana>
     <schema:name xml:lang="ja">三浦あずさ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">三浦あずさ</rdfs:label>
-    <schema:name xml:lang="en">Miura Azusa</schema:name>
+    <schema:name xml:lang="en">Azusa Miura</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">168.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">48.0</schema:weight>
@@ -333,7 +333,7 @@
     <imas:nameKana xml:lang="ja">ふたみあみ</imas:nameKana>
     <schema:name xml:lang="ja">双海亜美</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">双海亜美</rdfs:label>
-    <schema:name xml:lang="en">Futami Ami</schema:name>
+    <schema:name xml:lang="en">Ami Futami</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">149.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">39.0</schema:weight>
@@ -365,7 +365,7 @@
     <imas:nameKana xml:lang="ja">ふたみまみ</imas:nameKana>
     <schema:name xml:lang="ja">双海真美</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">双海真美</rdfs:label>
-    <schema:name xml:lang="en">Futami Mami</schema:name>
+    <schema:name xml:lang="en">Mami Futami</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">149.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">37.0</schema:weight>
@@ -397,7 +397,7 @@
     <imas:nameKana xml:lang="ja">がなはひびき</imas:nameKana>
     <schema:name xml:lang="ja">我那覇響</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">我那覇響</rdfs:label>
-    <schema:name xml:lang="en">Ganaha Hibiki</schema:name>
+    <schema:name xml:lang="en">Hibiki Ganaha</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">152.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">41.0</schema:weight>

--- a/RDFs/283.rdf
+++ b/RDFs/283.rdf
@@ -17,7 +17,7 @@
     <imas:nameKana xml:lang="ja">さくらぎまの</imas:nameKana>
     <schema:name xml:lang="ja">櫻木真乃</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">櫻木真乃</rdfs:label>
-    <schema:name xml:lang="en">Sakuragi Mano</schema:name>
+    <schema:name xml:lang="en">Mano Sakuragi</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">155.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">48.0</schema:weight>
@@ -53,7 +53,7 @@
     <imas:nameKana xml:lang="ja">はちみやめぐる</imas:nameKana>
     <schema:name xml:lang="ja">八宮めぐる</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">八宮めぐる</rdfs:label>
-    <schema:name xml:lang="en">Hachimiya Meguru</schema:name>
+    <schema:name xml:lang="en">Meguru Hachimiya</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">157.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">46.0</schema:weight>
@@ -89,7 +89,7 @@
     <imas:nameKana xml:lang="ja">かざのひおり</imas:nameKana>
     <schema:name xml:lang="ja">風野灯織</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">風野灯織</rdfs:label>
-    <schema:name xml:lang="en">Kazano Hiori</schema:name>
+    <schema:name xml:lang="en">Hiori Kazano</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">154.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
@@ -127,7 +127,7 @@
     <imas:nameKana xml:lang="ja">つきおかこがね</imas:nameKana>
     <schema:name xml:lang="ja">月岡恋鐘</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">月岡恋鐘</rdfs:label>
-    <schema:name xml:lang="en">Tsukioka Kogane</schema:name>
+    <schema:name xml:lang="en">Kogane Tsukioka</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">165.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">58.0</schema:weight>
@@ -162,7 +162,7 @@
     <imas:nameKana xml:lang="ja">みつみねゆいか</imas:nameKana>
     <schema:name xml:lang="ja">三峰結華</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">三峰結華</rdfs:label>
-    <schema:name xml:lang="en">Mitsumine Yuika</schema:name>
+    <schema:name xml:lang="en">Yuika Mitsumine</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">158.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">44.0</schema:weight>
@@ -202,7 +202,7 @@
     <imas:nameKana xml:lang="ja">しらせさくや</imas:nameKana>
     <schema:name xml:lang="ja">白瀬咲耶</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">白瀬咲耶</rdfs:label>
-    <schema:name xml:lang="en">Shirase Sakuya</schema:name>
+    <schema:name xml:lang="en">Sakuya Shirase</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">175.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">60.0</schema:weight>
@@ -237,7 +237,7 @@
     <imas:nameKana xml:lang="ja">たなかまみみ</imas:nameKana>
     <schema:name xml:lang="ja">田中摩美々</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">田中摩美々</rdfs:label>
-    <schema:name xml:lang="en">Tanaka Mamimi</schema:name>
+    <schema:name xml:lang="en">Mamimi Tanaka</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">161.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">49.0</schema:weight>
@@ -273,7 +273,7 @@
     <imas:nameKana xml:lang="ja">ゆうこくきりこ</imas:nameKana>
     <schema:name xml:lang="ja">幽谷霧子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">幽谷霧子</rdfs:label>
-    <schema:name xml:lang="en">Yukoku Kiriko</schema:name>
+    <schema:name xml:lang="en">Kiriko Yukoku</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">160.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">51.0</schema:weight>
@@ -312,7 +312,7 @@
     <imas:nameKana xml:lang="ja">くわやまちゆき</imas:nameKana>
     <schema:name xml:lang="ja">桑山千雪</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">桑山千雪</rdfs:label>
-    <schema:name xml:lang="en">Kuwayama Chiyuki</schema:name>
+    <schema:name xml:lang="en">Chiyuki Kuwayama</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">163.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">47.0</schema:weight>
@@ -348,7 +348,7 @@
     <imas:nameKana xml:lang="ja">おおさきてんか</imas:nameKana>
     <schema:name xml:lang="ja">大崎甜花</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">大崎甜花</rdfs:label>
-    <schema:name xml:lang="en">Osaki Tenka</schema:name>
+    <schema:name xml:lang="en">Tenka Osaki</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">159.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">44.0</schema:weight>
@@ -386,7 +386,7 @@
     <imas:nameKana xml:lang="ja">おおさきあまな</imas:nameKana>
     <schema:name xml:lang="ja">大崎甘奈</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">大崎甘奈</rdfs:label>
-    <schema:name xml:lang="en">Osaki Amana</schema:name>
+    <schema:name xml:lang="en">Amana Osaki</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">159.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
@@ -424,7 +424,7 @@
     <imas:nameKana xml:lang="ja">こみやかほ</imas:nameKana>
     <schema:name xml:lang="ja">小宮果穂</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">小宮果穂</rdfs:label>
-    <schema:name xml:lang="en">Komiya Kaho</schema:name>
+    <schema:name xml:lang="en">Kaho Komiya</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">163.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
@@ -460,7 +460,7 @@
     <imas:nameKana xml:lang="ja">さいじょうじゅり</imas:nameKana>
     <schema:name xml:lang="ja">西城樹里</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">西城樹里</rdfs:label>
-    <schema:name xml:lang="en">Saijo Juri</schema:name>
+    <schema:name xml:lang="en">Juri Saijo</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">160.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">48.0</schema:weight>
@@ -497,7 +497,7 @@
     <imas:nameKana xml:lang="ja">ありすがわなつは</imas:nameKana>
     <schema:name xml:lang="ja">有栖川夏葉</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">有栖川夏葉</rdfs:label>
-    <schema:name xml:lang="en">Arisugawa Natsuha</schema:name>
+    <schema:name xml:lang="en">Natsuha Arisugawa</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">168.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">49.0</schema:weight>
@@ -533,7 +533,7 @@
     <imas:nameKana xml:lang="ja">もりのりんぜ</imas:nameKana>
     <schema:name xml:lang="ja">杜野凛世</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">杜野凛世</rdfs:label>
-    <schema:name xml:lang="en">Morino Rinze</schema:name>
+    <schema:name xml:lang="en">Rinze Morino</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">155.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">44.0</schema:weight>
@@ -570,7 +570,7 @@
     <imas:nameKana xml:lang="ja">そのだちよこ</imas:nameKana>
     <schema:name xml:lang="ja">園田智代子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">園田智代子</rdfs:label>
-    <schema:name xml:lang="en">Sonoda Chiyoko</schema:name>
+    <schema:name xml:lang="en">Chiyoko Sonoda</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">149.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">46.0</schema:weight>
@@ -605,7 +605,7 @@
     <imas:nameKana xml:lang="ja">まゆずみふゆこ</imas:nameKana>
     <schema:name xml:lang="ja">黛冬優子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">黛冬優子</rdfs:label>
-    <schema:name xml:lang="en">Mayuzumi Fuyuko</schema:name>
+    <schema:name xml:lang="en">Fuyuko Mayuzumi</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">163.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">55.0</schema:weight>
@@ -640,7 +640,7 @@
     <imas:nameKana xml:lang="ja">せりざわあさひ</imas:nameKana>
     <schema:name xml:lang="ja">芹沢あさひ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">芹沢あさひ</rdfs:label>
-    <schema:name xml:lang="en">Serizawa Asahi</schema:name>
+    <schema:name xml:lang="en">Asahi Serizawa</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">153.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">47.0</schema:weight>
@@ -676,7 +676,7 @@
     <imas:nameKana xml:lang="ja">いずみめい</imas:nameKana>
     <schema:name xml:lang="ja">和泉愛依</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">和泉愛依</rdfs:label>
-    <schema:name xml:lang="en">Izumi Mei</schema:name>
+    <schema:name xml:lang="en">Mei Izumi</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">162.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">51.0</schema:weight>
@@ -712,7 +712,7 @@
     <imas:nameKana xml:lang="ja">あさくらとおる</imas:nameKana>
     <schema:name xml:lang="ja">浅倉透</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">浅倉透</rdfs:label>
-    <schema:name xml:lang="en">Asakura Toru</schema:name>
+    <schema:name xml:lang="en">Toru Asakura</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">160.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">50.0</schema:weight>
@@ -747,7 +747,7 @@
     <imas:nameKana xml:lang="ja">ひぐちまどか</imas:nameKana>
     <schema:name xml:lang="ja">樋口円香</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">樋口円香</rdfs:label>
-    <schema:name xml:lang="en">Higuchi Madoka</schema:name>
+    <schema:name xml:lang="en">Madoka Higuchi</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">159.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">47.0</schema:weight>
@@ -782,7 +782,7 @@
     <imas:nameKana xml:lang="ja">ふくまるこいと</imas:nameKana>
     <schema:name xml:lang="ja">福丸小糸</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">福丸小糸</rdfs:label>
-    <schema:name xml:lang="en">Fukumaru Koito</schema:name>
+    <schema:name xml:lang="en">Koito Fukumaru</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">148.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
@@ -817,7 +817,7 @@
     <imas:nameKana xml:lang="ja">いちかわひなな</imas:nameKana>
     <schema:name xml:lang="ja">市川雛菜</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">市川雛菜</rdfs:label>
-    <schema:name xml:lang="en">Ichikawa Hinana</schema:name>
+    <schema:name xml:lang="en">Hinana Ichikawa</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">165.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">56.0</schema:weight>

--- a/RDFs/765AS.rdf
+++ b/RDFs/765AS.rdf
@@ -18,7 +18,7 @@
     <imas:nameKana xml:lang="ja">あまみはるか</imas:nameKana>
     <schema:name xml:lang="ja">天海春香</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">天海春香</rdfs:label>
-    <schema:name xml:lang="en">Amami Haruka</schema:name>
+    <schema:name xml:lang="en">Haruka Amami</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">158.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">46.0</schema:weight>
@@ -57,7 +57,7 @@
     <imas:nameKana xml:lang="ja">きさらぎちはや</imas:nameKana>
     <schema:name xml:lang="ja">如月千早</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">如月千早</rdfs:label>
-    <schema:name xml:lang="en">Kisaragi Chihaya</schema:name>
+    <schema:name xml:lang="en">Chihaya Kisaragi</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">162.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">41.0</schema:weight>
@@ -95,7 +95,7 @@
     <imas:nameKana xml:lang="ja">ほしいみき</imas:nameKana>
     <schema:name xml:lang="ja">星井美希</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">星井美希</rdfs:label>
-    <schema:name xml:lang="en">Hoshii Miki</schema:name>
+    <schema:name xml:lang="en">Miki Hoshii</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">161.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
@@ -135,7 +135,7 @@
     <imas:nameKana xml:lang="ja">はぎわらゆきほ</imas:nameKana>
     <schema:name xml:lang="ja">萩原雪歩</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">萩原雪歩</rdfs:label>
-    <schema:name xml:lang="en">Hagiwara Yukiho</schema:name>
+    <schema:name xml:lang="en">Yukiho Hagiwara</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">155.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
@@ -173,7 +173,7 @@
     <imas:nameKana xml:lang="ja">たかつきやよい</imas:nameKana>
     <schema:name xml:lang="ja">高槻やよい</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">高槻やよい</rdfs:label>
-    <schema:name xml:lang="en">Takatsuki Yayoi</schema:name>
+    <schema:name xml:lang="en">Yayoi Takatsuki</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">145.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">37.0</schema:weight>
@@ -213,7 +213,7 @@
     <imas:nameKana xml:lang="ja">きくちまこと</imas:nameKana>
     <schema:name xml:lang="ja">菊地真</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">菊地真</rdfs:label>
-    <schema:name xml:lang="en">Kikuchi Makoto</schema:name>
+    <schema:name xml:lang="en">Makoto Kikuchi</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">159.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">44.0</schema:weight>
@@ -252,7 +252,7 @@
     <imas:nameKana xml:lang="ja">みなせいおり</imas:nameKana>
     <schema:name xml:lang="ja">水瀬伊織</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">水瀬伊織</rdfs:label>
-    <schema:name xml:lang="en">Minase Iori</schema:name>
+    <schema:name xml:lang="en">Iori Minase</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">153.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">40.0</schema:weight>
@@ -291,7 +291,7 @@
     <imas:nameKana xml:lang="ja">しじょうたかね</imas:nameKana>
     <schema:name xml:lang="ja">四条貴音</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">四条貴音</rdfs:label>
-    <schema:name xml:lang="en">Shijou Takane</schema:name>
+    <schema:name xml:lang="en">Takane Shijou</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">169.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">49.0</schema:weight>
@@ -330,7 +330,7 @@
     <imas:nameKana xml:lang="ja">あきづきりつこ</imas:nameKana>
     <schema:name xml:lang="ja">秋月律子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">秋月律子</rdfs:label>
-    <schema:name xml:lang="en">Akizuki Ritsuko</schema:name>
+    <schema:name xml:lang="en">Ritsuko Akizuki</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">156.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
@@ -369,7 +369,7 @@
     <imas:nameKana xml:lang="ja">みうらあずさ</imas:nameKana>
     <schema:name xml:lang="ja">三浦あずさ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">三浦あずさ</rdfs:label>
-    <schema:name xml:lang="en">Miura Azusa</schema:name>
+    <schema:name xml:lang="en">Azusa Miura</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">168.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">48.0</schema:weight>
@@ -407,7 +407,7 @@
     <imas:nameKana xml:lang="ja">ふたみあみ</imas:nameKana>
     <schema:name xml:lang="ja">双海亜美</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">双海亜美</rdfs:label>
-    <schema:name xml:lang="en">Futami Ami</schema:name>
+    <schema:name xml:lang="en">Ami Futami</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">158.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
@@ -446,7 +446,7 @@
     <imas:nameKana xml:lang="ja">ふたみまみ</imas:nameKana>
     <schema:name xml:lang="ja">双海真美</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">双海真美</rdfs:label>
-    <schema:name xml:lang="en">Futami Mami</schema:name>
+    <schema:name xml:lang="en">Mami Futami</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">158.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
@@ -485,7 +485,7 @@
     <imas:nameKana xml:lang="ja">がなはひびき</imas:nameKana>
     <schema:name xml:lang="ja">我那覇響</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">我那覇響</rdfs:label>
-    <schema:name xml:lang="en">Ganaha Hibiki</schema:name>
+    <schema:name xml:lang="en">Hibiki Ganaha</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">152.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">41.0</schema:weight>

--- a/RDFs/765MillionStars.rdf
+++ b/RDFs/765MillionStars.rdf
@@ -18,7 +18,7 @@
     <imas:nameKana xml:lang="ja">かすがみらい</imas:nameKana>
     <schema:name xml:lang="ja">春日未来</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">春日未来</rdfs:label>
-    <schema:name xml:lang="en">Kasuga Mirai</schema:name>
+    <schema:name xml:lang="en">Mirai Kasuga</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">156.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
@@ -55,7 +55,7 @@
     <imas:nameKana xml:lang="ja">もがみしずか</imas:nameKana>
     <schema:name xml:lang="ja">最上静香</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">最上静香</rdfs:label>
-    <schema:name xml:lang="en">Mogami Shizuka</schema:name>
+    <schema:name xml:lang="en">Shizuka Mogami</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">162.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">44.0</schema:weight>
@@ -92,7 +92,7 @@
     <imas:nameKana xml:lang="ja">いぶきつばさ</imas:nameKana>
     <schema:name xml:lang="ja">伊吹翼</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">伊吹翼</rdfs:label>
-    <schema:name xml:lang="en">Ibuki Tsubasa</schema:name>
+    <schema:name xml:lang="en">Tsubasa Ibuki</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">158.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
@@ -129,7 +129,7 @@
     <imas:nameKana xml:lang="ja">たなかことは</imas:nameKana>
     <schema:name xml:lang="ja">田中琴葉</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">田中琴葉</rdfs:label>
-    <schema:name xml:lang="en">Tanaka Kotoha</schema:name>
+    <schema:name xml:lang="en">Kotoha Tanaka</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">157.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">44.0</schema:weight>
@@ -166,7 +166,7 @@
     <imas:nameKana xml:lang="ja">しまばらえれな</imas:nameKana>
     <schema:name xml:lang="ja">島原エレナ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">島原エレナ</rdfs:label>
-    <schema:name xml:lang="en">Shimabara Elena</schema:name>
+    <schema:name xml:lang="en">Elena Shimabara</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">160.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">47.0</schema:weight>
@@ -203,7 +203,7 @@
     <imas:nameKana xml:lang="ja">さたけみなこ</imas:nameKana>
     <schema:name xml:lang="ja">佐竹美奈子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">佐竹美奈子</rdfs:label>
-    <schema:name xml:lang="en">Satake Minako</schema:name>
+    <schema:name xml:lang="en">Minako Satake</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">158.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
@@ -240,7 +240,7 @@
     <imas:nameKana xml:lang="ja">ところめぐみ</imas:nameKana>
     <schema:name xml:lang="ja">所恵美</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">所恵美</rdfs:label>
-    <schema:name xml:lang="en">Tokoro Megumi</schema:name>
+    <schema:name xml:lang="en">Megumi Tokoro</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">159.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">47.0</schema:weight>
@@ -277,7 +277,7 @@
     <imas:nameKana xml:lang="ja">とくがわまつり</imas:nameKana>
     <schema:name xml:lang="ja">徳川まつり</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">徳川まつり</rdfs:label>
-    <schema:name xml:lang="en">Tokugawa Matsuri</schema:name>
+    <schema:name xml:lang="en">Matsuri Tokugawa</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">163.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">44.0</schema:weight>
@@ -315,7 +315,7 @@
     <imas:nameKana xml:lang="ja">はこざきせりか</imas:nameKana>
     <schema:name xml:lang="ja">箱崎星梨花</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">箱崎星梨花</rdfs:label>
-    <schema:name xml:lang="en">Hakozaki Serika</schema:name>
+    <schema:name xml:lang="en">Serika Hakozaki</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">146.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">37.0</schema:weight>
@@ -353,7 +353,7 @@
     <imas:nameKana xml:lang="ja">ののはらあかね</imas:nameKana>
     <schema:name xml:lang="ja">野々原茜</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">野々原茜</rdfs:label>
-    <schema:name xml:lang="en">Nonohara Akane</schema:name>
+    <schema:name xml:lang="en">Akane Nonohara</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">150.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
@@ -390,7 +390,7 @@
     <imas:nameKana xml:lang="ja">もちづきあんな</imas:nameKana>
     <schema:name xml:lang="ja">望月杏奈</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">望月杏奈</rdfs:label>
-    <schema:name xml:lang="en">Mochizuki Anna</schema:name>
+    <schema:name xml:lang="en">Anna Mochizuki</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">152.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">41.0</schema:weight>
@@ -430,7 +430,7 @@
     <imas:nameKana xml:lang="ja">はんだろこ</imas:nameKana>
     <schema:name xml:lang="ja">伴田路子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ロコ</rdfs:label>
-    <schema:name xml:lang="en">Handa Roco</schema:name>
+    <schema:name xml:lang="en">Roco Handa</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">154.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
@@ -467,7 +467,7 @@
     <imas:nameKana xml:lang="ja">ななおゆりこ</imas:nameKana>
     <schema:name xml:lang="ja">七尾百合子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">七尾百合子</rdfs:label>
-    <schema:name xml:lang="en">Nanao Yuriko</schema:name>
+    <schema:name xml:lang="en">Yuriko Nanao</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">154.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">41.0</schema:weight>
@@ -504,7 +504,7 @@
     <imas:nameKana xml:lang="ja">たかやまさよこ</imas:nameKana>
     <schema:name xml:lang="ja">高山紗代子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">高山紗代子</rdfs:label>
-    <schema:name xml:lang="en">Takayama Sayoko</schema:name>
+    <schema:name xml:lang="en">Sayoko Takayama</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">156.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
@@ -542,7 +542,7 @@
     <imas:nameKana xml:lang="ja">まつだありさ</imas:nameKana>
     <schema:name xml:lang="ja">松田亜利沙</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">松田亜利沙</rdfs:label>
-    <schema:name xml:lang="en">Matsuda Arisa</schema:name>
+    <schema:name xml:lang="en">Arisa Matsuda</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">154.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">40.0</schema:weight>
@@ -579,7 +579,7 @@
     <imas:nameKana xml:lang="ja">こうさかうみ</imas:nameKana>
     <schema:name xml:lang="ja">高坂海美</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">高坂海美</rdfs:label>
-    <schema:name xml:lang="en">Kousaka Umi</schema:name>
+    <schema:name xml:lang="en">Umi Kousaka</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">155.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
@@ -616,7 +616,7 @@
     <imas:nameKana xml:lang="ja">なかたにいく</imas:nameKana>
     <schema:name xml:lang="ja">中谷育</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">中谷育</rdfs:label>
-    <schema:name xml:lang="en">Nakatani Iku</schema:name>
+    <schema:name xml:lang="en">Iku Nakatani</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">142.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">37.0</schema:weight>
@@ -653,7 +653,7 @@
     <imas:nameKana xml:lang="ja">てんくうばしともか</imas:nameKana>
     <schema:name xml:lang="ja">天空橋朋花</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">天空橋朋花</rdfs:label>
-    <schema:name xml:lang="en">Tenkubashi Tomoka</schema:name>
+    <schema:name xml:lang="en">Tomoka Tenkubashi</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">156.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">41.0</schema:weight>
@@ -690,7 +690,7 @@
     <imas:nameKana xml:lang="ja">えみりーすちゅあーと</imas:nameKana>
     <schema:name xml:lang="ja">エミリースチュアート</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エミリー</rdfs:label>
-    <schema:name xml:lang="en">Emily Stewart</schema:name>
+    <schema:name xml:lang="en">Stewart Emily</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">156.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">41.0</schema:weight>
@@ -727,7 +727,7 @@
     <imas:nameKana xml:lang="ja">きたざわしほ</imas:nameKana>
     <schema:name xml:lang="ja">北沢志保</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">北沢志保</rdfs:label>
-    <schema:name xml:lang="en">Kitazawa Shiho</schema:name>
+    <schema:name xml:lang="en">Shiho Kitazawa</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">161.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">46.0</schema:weight>
@@ -765,7 +765,7 @@
     <imas:nameKana xml:lang="ja">まいはまあゆむ</imas:nameKana>
     <schema:name xml:lang="ja">舞浜歩</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">舞浜歩</rdfs:label>
-    <schema:name xml:lang="en">Maihama Ayumu</schema:name>
+    <schema:name xml:lang="en">Ayumu Maihama</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">158.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">49.9</schema:weight>
@@ -802,7 +802,7 @@
     <imas:nameKana xml:lang="ja">きのしたひなた</imas:nameKana>
     <schema:name xml:lang="ja">木下ひなた</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">木下ひなた</rdfs:label>
-    <schema:name xml:lang="en">Kinoshita Hinata</schema:name>
+    <schema:name xml:lang="en">Hinata Kinoshita</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">146.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">39.5</schema:weight>
@@ -839,7 +839,7 @@
     <imas:nameKana xml:lang="ja">やぶきかな</imas:nameKana>
     <schema:name xml:lang="ja">矢吹可奈</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">矢吹可奈</rdfs:label>
-    <schema:name xml:lang="en">Yabuki Kana</schema:name>
+    <schema:name xml:lang="en">Kana Yabuki</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">155.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
@@ -876,7 +876,7 @@
     <imas:nameKana xml:lang="ja">よこやまなお</imas:nameKana>
     <schema:name xml:lang="ja">横山奈緒</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">横山奈緒</rdfs:label>
-    <schema:name xml:lang="en">Yokoyama Nao</schema:name>
+    <schema:name xml:lang="en">Nao Yokoyama</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">159.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">46.0</schema:weight>
@@ -913,7 +913,7 @@
     <imas:nameKana xml:lang="ja">にかいどうちづる</imas:nameKana>
     <schema:name xml:lang="ja">二階堂千鶴</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">二階堂千鶴</rdfs:label>
-    <schema:name xml:lang="en">Nikaido Chizuru</schema:name>
+    <schema:name xml:lang="en">Chizuru Nikaido</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">165.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">50.0</schema:weight>
@@ -950,7 +950,7 @@
     <imas:nameKana xml:lang="ja">ばばこのみ</imas:nameKana>
     <schema:name xml:lang="ja">馬場このみ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">馬場このみ</rdfs:label>
-    <schema:name xml:lang="en">Baba Konomi</schema:name>
+    <schema:name xml:lang="en">Konomi Baba</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">24</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">143.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">37.0</schema:weight>
@@ -987,7 +987,7 @@
     <imas:nameKana xml:lang="ja">おおがみたまき</imas:nameKana>
     <schema:name xml:lang="ja">大神環</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">大神環</rdfs:label>
-    <schema:name xml:lang="en">Ogami Tamaki</schema:name>
+    <schema:name xml:lang="en">Tamaki Ogami</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">147.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">39.0</schema:weight>
@@ -1024,7 +1024,7 @@
     <imas:nameKana xml:lang="ja">とよかわふうか</imas:nameKana>
     <schema:name xml:lang="ja">豊川風花</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">豊川風花</rdfs:label>
-    <schema:name xml:lang="en">Toyokawa Fuka</schema:name>
+    <schema:name xml:lang="en">Fuka Toyokawa</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">22</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">162.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">51.0</schema:weight>
@@ -1061,7 +1061,7 @@
     <imas:nameKana xml:lang="ja">みやおみや</imas:nameKana>
     <schema:name xml:lang="ja">宮尾美也</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">宮尾美也</rdfs:label>
-    <schema:name xml:lang="en">Miyao Miya</schema:name>
+    <schema:name xml:lang="en">Miya Miyao</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">156.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">46.0</schema:weight>
@@ -1099,7 +1099,7 @@
     <imas:nameKana xml:lang="ja">ふくだのりこ</imas:nameKana>
     <schema:name xml:lang="ja">福田のり子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">福田のり子</rdfs:label>
-    <schema:name xml:lang="en">Fukuda Noriko</schema:name>
+    <schema:name xml:lang="en">Noriko Fukuda</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">164.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">48.0</schema:weight>
@@ -1136,7 +1136,7 @@
     <imas:nameKana xml:lang="ja">まかべみずき</imas:nameKana>
     <schema:name xml:lang="ja">真壁瑞希</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">真壁瑞希</rdfs:label>
-    <schema:name xml:lang="en">Makabe Mizuki</schema:name>
+    <schema:name xml:lang="en">Mizuki Makabe</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">160.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">43.0</schema:weight>
@@ -1173,7 +1173,7 @@
     <imas:nameKana xml:lang="ja">しのみやかれん</imas:nameKana>
     <schema:name xml:lang="ja">篠宮可憐</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">篠宮可憐</rdfs:label>
-    <schema:name xml:lang="en">Shinomiya Karen</schema:name>
+    <schema:name xml:lang="en">Karen Shinomiya</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">159.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">48.0</schema:weight>
@@ -1210,7 +1210,7 @@
     <imas:nameKana xml:lang="ja">ももせりお</imas:nameKana>
     <schema:name xml:lang="ja">百瀬莉緒</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">百瀬莉緒</rdfs:label>
-    <schema:name xml:lang="en">Momose Rio</schema:name>
+    <schema:name xml:lang="en">Rio Momose</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">168.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">46.0</schema:weight>
@@ -1247,7 +1247,7 @@
     <imas:nameKana xml:lang="ja">ながよしすばる</imas:nameKana>
     <schema:name xml:lang="ja">永吉昴</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">永吉昴</rdfs:label>
-    <schema:name xml:lang="en">Nagayoshi Subaru</schema:name>
+    <schema:name xml:lang="en">Subaru Nagayoshi</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">154.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">41.0</schema:weight>
@@ -1284,7 +1284,7 @@
     <imas:nameKana xml:lang="ja">きたかみれいか</imas:nameKana>
     <schema:name xml:lang="ja">北上麗花</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">北上麗花</rdfs:label>
-    <schema:name xml:lang="en">Kitakami Reika</schema:name>
+    <schema:name xml:lang="en">Reika Kitakami</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">164.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">47.0</schema:weight>
@@ -1321,7 +1321,7 @@
     <imas:nameKana xml:lang="ja">すおうももこ</imas:nameKana>
     <schema:name xml:lang="ja">周防桃子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">周防桃子</rdfs:label>
-    <schema:name xml:lang="en">Suou Momoko</schema:name>
+    <schema:name xml:lang="en">Momoko Suou</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">140.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">35.0</schema:weight>
@@ -1389,7 +1389,7 @@
     <imas:nameKana xml:lang="ja">しらいしつむぎ</imas:nameKana>
     <schema:name xml:lang="ja">白石紬</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">白石紬</rdfs:label>
-    <schema:name xml:lang="en">Shiraishi Tsumugi</schema:name>
+    <schema:name xml:lang="en">Tsumugi Shiraishi</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">160.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
@@ -1428,7 +1428,7 @@
     <imas:nameKana xml:lang="ja">さくらもりかおり</imas:nameKana>
     <schema:name xml:lang="ja">桜守歌織</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">桜守歌織</rdfs:label>
-    <schema:name xml:lang="en">Sakuramori Kaori</schema:name>
+    <schema:name xml:lang="en">Kaori Sakuramori</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">165.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">47.0</schema:weight>

--- a/RDFs/765MillionStars.rdf
+++ b/RDFs/765MillionStars.rdf
@@ -690,7 +690,7 @@
     <imas:nameKana xml:lang="ja">えみりーすちゅあーと</imas:nameKana>
     <schema:name xml:lang="ja">エミリースチュアート</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エミリー</rdfs:label>
-    <schema:name xml:lang="en">Stewart Emily</schema:name>
+    <schema:name xml:lang="en">Emily Stewart</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">156.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">41.0</schema:weight>

--- a/RDFs/876.rdf
+++ b/RDFs/876.rdf
@@ -17,7 +17,7 @@
     <imas:nameKana xml:lang="ja">ひだかあい</imas:nameKana>
     <schema:name xml:lang="ja">日高愛</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">日高愛</rdfs:label>
-    <schema:name xml:lang="en">Hidaka Ai</schema:name>
+    <schema:name xml:lang="en">Ai Hidaka</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">149.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">40.0</schema:weight>
@@ -50,7 +50,7 @@
     <imas:nameKana xml:lang="ja">みずたにえり</imas:nameKana>
     <schema:name xml:lang="ja">水谷絵理</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">水谷絵理</rdfs:label>
-    <schema:name xml:lang="en">Mizutani Eri</schema:name>
+    <schema:name xml:lang="en">Eri Mizutani</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">152.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">36.0</schema:weight>
@@ -83,7 +83,7 @@
     <imas:nameKana xml:lang="ja">あきづきりょう</imas:nameKana>
     <schema:name xml:lang="ja">秋月涼</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">秋月涼</rdfs:label>
-    <schema:name xml:lang="en">Akizuki Ryo</schema:name>
+    <schema:name xml:lang="en">Ryo Akizuki</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">162.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">54.0</schema:weight>
@@ -116,7 +116,7 @@
     <imas:nameKana xml:lang="ja">さくらいゆめこ</imas:nameKana>
     <schema:name xml:lang="ja">桜井夢子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">桜井夢子</rdfs:label>
-    <schema:name xml:lang="en">Sakurai Yumeko</schema:name>
+    <schema:name xml:lang="en">Yumeko Sakurai</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">156.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">45.0</schema:weight>
@@ -149,7 +149,7 @@
     <imas:nameKana xml:lang="ja">すずきあやね</imas:nameKana>
     <schema:name xml:lang="ja">鈴木彩音</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">サイネリア</rdfs:label>
-    <schema:name xml:lang="en">Suzuki Ayane</schema:name>
+    <schema:name xml:lang="en">Ayane Suzuki</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">147.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">39.0</schema:weight>
@@ -180,7 +180,7 @@
     <imas:nameKana xml:lang="ja">とうごうじれいか</imas:nameKana>
     <schema:name xml:lang="ja">東豪寺麗華</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">東豪寺麗華</rdfs:label>
-    <schema:name xml:lang="en">Togoji Reika</schema:name>
+    <schema:name xml:lang="en">Reika Togoji</schema:name>
     <imas:cv xml:lang="ja">今野宏美</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/今野宏美"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q843178"/>
@@ -199,7 +199,7 @@
     <imas:nameKana xml:lang="ja">あさひなりん</imas:nameKana>
     <schema:name xml:lang="ja">朝比奈りん</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">朝比奈りん</rdfs:label>
-    <schema:name xml:lang="en">Asahina Rin</schema:name>
+    <schema:name xml:lang="en">Rin Asahina</schema:name>
     <imas:cv xml:lang="ja">阿澄佳奈</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/阿澄佳奈"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q49474"/>
@@ -218,7 +218,7 @@
     <imas:nameKana xml:lang="ja">さんじょうともみ</imas:nameKana>
     <schema:name xml:lang="ja">三条ともみ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">三条ともみ</rdfs:label>
-    <schema:name xml:lang="en">Sanjo Tomomi</schema:name>
+    <schema:name xml:lang="en">Tomomi Sanjo</schema:name>
     <imas:cv xml:lang="ja">茅原実里</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/茅原実里"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q256910"/>

--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -21,7 +21,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">島村卯月</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">島村卯月</rdfs:label>
-    <schema:name xml:lang="en">Shimamura Uzuki</schema:name>
+    <schema:name xml:lang="en">Uzuki Shimamura</schema:name>
     <imas:nameKana xml:lang="ja">しまむらうづき</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">159.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
@@ -55,7 +55,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">中野有香</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">中野有香</rdfs:label>
-    <schema:name xml:lang="en">Nakano Yuka</schema:name>
+    <schema:name xml:lang="en">Yuka Nakano</schema:name>
     <imas:nameKana xml:lang="ja">なかのゆか</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">149.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
@@ -89,7 +89,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">水本ゆかり</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">水本ゆかり</rdfs:label>
-    <schema:name xml:lang="en">Mizumoto Yukari</schema:name>
+    <schema:name xml:lang="en">Yukari Mizumoto</schema:name>
     <imas:nameKana xml:lang="ja">みずもとゆかり</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">155.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -123,7 +123,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">福山舞</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">福山舞</rdfs:label>
-    <schema:name xml:lang="en">Fukuyama Mai</schema:name>
+    <schema:name xml:lang="en">Mai Fukuyama</schema:name>
     <imas:nameKana xml:lang="ja">ふくやままい</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">132.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</foaf:age>
@@ -153,7 +153,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">椎名法子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">椎名法子</rdfs:label>
-    <schema:name xml:lang="en">Shiina Noriko</schema:name>
+    <schema:name xml:lang="en">Noriko Shiina</schema:name>
     <imas:nameKana xml:lang="ja">しいなのりこ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">147.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</foaf:age>
@@ -187,7 +187,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">今井加奈</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">今井加奈</rdfs:label>
-    <schema:name xml:lang="en">Imai Kana</schema:name>
+    <schema:name xml:lang="en">Kana Imai</schema:name>
     <imas:nameKana xml:lang="ja">いまいかな</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">153.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
@@ -217,7 +217,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">持田亜里沙</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">持田亜里沙</rdfs:label>
-    <schema:name xml:lang="en">Mochida Arisa</schema:name>
+    <schema:name xml:lang="en">Arisa Mochida</schema:name>
     <imas:nameKana xml:lang="ja">もちだありさ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">156.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</foaf:age>
@@ -247,7 +247,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">三村かな子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">三村かな子</rdfs:label>
-    <schema:name xml:lang="en">Mimura Kanako</schema:name>
+    <schema:name xml:lang="en">Kanako Mimura</schema:name>
     <imas:nameKana xml:lang="ja">みむらかなこ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">153.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
@@ -281,7 +281,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">奥山沙織</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">奥山沙織</rdfs:label>
-    <schema:name xml:lang="en">Okuyama Saori</schema:name>
+    <schema:name xml:lang="en">Saori Okuyama</schema:name>
     <imas:nameKana xml:lang="ja">おくやまさおり</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">156.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
@@ -311,7 +311,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">間中美里</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">間中美里</rdfs:label>
-    <schema:name xml:lang="en">Manaka Misato</schema:name>
+    <schema:name xml:lang="en">Misato Manaka</schema:name>
     <imas:nameKana xml:lang="ja">まなかみさと</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">160.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</foaf:age>
@@ -341,7 +341,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">小日向美穂</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">小日向美穂</rdfs:label>
-    <schema:name xml:lang="en">Kohinata Miho</schema:name>
+    <schema:name xml:lang="en">Miho Kohinata</schema:name>
     <imas:nameKana xml:lang="ja">こひなたみほ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">155.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
@@ -375,7 +375,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">緒方智絵里</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">緒方智絵里</rdfs:label>
-    <schema:name xml:lang="en">Ogata Chieri</schema:name>
+    <schema:name xml:lang="en">Chieri Ogata</schema:name>
     <imas:nameKana xml:lang="ja">おがたちえり</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">153.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
@@ -409,7 +409,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">五十嵐響子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">五十嵐響子</rdfs:label>
-    <schema:name xml:lang="en">Igarashi Kyoko</schema:name>
+    <schema:name xml:lang="en">Kyoko Igarashi</schema:name>
     <imas:nameKana xml:lang="ja">いがらしきょうこ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">154.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -443,7 +443,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">柳瀬美由紀</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">柳瀬美由紀</rdfs:label>
-    <schema:name xml:lang="en">Yanase Miyuki</schema:name>
+    <schema:name xml:lang="en">Miyuki Yanase</schema:name>
     <imas:nameKana xml:lang="ja">やなせみゆき</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">144.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
@@ -473,7 +473,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">櫻井桃華</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">櫻井桃華</rdfs:label>
-    <schema:name xml:lang="en">Sakurai Momoka</schema:name>
+    <schema:name xml:lang="en">Momoka Sakurai</schema:name>
     <imas:nameKana xml:lang="ja">さくらいももか</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">145.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</foaf:age>
@@ -507,7 +507,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">江上椿</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">江上椿</rdfs:label>
-    <schema:name xml:lang="en">Egami Tsubaki</schema:name>
+    <schema:name xml:lang="en">Tsubaki Egami</schema:name>
     <imas:nameKana xml:lang="ja">えがみつばき</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">161.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
@@ -537,7 +537,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">長富蓮実</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">長富蓮実</rdfs:label>
-    <schema:name xml:lang="en">Nagatomi Hasumi</schema:name>
+    <schema:name xml:lang="en">Hasumi Nagatomi</schema:name>
     <imas:nameKana xml:lang="ja">ながとみはすみ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">161.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
@@ -568,7 +568,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">横山千佳</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">横山千佳</rdfs:label>
-    <schema:name xml:lang="en">Yokoyama Chika</schema:name>
+    <schema:name xml:lang="en">Chika Yokoyama</schema:name>
     <imas:nameKana xml:lang="ja">よこやまちか</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">127.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</foaf:age>
@@ -598,7 +598,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">関裕美</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">関裕美</rdfs:label>
-    <schema:name xml:lang="en">Seki Hiromi</schema:name>
+    <schema:name xml:lang="en">Hiromi Seki</schema:name>
     <imas:nameKana xml:lang="ja">せきひろみ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">155.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
@@ -632,7 +632,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">太田優</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">太田優</rdfs:label>
-    <schema:name xml:lang="en">Ohta Yuu</schema:name>
+    <schema:name xml:lang="en">Yuu Ohta</schema:name>
     <imas:nameKana xml:lang="ja">おおたゆう</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">159.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</foaf:age>
@@ -663,7 +663,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">棟方愛海</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">棟方愛海</rdfs:label>
-    <schema:name xml:lang="en">Munakata Atsumi</schema:name>
+    <schema:name xml:lang="en">Atsumi Munakata</schema:name>
     <imas:nameKana xml:lang="ja">むなかたあつみ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">151.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
@@ -697,7 +697,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">藤本里奈</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">藤本里奈</rdfs:label>
-    <schema:name xml:lang="en">Fujimoto Rina</schema:name>
+    <schema:name xml:lang="en">Rina Fujimoto</schema:name>
     <imas:nameKana xml:lang="ja">ふじもとりな</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">154.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
@@ -732,7 +732,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">大原みちる</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">大原みちる</rdfs:label>
-    <schema:name xml:lang="en">Ohara Michiru</schema:name>
+    <schema:name xml:lang="en">Michiru Ohara</schema:name>
     <imas:nameKana xml:lang="ja">おおはらみちる</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">153.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -762,7 +762,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">遊佐こずえ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">遊佐こずえ</rdfs:label>
-    <schema:name xml:lang="en">Yusa Kozue</schema:name>
+    <schema:name xml:lang="en">Kozue Yusa</schema:name>
     <imas:nameKana xml:lang="ja">ゆさこずえ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">130.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</foaf:age>
@@ -795,7 +795,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">大沼くるみ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">大沼くるみ</rdfs:label>
-    <schema:name xml:lang="en">Ohnuma Kurumi</schema:name>
+    <schema:name xml:lang="en">Kurumi Ohnuma</schema:name>
     <imas:nameKana xml:lang="ja">おおぬまくるみ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">145.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</foaf:age>
@@ -826,7 +826,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">一ノ瀬志希</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">一ノ瀬志希</rdfs:label>
-    <schema:name xml:lang="en">Ichinose Shiki</schema:name>
+    <schema:name xml:lang="en">Shiki Ichinose</schema:name>
     <imas:nameKana xml:lang="ja">いちのせしき</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">161.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
@@ -864,7 +864,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">前川みく</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">前川みく</rdfs:label>
-    <schema:name xml:lang="en">Maekawa Miku</schema:name>
+    <schema:name xml:lang="en">Miku Maekawa</schema:name>
     <imas:nameKana xml:lang="ja">まえかわみく</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">152.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -898,7 +898,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">赤西瑛梨華</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">赤西瑛梨華</rdfs:label>
-    <schema:name xml:lang="en">Akanishi Erika</schema:name>
+    <schema:name xml:lang="en">Erika Akanishi</schema:name>
     <imas:nameKana xml:lang="ja">あかにしえりか</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">154.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
@@ -928,7 +928,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">松原早耶</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">松原早耶</rdfs:label>
-    <schema:name xml:lang="en">Matsubara Saya</schema:name>
+    <schema:name xml:lang="en">Saya Matsubara</schema:name>
     <imas:nameKana xml:lang="ja">まつばらさや</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">156.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
@@ -958,7 +958,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">相原雪乃</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">相原雪乃</rdfs:label>
-    <schema:name xml:lang="en">Aihara Yukino</schema:name>
+    <schema:name xml:lang="en">Yukino Aihara</schema:name>
     <imas:nameKana xml:lang="ja">あいはらゆきの</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">160.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">22</foaf:age>
@@ -988,7 +988,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">宮本フレデリカ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">宮本フレデリカ</rdfs:label>
-    <schema:name xml:lang="en">Miyamoto Frederica</schema:name>
+    <schema:name xml:lang="en">Frederica Miyamoto</schema:name>
     <imas:nameKana xml:lang="ja">みやもとふれでりか</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">164.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
@@ -1024,7 +1024,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">小早川紗枝</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">小早川紗枝</rdfs:label>
-    <schema:name xml:lang="en">Kobayakawa Sae</schema:name>
+    <schema:name xml:lang="en">Sae Kobayakawa</schema:name>
     <imas:nameKana xml:lang="ja">こばやかわさえ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">148.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -1058,7 +1058,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">西園寺琴歌</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">西園寺琴歌</rdfs:label>
-    <schema:name xml:lang="en">Saionji Kotoka</schema:name>
+    <schema:name xml:lang="en">Kotoka Saionji</schema:name>
     <imas:nameKana xml:lang="ja">さいおんじことか</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">156.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
@@ -1088,7 +1088,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">双葉杏</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">双葉杏</rdfs:label>
-    <schema:name xml:lang="en">Futaba Anzu</schema:name>
+    <schema:name xml:lang="en">Anzu Futaba</schema:name>
     <imas:nameKana xml:lang="ja">ふたばあんず</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">139.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
@@ -1122,7 +1122,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">楊菲菲</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">楊菲菲</rdfs:label>
-    <schema:name xml:lang="en">Yao Fueifuei</schema:name>
+    <schema:name xml:lang="en">Fueifuei Yao</schema:name>
     <imas:nameKana xml:lang="ja">やおふぇいふぇい</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">152.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -1152,7 +1152,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">桃井あずき</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">桃井あずき</rdfs:label>
-    <schema:name xml:lang="en">Momoi Azuki</schema:name>
+    <schema:name xml:lang="en">Azuki Momoi</schema:name>
     <imas:nameKana xml:lang="ja">ももいあずき</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">145.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -1182,7 +1182,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">涼宮星花</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">涼宮星花</rdfs:label>
-    <schema:name xml:lang="en">Suzumiya Seika</schema:name>
+    <schema:name xml:lang="en">Seika Suzumiya</schema:name>
     <imas:nameKana xml:lang="ja">すずみやせいか</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">158.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
@@ -1212,7 +1212,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">月宮雅</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">月宮雅</rdfs:label>
-    <schema:name xml:lang="en">Tsukimiya Miyabi</schema:name>
+    <schema:name xml:lang="en">Miyabi Tsukimiya</schema:name>
     <imas:nameKana xml:lang="ja">つきみやみやび</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">153.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
@@ -1242,7 +1242,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">兵藤レナ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">兵藤レナ</rdfs:label>
-    <schema:name xml:lang="en">Hyodo Rena</schema:name>
+    <schema:name xml:lang="en">Rena Hyodo</schema:name>
     <imas:nameKana xml:lang="ja">ひょうどうれな</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">167.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">27</foaf:age>
@@ -1272,7 +1272,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">丹羽仁美</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">丹羽仁美</rdfs:label>
-    <schema:name xml:lang="en">Niwa Hitomi</schema:name>
+    <schema:name xml:lang="en">Hitomi Niwa</schema:name>
     <imas:nameKana xml:lang="ja">にわひとみ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">157.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
@@ -1303,7 +1303,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">道明寺歌鈴</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">道明寺歌鈴</rdfs:label>
-    <schema:name xml:lang="en">Domyoji Karin</schema:name>
+    <schema:name xml:lang="en">Karin Domyoji</schema:name>
     <imas:nameKana xml:lang="ja">どうみょうじかりん</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">155.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
@@ -1337,7 +1337,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">柳清良</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">柳清良</rdfs:label>
-    <schema:name xml:lang="en">Yanagi Kiyora</schema:name>
+    <schema:name xml:lang="en">Kiyora Yanagi</schema:name>
     <imas:nameKana xml:lang="ja">やなぎきよら</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">158.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</foaf:age>
@@ -1367,7 +1367,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">井村雪菜</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">井村雪菜</rdfs:label>
-    <schema:name xml:lang="en">Imura Setsuna</schema:name>
+    <schema:name xml:lang="en">Setsuna Imura</schema:name>
     <imas:nameKana xml:lang="ja">いむらせつな</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">163.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
@@ -1397,7 +1397,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">日下部若葉</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">日下部若葉</rdfs:label>
-    <schema:name xml:lang="en">Kusakabe Wakaba</schema:name>
+    <schema:name xml:lang="en">Wakaba Kusakabe</schema:name>
     <imas:nameKana xml:lang="ja">くさかべわかば</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">148.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</foaf:age>
@@ -1427,7 +1427,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">榊原里美</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">榊原里美</rdfs:label>
-    <schema:name xml:lang="en">Sakakibara Satomi</schema:name>
+    <schema:name xml:lang="en">Satomi Sakakibara</schema:name>
     <imas:nameKana xml:lang="ja">さかきばらさとみ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">162.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
@@ -1457,7 +1457,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">輿水幸子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">輿水幸子</rdfs:label>
-    <schema:name xml:lang="en">Koshimizu Sachiko</schema:name>
+    <schema:name xml:lang="en">Sachiko Koshimizu</schema:name>
     <imas:nameKana xml:lang="ja">こしみずさちこ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">142.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
@@ -1491,7 +1491,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">安斎都</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">安斎都</rdfs:label>
-    <schema:name xml:lang="en">Anzai Miyako</schema:name>
+    <schema:name xml:lang="en">Miyako Anzai</schema:name>
     <imas:nameKana xml:lang="ja">あんざいみやこ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">156.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
@@ -1522,7 +1522,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">浅野風香</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">浅野風香</rdfs:label>
-    <schema:name xml:lang="en">Asano Fuka</schema:name>
+    <schema:name xml:lang="en">Fuka Asano</schema:name>
     <imas:nameKana xml:lang="ja">あさのふうか</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">160.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
@@ -1552,7 +1552,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">大西由里子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">大西由里子</rdfs:label>
-    <schema:name xml:lang="en">Ohnishi Yuriko</schema:name>
+    <schema:name xml:lang="en">Yuriko Ohnishi</schema:name>
     <imas:nameKana xml:lang="ja">おおにしゆりこ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">156.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</foaf:age>
@@ -1583,7 +1583,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">安部菜々</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">安部菜々</rdfs:label>
-    <schema:name xml:lang="en">Abe Nana</schema:name>
+    <schema:name xml:lang="en">Nana Abe</schema:name>
     <imas:nameKana xml:lang="ja">あべなな</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">146.0</schema:height>
     <foaf:age xml:lang="ja">永遠の17</foaf:age>
@@ -1617,7 +1617,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">工藤忍</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">工藤忍</rdfs:label>
-    <schema:name xml:lang="en">Kudo Shinobu</schema:name>
+    <schema:name xml:lang="en">Shinobu Kudo</schema:name>
     <imas:nameKana xml:lang="ja">くどうしのぶ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">154.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
@@ -1647,7 +1647,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">栗原ネネ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">栗原ネネ</rdfs:label>
-    <schema:name xml:lang="en">Kurihara Nene</schema:name>
+    <schema:name xml:lang="en">Nene Kurihara</schema:name>
     <imas:nameKana xml:lang="ja">くりはらねね</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">161.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -1678,7 +1678,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">古賀小春</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">古賀小春</rdfs:label>
-    <schema:name xml:lang="en">Koga Koharu</schema:name>
+    <schema:name xml:lang="en">Koharu Koga</schema:name>
     <imas:nameKana xml:lang="ja">こがこはる</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">140.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</foaf:age>
@@ -1703,7 +1703,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">クラリス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">クラリス</rdfs:label>
-    <schema:name xml:lang="en">Clarice</schema:name>
+    <schema:name xml:lang="en">larice C</schema:name>
     <imas:nameKana xml:lang="ja">くらりす</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">166.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</foaf:age>
@@ -1733,7 +1733,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">佐久間まゆ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">佐久間まゆ</rdfs:label>
-    <schema:name xml:lang="en">Sakuma Mayu</schema:name>
+    <schema:name xml:lang="en">Mayu Sakuma</schema:name>
     <imas:nameKana xml:lang="ja">さくままゆ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">153.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
@@ -1768,7 +1768,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">村松さくら</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">村松さくら</rdfs:label>
-    <schema:name xml:lang="en">Muramatsu Sakura</schema:name>
+    <schema:name xml:lang="en">Sakura Muramatsu</schema:name>
     <imas:nameKana xml:lang="ja">むらまつさくら</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">145.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -1798,7 +1798,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">白菊ほたる</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">白菊ほたる</rdfs:label>
-    <schema:name xml:lang="en">Shiragiku Hotaru</schema:name>
+    <schema:name xml:lang="en">Hotaru Shiragiku</schema:name>
     <imas:nameKana xml:lang="ja">しらぎくほたる</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">156.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</foaf:age>
@@ -1833,7 +1833,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">早坂美玲</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">早坂美玲</rdfs:label>
-    <schema:name xml:lang="en">Hayasaka Mirei</schema:name>
+    <schema:name xml:lang="en">Mirei Hayasaka</schema:name>
     <imas:nameKana xml:lang="ja">はやさかみれい</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">147.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
@@ -1867,7 +1867,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">有浦柑奈</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">有浦柑奈</rdfs:label>
-    <schema:name xml:lang="en">Ariura Kanna</schema:name>
+    <schema:name xml:lang="en">Kanna Ariura</schema:name>
     <imas:nameKana xml:lang="ja">ありうらかんな</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">155.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
@@ -1897,7 +1897,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">乙倉悠貴</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">乙倉悠貴</rdfs:label>
-    <schema:name xml:lang="en">Otokura Yuuki</schema:name>
+    <schema:name xml:lang="en">Yuuki Otokura</schema:name>
     <imas:nameKana xml:lang="ja">おとくらゆうき</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">164.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</foaf:age>
@@ -1932,7 +1932,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">原田美世</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">原田美世</rdfs:label>
-    <schema:name xml:lang="en">Harada Miyo</schema:name>
+    <schema:name xml:lang="en">Miyo Harada</schema:name>
     <imas:nameKana xml:lang="ja">はらだみよ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">163.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</foaf:age>
@@ -1963,7 +1963,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">池袋晶葉</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">池袋晶葉</rdfs:label>
-    <schema:name xml:lang="en">Ikebukuro Akiha</schema:name>
+    <schema:name xml:lang="en">Akiha Ikebukuro</schema:name>
     <imas:nameKana xml:lang="ja">いけぶくろあきは</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">148.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
@@ -1993,7 +1993,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">辻野あかり</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">辻野あかり</rdfs:label>
-    <schema:name xml:lang="en">Tsujino Akari</schema:name>
+    <schema:name xml:lang="en">Akari Tsujino</schema:name>
     <imas:nameKana xml:lang="ja">つじのあかり</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">160.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -2026,7 +2026,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">白雪千夜</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">白雪千夜</rdfs:label>
-    <schema:name xml:lang="en">Shirayuki Chiyo</schema:name>
+    <schema:name xml:lang="en">Chiyo Shirayuki</schema:name>
     <imas:nameKana xml:lang="ja">しらゆきちよ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">157.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
@@ -2060,7 +2060,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">黒埼ちとせ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">黒埼ちとせ</rdfs:label>
-    <schema:name xml:lang="en">Kurosaki Chitose</schema:name>
+    <schema:name xml:lang="en">Chitose Kurosaki</schema:name>
     <imas:nameKana xml:lang="ja">くろさきちとせ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">164.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
@@ -2095,7 +2095,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">渋谷凛</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">渋谷凛</rdfs:label>
-    <schema:name xml:lang="en">Shibuya Rin</schema:name>
+    <schema:name xml:lang="en">Rin Shibuya</schema:name>
     <imas:nameKana xml:lang="ja">しぶやりん</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">165.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -2129,7 +2129,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">黒川千秋</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">黒川千秋</rdfs:label>
-    <schema:name xml:lang="en">Kurokawa Chiaki</schema:name>
+    <schema:name xml:lang="en">Chiaki Kurokawa</schema:name>
     <imas:nameKana xml:lang="ja">くろかわちあき</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">163.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</foaf:age>
@@ -2159,7 +2159,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">松本沙理奈</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">松本沙理奈</rdfs:label>
-    <schema:name xml:lang="en">Matsumoto Sarina</schema:name>
+    <schema:name xml:lang="en">Sarina Matsumoto</schema:name>
     <imas:nameKana xml:lang="ja">まつもとさりな</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">165.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">22</foaf:age>
@@ -2189,7 +2189,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">桐野アヤ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">桐野アヤ</rdfs:label>
-    <schema:name xml:lang="en">Kirino Aya</schema:name>
+    <schema:name xml:lang="en">Aya Kirino</schema:name>
     <imas:nameKana xml:lang="ja">きりのあや</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">160.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
@@ -2219,7 +2219,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">高橋礼子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">高橋礼子</rdfs:label>
-    <schema:name xml:lang="en">Takahashi Reiko</schema:name>
+    <schema:name xml:lang="en">Reiko Takahashi</schema:name>
     <imas:nameKana xml:lang="ja">たかはしれいこ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">167.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">31</foaf:age>
@@ -2249,7 +2249,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">相川千夏</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">相川千夏</rdfs:label>
-    <schema:name xml:lang="en">Aikawa Chinatsu</schema:name>
+    <schema:name xml:lang="en">Chinatsu Aikawa</schema:name>
     <imas:nameKana xml:lang="ja">あいかわちなつ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">161.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</foaf:age>
@@ -2279,7 +2279,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">川島瑞樹</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">川島瑞樹</rdfs:label>
-    <schema:name xml:lang="en">Kawashima Mizuki</schema:name>
+    <schema:name xml:lang="en">Mizuki Kawashima</schema:name>
     <imas:nameKana xml:lang="ja">かわしまみずき</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">159.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">28</foaf:age>
@@ -2314,7 +2314,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">神谷奈緒</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">神谷奈緒</rdfs:label>
-    <schema:name xml:lang="en">Kamiya Nao</schema:name>
+    <schema:name xml:lang="en">Nao Kamiya</schema:name>
     <imas:nameKana xml:lang="ja">かみやなお</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">154.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
@@ -2348,7 +2348,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">上条春菜</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">上条春菜</rdfs:label>
-    <schema:name xml:lang="en">Kamijo Haruna</schema:name>
+    <schema:name xml:lang="en">Haruna Kamijo</schema:name>
     <imas:nameKana xml:lang="ja">かみじょうはるな</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">156.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
@@ -2382,7 +2382,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">荒木比奈</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">荒木比奈</rdfs:label>
-    <schema:name xml:lang="en">Araki Hina</schema:name>
+    <schema:name xml:lang="en">Hina Araki</schema:name>
     <imas:nameKana xml:lang="ja">あらきひな</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">157.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</foaf:age>
@@ -2416,7 +2416,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">東郷あい</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">東郷あい</rdfs:label>
-    <schema:name xml:lang="en">Togo Ai</schema:name>
+    <schema:name xml:lang="en">Ai Togo</schema:name>
     <imas:nameKana xml:lang="ja">とうごうあい</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">167.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</foaf:age>
@@ -2446,7 +2446,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">多田李衣菜</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">多田李衣菜</rdfs:label>
-    <schema:name xml:lang="en">Tada Rina</schema:name>
+    <schema:name xml:lang="en">Rina Tada</schema:name>
     <imas:nameKana xml:lang="ja">ただりいな</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">152.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
@@ -2480,7 +2480,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">水木聖來</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">水木聖來</rdfs:label>
-    <schema:name xml:lang="en">Mizuki Seira</schema:name>
+    <schema:name xml:lang="en">Seira Mizuki</schema:name>
     <imas:nameKana xml:lang="ja">みずきせいら</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">155.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</foaf:age>
@@ -2510,7 +2510,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">佐々木千枝</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">佐々木千枝</rdfs:label>
-    <schema:name xml:lang="en">Sasaki Chie</schema:name>
+    <schema:name xml:lang="en">Chie Sasaki</schema:name>
     <imas:nameKana xml:lang="ja">ささきちえ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">139.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</foaf:age>
@@ -2544,7 +2544,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">三船美優</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">三船美優</rdfs:label>
-    <schema:name xml:lang="en">Mifune Miyu</schema:name>
+    <schema:name xml:lang="en">Miyu Mifune</schema:name>
     <imas:nameKana xml:lang="ja">みふねみゆ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">165.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">26</foaf:age>
@@ -2578,7 +2578,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">服部瞳子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">服部瞳子</rdfs:label>
-    <schema:name xml:lang="en">Hattori Toko</schema:name>
+    <schema:name xml:lang="en">Toko Hattori</schema:name>
     <imas:nameKana xml:lang="ja">はっとりとうこ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">169.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">25</foaf:age>
@@ -2609,7 +2609,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">木場真奈美</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">木場真奈美</rdfs:label>
-    <schema:name xml:lang="en">Kiba Manami</schema:name>
+    <schema:name xml:lang="en">Manami Kiba</schema:name>
     <imas:nameKana xml:lang="ja">きばまなみ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">172.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">25</foaf:age>
@@ -2640,7 +2640,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">藤原肇</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">藤原肇</rdfs:label>
-    <schema:name xml:lang="en">Fujiwara Hajime</schema:name>
+    <schema:name xml:lang="en">Hajime Fujiwara</schema:name>
     <imas:nameKana xml:lang="ja">ふじわらはじめ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">161.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
@@ -2675,7 +2675,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">新田美波</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">新田美波</rdfs:label>
-    <schema:name xml:lang="en">Nitta Minami</schema:name>
+    <schema:name xml:lang="en">Minami Nitta</schema:name>
     <imas:nameKana xml:lang="ja">にったみなみ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">165.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
@@ -2710,7 +2710,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">水野翠</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">水野翠</rdfs:label>
-    <schema:name xml:lang="en">Mizuno Midori</schema:name>
+    <schema:name xml:lang="en">Midori Mizuno</schema:name>
     <imas:nameKana xml:lang="ja">みずのみどり</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">164.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
@@ -2740,7 +2740,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">古澤頼子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">古澤頼子</rdfs:label>
-    <schema:name xml:lang="en">Furusawa Yoriko</schema:name>
+    <schema:name xml:lang="en">Yoriko Furusawa</schema:name>
     <imas:nameKana xml:lang="ja">ふるさわよりこ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">166.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
@@ -2771,7 +2771,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">橘ありす</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">橘ありす</rdfs:label>
-    <schema:name xml:lang="en">Tachibana Arisu</schema:name>
+    <schema:name xml:lang="en">Arisu Tachibana</schema:name>
     <imas:nameKana xml:lang="ja">たちばなありす</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">141.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</foaf:age>
@@ -2806,7 +2806,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">鷺沢文香</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">鷺沢文香</rdfs:label>
-    <schema:name xml:lang="en">Sagisawa Fumika</schema:name>
+    <schema:name xml:lang="en">Fumika Sagisawa</schema:name>
     <imas:nameKana xml:lang="ja">さぎさわふみか</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">162.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
@@ -2840,7 +2840,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">八神マキノ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">八神マキノ</rdfs:label>
-    <schema:name xml:lang="en">Yagami Makino</schema:name>
+    <schema:name xml:lang="en">Makino Yagami</schema:name>
     <imas:nameKana xml:lang="ja">やがみまきの</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">160.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
@@ -2864,7 +2864,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">ライラ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ライラ</rdfs:label>
-    <schema:name xml:lang="en">Layla</schema:name>
+    <schema:name xml:lang="en">ayla L</schema:name>
     <imas:nameKana xml:lang="ja">らいら</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">150.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
@@ -2894,7 +2894,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">浅利七海</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">浅利七海</rdfs:label>
-    <schema:name xml:lang="en">Asari Nanami</schema:name>
+    <schema:name xml:lang="en">Nanami Asari</schema:name>
     <imas:nameKana xml:lang="ja">あさりななみ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">151.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
@@ -2919,7 +2919,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">ヘレン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ヘレン</rdfs:label>
-    <schema:name xml:lang="en">Helen</schema:name>
+    <schema:name xml:lang="en">n Hele</schema:name>
     <imas:nameKana xml:lang="ja">へれん</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">158.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">24</foaf:age>
@@ -2949,7 +2949,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">松永涼</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">松永涼</rdfs:label>
-    <schema:name xml:lang="en">Matsunaga Ryo</schema:name>
+    <schema:name xml:lang="en">Ryo Matsunaga</schema:name>
     <imas:nameKana xml:lang="ja">まつながりょう</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">160.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
@@ -2983,7 +2983,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">小室千奈美</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">小室千奈美</rdfs:label>
-    <schema:name xml:lang="en">Komuro Chinami</schema:name>
+    <schema:name xml:lang="en">Chinami Komuro</schema:name>
     <imas:nameKana xml:lang="ja">こむろちなみ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">164.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
@@ -3013,7 +3013,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">高峯のあ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">高峯のあ</rdfs:label>
-    <schema:name xml:lang="en">Takamine Noa</schema:name>
+    <schema:name xml:lang="en">Noa Takamine</schema:name>
     <imas:nameKana xml:lang="ja">たかみねのあ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">168.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">24</foaf:age>
@@ -3043,7 +3043,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">高垣楓</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">高垣楓</rdfs:label>
-    <schema:name xml:lang="en">Takagaki Kaede</schema:name>
+    <schema:name xml:lang="en">Kaede Takagaki</schema:name>
     <imas:nameKana xml:lang="ja">たかがきかえで</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">171.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">25</foaf:age>
@@ -3077,7 +3077,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">神崎蘭子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">神崎蘭子</rdfs:label>
-    <schema:name xml:lang="en">Kanzaki Ranko</schema:name>
+    <schema:name xml:lang="en">Ranko Kanzaki</schema:name>
     <imas:nameKana xml:lang="ja">かんざきらんこ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">156.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
@@ -3111,7 +3111,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">伊集院惠</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">伊集院惠</rdfs:label>
-    <schema:name xml:lang="en">Ijuin Megumi</schema:name>
+    <schema:name xml:lang="en">Megumi Ijuin</schema:name>
     <imas:nameKana xml:lang="ja">いじゅういんめぐみ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">160.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</foaf:age>
@@ -3141,7 +3141,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">柊志乃</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">柊志乃</rdfs:label>
-    <schema:name xml:lang="en">Hiiragi Shino</schema:name>
+    <schema:name xml:lang="en">Shino Hiiragi</schema:name>
     <imas:nameKana xml:lang="ja">ひいらぎしの</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">167.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">31</foaf:age>
@@ -3171,7 +3171,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">北条加蓮</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">北条加蓮</rdfs:label>
-    <schema:name xml:lang="en">Hojo Karen</schema:name>
+    <schema:name xml:lang="en">Karen Hojo</schema:name>
     <imas:nameKana xml:lang="ja">ほうじょうかれん</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">155.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
@@ -3199,7 +3199,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">ケイト</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ケイト</rdfs:label>
-    <schema:name xml:lang="en">Kate</schema:name>
+    <schema:name xml:lang="en">e Kat</schema:name>
     <imas:nameKana xml:lang="ja">けいと</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">157.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</foaf:age>
@@ -3229,7 +3229,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">瀬名詩織</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">瀬名詩織</rdfs:label>
-    <schema:name xml:lang="en">Sena Shiori</schema:name>
+    <schema:name xml:lang="en">Shiori Sena</schema:name>
     <imas:nameKana xml:lang="ja">せなしおり</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">165.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
@@ -3259,7 +3259,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">綾瀬穂乃香</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">綾瀬穂乃香</rdfs:label>
-    <schema:name xml:lang="en">Ayase Honoka</schema:name>
+    <schema:name xml:lang="en">Honoka Ayase</schema:name>
     <imas:nameKana xml:lang="ja">あやせほのか</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">161.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
@@ -3289,7 +3289,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">佐城雪美</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">佐城雪美</rdfs:label>
-    <schema:name xml:lang="en">Sajo Yukimi</schema:name>
+    <schema:name xml:lang="en">Yukimi Sajo</schema:name>
     <imas:nameKana xml:lang="ja">さじょうゆきみ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">137.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</foaf:age>
@@ -3322,7 +3322,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">篠原礼</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">篠原礼</rdfs:label>
-    <schema:name xml:lang="en">Shinohara Rei</schema:name>
+    <schema:name xml:lang="en">Rei Shinohara</schema:name>
     <imas:nameKana xml:lang="ja">しのはられい</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">171.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">27</foaf:age>
@@ -3352,7 +3352,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">和久井留美</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">和久井留美</rdfs:label>
-    <schema:name xml:lang="en">Wakui Rumi</schema:name>
+    <schema:name xml:lang="en">Rumi Wakui</schema:name>
     <imas:nameKana xml:lang="ja">わくいるみ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">168.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">26</foaf:age>
@@ -3382,7 +3382,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">吉岡沙紀</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">吉岡沙紀</rdfs:label>
-    <schema:name xml:lang="en">Yoshioka Saki</schema:name>
+    <schema:name xml:lang="en">Saki Yoshioka</schema:name>
     <imas:nameKana xml:lang="ja">よしおかさき</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">166.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
@@ -3412,7 +3412,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">梅木音葉</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">梅木音葉</rdfs:label>
-    <schema:name xml:lang="en">Umeki Otoha</schema:name>
+    <schema:name xml:lang="en">Otoha Umeki</schema:name>
     <imas:nameKana xml:lang="ja">うめきおとは</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">172.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
@@ -3443,7 +3443,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">白坂小梅</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">白坂小梅</rdfs:label>
-    <schema:name xml:lang="en">Shirasaka Koume</schema:name>
+    <schema:name xml:lang="en">Koume Shirasaka</schema:name>
     <imas:nameKana xml:lang="ja">しらさかこうめ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">142.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</foaf:age>
@@ -3478,7 +3478,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">岸部彩華</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">岸部彩華</rdfs:label>
-    <schema:name xml:lang="en">Kishibe Ayaka</schema:name>
+    <schema:name xml:lang="en">Ayaka Kishibe</schema:name>
     <imas:nameKana xml:lang="ja">きしべあやか</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">162.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
@@ -3510,7 +3510,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">氏家むつみ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">氏家むつみ</rdfs:label>
-    <schema:name xml:lang="en">Ujiie Mutsumi</schema:name>
+    <schema:name xml:lang="en">Mutsumi Ujiie</schema:name>
     <imas:nameKana xml:lang="ja">うじいえむつみ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">152.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</foaf:age>
@@ -3541,7 +3541,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">西川保奈美</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">西川保奈美</rdfs:label>
-    <schema:name xml:lang="en">Nishikawa Honami</schema:name>
+    <schema:name xml:lang="en">Honami Nishikawa</schema:name>
     <imas:nameKana xml:lang="ja">にしかわほなみ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">155.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
@@ -3572,7 +3572,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">成宮由愛</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">成宮由愛</rdfs:label>
-    <schema:name xml:lang="en">Narumiya Yume</schema:name>
+    <schema:name xml:lang="en">Yume Narumiya</schema:name>
     <imas:nameKana xml:lang="ja">なるみやゆめ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">150.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</foaf:age>
@@ -3603,7 +3603,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">藤居朋</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">藤居朋</rdfs:label>
-    <schema:name xml:lang="en">Fujii Tomo</schema:name>
+    <schema:name xml:lang="en">Tomo Fujii</schema:name>
     <imas:nameKana xml:lang="ja">ふじいとも</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">163.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
@@ -3633,7 +3633,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">塩見周子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">塩見周子</rdfs:label>
-    <schema:name xml:lang="en">Shiomi Syuko</schema:name>
+    <schema:name xml:lang="en">Syuko Shiomi</schema:name>
     <imas:nameKana xml:lang="ja">しおみしゅうこ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">163.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
@@ -3668,7 +3668,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">脇山珠美</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">脇山珠美</rdfs:label>
-    <schema:name xml:lang="en">Wakiyama Tamami</schema:name>
+    <schema:name xml:lang="en">Tamami Wakiyama</schema:name>
     <imas:nameKana xml:lang="ja">わきやまたまみ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">145.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
@@ -3703,7 +3703,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">岡崎泰葉</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">岡崎泰葉</rdfs:label>
-    <schema:name xml:lang="en">Okazaki Yasuha</schema:name>
+    <schema:name xml:lang="en">Yasuha Okazaki</schema:name>
     <imas:nameKana xml:lang="ja">おかざきやすは</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">153.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
@@ -3733,7 +3733,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">速水奏</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">速水奏</rdfs:label>
-    <schema:name xml:lang="en">Hayami Kanade</schema:name>
+    <schema:name xml:lang="en">Kanade Hayami</schema:name>
     <imas:nameKana xml:lang="ja">はやみかなで</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">162.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
@@ -3767,7 +3767,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">大石泉</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">大石泉</rdfs:label>
-    <schema:name xml:lang="en">Ohishi Izumi</schema:name>
+    <schema:name xml:lang="en">Izumi Ohishi</schema:name>
     <imas:nameKana xml:lang="ja">おおいしいずみ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">157.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -3797,7 +3797,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">松尾千鶴</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">松尾千鶴</rdfs:label>
-    <schema:name xml:lang="en">Matsuo Chizuru</schema:name>
+    <schema:name xml:lang="en">Chizuru Matsuo</schema:name>
     <imas:nameKana xml:lang="ja">まつおちづる</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">161.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -3828,7 +3828,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">森久保乃々</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">森久保乃々</rdfs:label>
-    <schema:name xml:lang="en">Morikubo Nono</schema:name>
+    <schema:name xml:lang="en">Nono Morikubo</schema:name>
     <imas:nameKana xml:lang="ja">もりくぼのの</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">149.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
@@ -3857,7 +3857,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">アナスタシア</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アナスタシア</rdfs:label>
-    <schema:name xml:lang="en">Anastasia</schema:name>
+    <schema:name xml:lang="en">a Anastasi</schema:name>
     <imas:nameKana xml:lang="ja">あなすたしあ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">165.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -3892,7 +3892,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">大和亜季</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">大和亜季</rdfs:label>
-    <schema:name xml:lang="en">Yamato Aki</schema:name>
+    <schema:name xml:lang="en">Aki Yamato</schema:name>
     <imas:nameKana xml:lang="ja">やまとあき</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">165.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</foaf:age>
@@ -3927,7 +3927,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">結城晴</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">結城晴</rdfs:label>
-    <schema:name xml:lang="en">Yuuki Haru</schema:name>
+    <schema:name xml:lang="en">Haru Yuuki</schema:name>
     <imas:nameKana xml:lang="ja">ゆうきはる</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">140.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</foaf:age>
@@ -3961,7 +3961,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">二宮飛鳥</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">二宮飛鳥</rdfs:label>
-    <schema:name xml:lang="en">Ninomiya Asuka</schema:name>
+    <schema:name xml:lang="en">Asuka Ninomiya</schema:name>
     <imas:nameKana xml:lang="ja">にのみやあすか</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">154.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
@@ -3997,7 +3997,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">桐生つかさ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">桐生つかさ</rdfs:label>
-    <schema:name xml:lang="en">Kiryu Tsukasa</schema:name>
+    <schema:name xml:lang="en">Tsukasa Kiryu</schema:name>
     <imas:nameKana xml:lang="ja">きりゅうつかさ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">164.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
@@ -4032,7 +4032,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">望月聖</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">望月聖</rdfs:label>
-    <schema:name xml:lang="en">Mochizuki Hijiri</schema:name>
+    <schema:name xml:lang="en">Hijiri Mochizuki</schema:name>
     <imas:nameKana xml:lang="ja">もちづきひじり</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">150.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</foaf:age>
@@ -4062,7 +4062,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">鷹富士茄子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">鷹富士茄子</rdfs:label>
-    <schema:name xml:lang="en">Takafuji Kako</schema:name>
+    <schema:name xml:lang="en">Kako Takafuji</schema:name>
     <imas:nameKana xml:lang="ja">たかふじかこ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">160.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</foaf:age>
@@ -4096,7 +4096,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">砂塚あきら</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">砂塚あきら</rdfs:label>
-    <schema:name xml:lang="en">Sunazuka Akira</schema:name>
+    <schema:name xml:lang="en">Akira Sunazuka</schema:name>
     <imas:nameKana xml:lang="ja">すなづかあきら</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">154.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -4131,7 +4131,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">久川颯</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">久川颯</rdfs:label>
-    <schema:name xml:lang="en">Hisakawa Hayate</schema:name>
+    <schema:name xml:lang="en">Hayate Hisakawa</schema:name>
     <imas:nameKana xml:lang="ja">ひさかわはやて</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">151.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
@@ -4167,7 +4167,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">本田未央</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">本田未央</rdfs:label>
-    <schema:name xml:lang="en">Honda Mio</schema:name>
+    <schema:name xml:lang="en">Mio Honda</schema:name>
     <imas:nameKana xml:lang="ja">ほんだみお</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">161.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -4201,7 +4201,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">高森藍子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">高森藍子</rdfs:label>
-    <schema:name xml:lang="en">Takamori Aiko</schema:name>
+    <schema:name xml:lang="en">Aiko Takamori</schema:name>
     <imas:nameKana xml:lang="ja">たかもりあいこ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">155.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
@@ -4235,7 +4235,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">並木芽衣子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">並木芽衣子</rdfs:label>
-    <schema:name xml:lang="en">Namiki Meiko</schema:name>
+    <schema:name xml:lang="en">Meiko Namiki</schema:name>
     <imas:nameKana xml:lang="ja">なみきめいこ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">160.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">22</foaf:age>
@@ -4265,7 +4265,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">龍崎薫</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">龍崎薫</rdfs:label>
-    <schema:name xml:lang="en">Ryuzaki Kaoru</schema:name>
+    <schema:name xml:lang="en">Kaoru Ryuzaki</schema:name>
     <imas:nameKana xml:lang="ja">りゅうざきかおる</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">132.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</foaf:age>
@@ -4299,7 +4299,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">木村夏樹</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">木村夏樹</rdfs:label>
-    <schema:name xml:lang="en">Kimura Natsuki</schema:name>
+    <schema:name xml:lang="en">Natsuki Kimura</schema:name>
     <imas:nameKana xml:lang="ja">きむらなつき</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">159.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
@@ -4333,7 +4333,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">松山久美子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">松山久美子</rdfs:label>
-    <schema:name xml:lang="en">Matsuyama Kumiko</schema:name>
+    <schema:name xml:lang="en">Kumiko Matsuyama</schema:name>
     <imas:nameKana xml:lang="ja">まつやまくみこ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">161.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</foaf:age>
@@ -4363,7 +4363,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">斉藤洋子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">斉藤洋子</rdfs:label>
-    <schema:name xml:lang="en">Saito Yoko</schema:name>
+    <schema:name xml:lang="en">Yoko Saito</schema:name>
     <imas:nameKana xml:lang="ja">さいとうようこ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">157.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</foaf:age>
@@ -4393,7 +4393,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">沢田麻理菜</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">沢田麻理菜</rdfs:label>
-    <schema:name xml:lang="en">Sawada Marina</schema:name>
+    <schema:name xml:lang="en">Marina Sawada</schema:name>
     <imas:nameKana xml:lang="ja">さわだまりな</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">166.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">26</foaf:age>
@@ -4423,7 +4423,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">矢口美羽</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">矢口美羽</rdfs:label>
-    <schema:name xml:lang="en">Yaguchi Miu</schema:name>
+    <schema:name xml:lang="en">Miu Yaguchi</schema:name>
     <imas:nameKana xml:lang="ja">やぐちみう</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">150.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
@@ -4453,7 +4453,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">赤城みりあ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">赤城みりあ</rdfs:label>
-    <schema:name xml:lang="en">Akagi Miria</schema:name>
+    <schema:name xml:lang="en">Miria Akagi</schema:name>
     <imas:nameKana xml:lang="ja">あかぎみりあ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">140.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</foaf:age>
@@ -4487,7 +4487,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">愛野渚</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">愛野渚</rdfs:label>
-    <schema:name xml:lang="en">Aino Nagisa</schema:name>
+    <schema:name xml:lang="en">Nagisa Aino</schema:name>
     <imas:nameKana xml:lang="ja">あいのなぎさ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">163.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
@@ -4517,7 +4517,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">真鍋いつき</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">真鍋いつき</rdfs:label>
-    <schema:name xml:lang="en">Manabe Itsuki</schema:name>
+    <schema:name xml:lang="en">Itsuki Manabe</schema:name>
     <imas:nameKana xml:lang="ja">まなべいつき</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">165.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">22</foaf:age>
@@ -4547,7 +4547,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">大槻唯</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">大槻唯</rdfs:label>
-    <schema:name xml:lang="en">Ohtsuki Yui</schema:name>
+    <schema:name xml:lang="en">Yui Ohtsuki</schema:name>
     <imas:nameKana xml:lang="ja">おおつきゆい</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">155.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
@@ -4581,7 +4581,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">姫川友紀</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">姫川友紀</rdfs:label>
-    <schema:name xml:lang="en">Himekawa Yuki</schema:name>
+    <schema:name xml:lang="en">Yuki Himekawa</schema:name>
     <imas:nameKana xml:lang="ja">ひめかわゆき</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">161.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</foaf:age>
@@ -4615,7 +4615,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">喜多見柚</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">喜多見柚</rdfs:label>
-    <schema:name xml:lang="en">Kitami Yuzu</schema:name>
+    <schema:name xml:lang="en">Yuzu Kitami</schema:name>
     <imas:nameKana xml:lang="ja">きたみゆず</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">156.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -4649,7 +4649,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">上田鈴帆</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">上田鈴帆</rdfs:label>
-    <schema:name xml:lang="en">Ueda Suzuho</schema:name>
+    <schema:name xml:lang="en">Suzuho Ueda</schema:name>
     <imas:nameKana xml:lang="ja">うえだすずほ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">156.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
@@ -4683,7 +4683,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">海老原菜帆</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">海老原菜帆</rdfs:label>
-    <schema:name xml:lang="en">Ebihara Naho</schema:name>
+    <schema:name xml:lang="en">Naho Ebihara</schema:name>
     <imas:nameKana xml:lang="ja">えびはらなほ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">162.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
@@ -4714,7 +4714,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">及川雫</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">及川雫</rdfs:label>
-    <schema:name xml:lang="en">Oikawa Shizuku</schema:name>
+    <schema:name xml:lang="en">Shizuku Oikawa</schema:name>
     <imas:nameKana xml:lang="ja">おいかわしずく</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">170.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
@@ -4749,7 +4749,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">小関麗奈</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">小関麗奈</rdfs:label>
-    <schema:name xml:lang="en">Koseki Reina</schema:name>
+    <schema:name xml:lang="en">Reina Koseki</schema:name>
     <imas:nameKana xml:lang="ja">こせきれいな</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">148.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</foaf:age>
@@ -4782,7 +4782,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">衛藤美紗希</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">衛藤美紗希</rdfs:label>
-    <schema:name xml:lang="en">Etou Misaki</schema:name>
+    <schema:name xml:lang="en">Misaki Etou</schema:name>
     <imas:nameKana xml:lang="ja">えとうみさき</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">160.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">22</foaf:age>
@@ -4813,7 +4813,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">星輝子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">星輝子</rdfs:label>
-    <schema:name xml:lang="en">Hoshi Syoko</schema:name>
+    <schema:name xml:lang="en">Syoko Hoshi</schema:name>
     <imas:nameKana xml:lang="ja">ほししょうこ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">142.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -4847,7 +4847,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">片桐早苗</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">片桐早苗</rdfs:label>
-    <schema:name xml:lang="en">Katagiri Sanae</schema:name>
+    <schema:name xml:lang="en">Sanae Katagiri</schema:name>
     <imas:nameKana xml:lang="ja">かたぎりさなえ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">152.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">28</foaf:age>
@@ -4882,7 +4882,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">堀裕子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">堀裕子</rdfs:label>
-    <schema:name xml:lang="en">Hori Yuko</schema:name>
+    <schema:name xml:lang="en">Yuko Hori</schema:name>
     <imas:nameKana xml:lang="ja">ほりゆうこ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">157.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
@@ -4916,7 +4916,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">西島櫂</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">西島櫂</rdfs:label>
-    <schema:name xml:lang="en">Nishijima Kai</schema:name>
+    <schema:name xml:lang="en">Kai Nishijima</schema:name>
     <imas:nameKana xml:lang="ja">にしじまかい</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">172.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
@@ -4946,7 +4946,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">的場梨沙</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">的場梨沙</rdfs:label>
-    <schema:name xml:lang="en">Matoba Risa</schema:name>
+    <schema:name xml:lang="en">Risa Matoba</schema:name>
     <imas:nameKana xml:lang="ja">まとばりさ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">143.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</foaf:age>
@@ -4980,7 +4980,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">財前時子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">財前時子</rdfs:label>
-    <schema:name xml:lang="en">Zaizen Tokiko</schema:name>
+    <schema:name xml:lang="en">Tokiko Zaizen</schema:name>
     <imas:nameKana xml:lang="ja">ざいぜんときこ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">168.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</foaf:age>
@@ -5011,7 +5011,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">依田芳乃</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">依田芳乃</rdfs:label>
-    <schema:name xml:lang="en">Yorita Yoshino</schema:name>
+    <schema:name xml:lang="en">Yoshino Yorita</schema:name>
     <imas:nameKana xml:lang="ja">よりたよしの</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">151.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
@@ -5047,7 +5047,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">相葉夕美</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">相葉夕美</rdfs:label>
-    <schema:name xml:lang="en">Aiba Yumi</schema:name>
+    <schema:name xml:lang="en">Yumi Aiba</schema:name>
     <imas:nameKana xml:lang="ja">あいばゆみ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">158.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
@@ -5081,7 +5081,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">野々村そら</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">野々村そら</rdfs:label>
-    <schema:name xml:lang="en">Nonomura Sora</schema:name>
+    <schema:name xml:lang="en">Sora Nonomura</schema:name>
     <imas:nameKana xml:lang="ja">ののむらそら</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">157.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -5111,7 +5111,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">浜川愛結奈</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">浜川愛結奈</rdfs:label>
-    <schema:name xml:lang="en">Hamakawa Ayuna</schema:name>
+    <schema:name xml:lang="en">Ayuna Hamakawa</schema:name>
     <imas:nameKana xml:lang="ja">はまかわあゆな</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">168.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">22</foaf:age>
@@ -5141,7 +5141,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">若林智香</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">若林智香</rdfs:label>
-    <schema:name xml:lang="en">Wakabayashi Tomoka</schema:name>
+    <schema:name xml:lang="en">Tomoka Wakabayashi</schema:name>
     <imas:nameKana xml:lang="ja">わかばやしともか</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">156.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
@@ -5171,7 +5171,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">城ヶ崎美嘉</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">城ヶ崎美嘉</rdfs:label>
-    <schema:name xml:lang="en">Jougasaki Mika</schema:name>
+    <schema:name xml:lang="en">Mika Jougasaki</schema:name>
     <imas:nameKana xml:lang="ja">じょうがさきみか</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">162.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
@@ -5205,7 +5205,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">城ヶ崎莉嘉</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">城ヶ崎莉嘉</rdfs:label>
-    <schema:name xml:lang="en">Jougasaki Rika</schema:name>
+    <schema:name xml:lang="en">Rika Jougasaki</schema:name>
     <imas:nameKana xml:lang="ja">じょうがさきりか</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">149.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</foaf:age>
@@ -5239,7 +5239,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">仙崎恵磨</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">仙崎恵磨</rdfs:label>
-    <schema:name xml:lang="en">Senzaki Ema</schema:name>
+    <schema:name xml:lang="en">Ema Senzaki</schema:name>
     <imas:nameKana xml:lang="ja">せんざきえま</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">156.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</foaf:age>
@@ -5269,7 +5269,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">日野茜</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">日野茜</rdfs:label>
-    <schema:name xml:lang="en">Hino Akane</schema:name>
+    <schema:name xml:lang="en">Akane Hino</schema:name>
     <imas:nameKana xml:lang="ja">ひのあかね</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">148.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
@@ -5303,7 +5303,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">諸星きらり</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">諸星きらり</rdfs:label>
-    <schema:name xml:lang="en">Moroboshi Kirari</schema:name>
+    <schema:name xml:lang="en">Kirari Moroboshi</schema:name>
     <imas:nameKana xml:lang="ja">もろぼしきらり</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">182.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
@@ -5337,7 +5337,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">十時愛梨</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">十時愛梨</rdfs:label>
-    <schema:name xml:lang="en">Totoki Airi</schema:name>
+    <schema:name xml:lang="en">Airi Totoki</schema:name>
     <imas:nameKana xml:lang="ja">とときあいり</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">161.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
@@ -5365,7 +5365,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">ナターリア</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ナターリア</rdfs:label>
-    <schema:name xml:lang="en">Natalia</schema:name>
+    <schema:name xml:lang="en">a Natali</schema:name>
     <imas:nameKana xml:lang="ja">なたーりあ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">155.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
@@ -5398,7 +5398,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">相馬夏美</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">相馬夏美</rdfs:label>
-    <schema:name xml:lang="en">Souma Natsumi</schema:name>
+    <schema:name xml:lang="en">Natsumi Souma</schema:name>
     <imas:nameKana xml:lang="ja">そうまなつみ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">160.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">25</foaf:age>
@@ -5428,7 +5428,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">槙原志保</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">槙原志保</rdfs:label>
-    <schema:name xml:lang="en">Makihara Shiho</schema:name>
+    <schema:name xml:lang="en">Shiho Makihara</schema:name>
     <imas:nameKana xml:lang="ja">まきはらしほ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">162.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
@@ -5458,7 +5458,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">向井拓海</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">向井拓海</rdfs:label>
-    <schema:name xml:lang="en">Mukai Takumi</schema:name>
+    <schema:name xml:lang="en">Takumi Mukai</schema:name>
     <imas:nameKana xml:lang="ja">むかいたくみ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">163.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
@@ -5492,7 +5492,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">市原仁奈</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">市原仁奈</rdfs:label>
-    <schema:name xml:lang="en">Ichihara Nina</schema:name>
+    <schema:name xml:lang="en">Nina Ichihara</schema:name>
     <imas:nameKana xml:lang="ja">いちはらにな</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">128.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</foaf:age>
@@ -5526,7 +5526,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">喜多日菜子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">喜多日菜子</rdfs:label>
-    <schema:name xml:lang="en">Kita Hinako</schema:name>
+    <schema:name xml:lang="en">Hinako Kita</schema:name>
     <imas:nameKana xml:lang="ja">きたひなこ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">151.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -5560,7 +5560,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">杉坂海</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">杉坂海</rdfs:label>
-    <schema:name xml:lang="en">Sugisaka Umi</schema:name>
+    <schema:name xml:lang="en">Umi Sugisaka</schema:name>
     <imas:nameKana xml:lang="ja">すぎさかうみ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">162.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
@@ -5590,7 +5590,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">北川真尋</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">北川真尋</rdfs:label>
-    <schema:name xml:lang="en">Kitagawa Mahiro</schema:name>
+    <schema:name xml:lang="en">Mahiro Kitagawa</schema:name>
     <imas:nameKana xml:lang="ja">きたがわまひろ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">158.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
@@ -5622,7 +5622,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">メアリー・コクラン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">メアリー・コクラン</rdfs:label>
-    <schema:name xml:lang="en">Mary Cochran</schema:name>
+    <schema:name xml:lang="en">Cochran Mary</schema:name>
     <imas:nameKana xml:lang="ja">めありー・こくらん</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">152.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</foaf:age>
@@ -5653,7 +5653,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">小松伊吹</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">小松伊吹</rdfs:label>
-    <schema:name xml:lang="en">Komatsu Ibuki</schema:name>
+    <schema:name xml:lang="en">Ibuki Komatsu</schema:name>
     <imas:nameKana xml:lang="ja">こまついぶき</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">165.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
@@ -5685,7 +5685,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">三好紗南</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">三好紗南</rdfs:label>
-    <schema:name xml:lang="en">Miyoshi Sana</schema:name>
+    <schema:name xml:lang="en">Sana Miyoshi</schema:name>
     <imas:nameKana xml:lang="ja">みよしさな</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">149.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
@@ -5716,7 +5716,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">キャシー・グラハム</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">キャシー・グラハム</rdfs:label>
-    <schema:name xml:lang="en">Cathy Graham</schema:name>
+    <schema:name xml:lang="en">Graham Cathy</schema:name>
     <imas:nameKana xml:lang="ja">きゃしー・ぐらはむ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">168.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -5747,7 +5747,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">難波笑美</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">難波笑美</rdfs:label>
-    <schema:name xml:lang="en">Namba Emi</schema:name>
+    <schema:name xml:lang="en">Emi Namba</schema:name>
     <imas:nameKana xml:lang="ja">なんばえみ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">158.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
@@ -5782,7 +5782,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">浜口あやめ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">浜口あやめ</rdfs:label>
-    <schema:name xml:lang="en">Hamaguchi Ayame</schema:name>
+    <schema:name xml:lang="en">Ayame Hamaguchi</schema:name>
     <imas:nameKana xml:lang="ja">はまぐちあやめ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">154.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -5818,7 +5818,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">村上巴</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">村上巴</rdfs:label>
-    <schema:name xml:lang="en">Murakami Tomoe</schema:name>
+    <schema:name xml:lang="en">Tomoe Murakami</schema:name>
     <imas:nameKana xml:lang="ja">むらかみともえ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">146.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</foaf:age>
@@ -5853,7 +5853,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">土屋亜子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">土屋亜子</rdfs:label>
-    <schema:name xml:lang="en">Tsuchiya Ako</schema:name>
+    <schema:name xml:lang="en">Ako Tsuchiya</schema:name>
     <imas:nameKana xml:lang="ja">つちやあこ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">156.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -5884,7 +5884,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">首藤葵</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">首藤葵</rdfs:label>
-    <schema:name xml:lang="en">Shuto Aoi</schema:name>
+    <schema:name xml:lang="en">Aoi Shuto</schema:name>
     <imas:nameKana xml:lang="ja">しゅとうあおい</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">145.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">13</foaf:age>
@@ -5914,7 +5914,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">冴島清美</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">冴島清美</rdfs:label>
-    <schema:name xml:lang="en">Saejima Kiyomi</schema:name>
+    <schema:name xml:lang="en">Kiyomi Saejima</schema:name>
     <imas:nameKana xml:lang="ja">さえじまきよみ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">153.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -5946,7 +5946,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">佐藤心</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">佐藤心</rdfs:label>
-    <schema:name xml:lang="en">Sato Shin</schema:name>
+    <schema:name xml:lang="en">Shin Sato</schema:name>
     <imas:nameKana xml:lang="ja">さとうしん</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">166.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">26</foaf:age>
@@ -5981,7 +5981,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">南条光</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">南条光</rdfs:label>
-    <schema:name xml:lang="en">Nanjo Hikaru</schema:name>
+    <schema:name xml:lang="en">Hikaru Nanjo</schema:name>
     <imas:nameKana xml:lang="ja">なんじょうひかる</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">140.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
@@ -6016,7 +6016,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">イヴ・サンタクロース</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">イヴ・サンタクロース</rdfs:label>
-    <schema:name xml:lang="en">Eve Santaclaus</schema:name>
+    <schema:name xml:lang="en">Santaclaus Eve</schema:name>
     <imas:nameKana xml:lang="ja">いゔ・さんたくろーす</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">165.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
@@ -6046,7 +6046,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">夢見りあむ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">夢見りあむ</rdfs:label>
-    <schema:name xml:lang="en">Yumemi Riamu</schema:name>
+    <schema:name xml:lang="en">Riamu Yumemi</schema:name>
     <imas:nameKana xml:lang="ja">ゆめみりあむ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">149.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
@@ -6080,7 +6080,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">久川凪</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">久川凪</rdfs:label>
-    <schema:name xml:lang="en">Hisakawa Nagi</schema:name>
+    <schema:name xml:lang="en">Nagi Hisakawa</schema:name>
     <imas:nameKana xml:lang="ja">ひさかわなぎ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">150.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>

--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -1122,7 +1122,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">楊菲菲</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">楊菲菲</rdfs:label>
-    <schema:name xml:lang="en">Fueifuei Yao</schema:name>
+    <schema:name xml:lang="en">Yao Fueifuei</schema:name>
     <imas:nameKana xml:lang="ja">やおふぇいふぇい</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">152.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -1703,7 +1703,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">クラリス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">クラリス</rdfs:label>
-    <schema:name xml:lang="en">larice C</schema:name>
+    <schema:name xml:lang="en">Clarice</schema:name>
     <imas:nameKana xml:lang="ja">くらりす</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">166.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</foaf:age>
@@ -2864,7 +2864,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">ライラ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ライラ</rdfs:label>
-    <schema:name xml:lang="en">ayla L</schema:name>
+    <schema:name xml:lang="en">Layla</schema:name>
     <imas:nameKana xml:lang="ja">らいら</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">150.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
@@ -2919,7 +2919,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">ヘレン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ヘレン</rdfs:label>
-    <schema:name xml:lang="en">n Hele</schema:name>
+    <schema:name xml:lang="en">Helen</schema:name>
     <imas:nameKana xml:lang="ja">へれん</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">158.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">24</foaf:age>
@@ -3199,7 +3199,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">ケイト</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ケイト</rdfs:label>
-    <schema:name xml:lang="en">e Kat</schema:name>
+    <schema:name xml:lang="en">Kate</schema:name>
     <imas:nameKana xml:lang="ja">けいと</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">157.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</foaf:age>
@@ -3857,7 +3857,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">アナスタシア</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アナスタシア</rdfs:label>
-    <schema:name xml:lang="en">a Anastasi</schema:name>
+    <schema:name xml:lang="en">Anastasia</schema:name>
     <imas:nameKana xml:lang="ja">あなすたしあ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">165.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -5365,7 +5365,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">ナターリア</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ナターリア</rdfs:label>
-    <schema:name xml:lang="en">a Natali</schema:name>
+    <schema:name xml:lang="en">Natalia</schema:name>
     <imas:nameKana xml:lang="ja">なたーりあ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">155.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
@@ -5622,7 +5622,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">メアリー・コクラン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">メアリー・コクラン</rdfs:label>
-    <schema:name xml:lang="en">Cochran Mary</schema:name>
+    <schema:name xml:lang="en">Mary Cochran</schema:name>
     <imas:nameKana xml:lang="ja">めありー・こくらん</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">152.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</foaf:age>
@@ -5716,7 +5716,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">キャシー・グラハム</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">キャシー・グラハム</rdfs:label>
-    <schema:name xml:lang="en">Graham Cathy</schema:name>
+    <schema:name xml:lang="en">Cathy Graham</schema:name>
     <imas:nameKana xml:lang="ja">きゃしー・ぐらはむ</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">168.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
@@ -6016,7 +6016,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <schema:name xml:lang="ja">イヴ・サンタクロース</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">イヴ・サンタクロース</rdfs:label>
-    <schema:name xml:lang="en">Santaclaus Eve</schema:name>
+    <schema:name xml:lang="en">Eve Santaclaus</schema:name>
     <imas:nameKana xml:lang="ja">いゔ・さんたくろーす</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">165.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>

--- a/RDFs/SideM.rdf
+++ b/RDFs/SideM.rdf
@@ -316,7 +316,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
     <schema:name xml:lang="ja">ピエール</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピエール</rdfs:label>
-    <schema:name xml:lang="en">ierre P</schema:name>
+    <schema:name xml:lang="en">Pierre</schema:name>
     <imas:nameKana xml:lang="ja">ぴえーる</imas:nameKana>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-01</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>

--- a/RDFs/SideM.rdf
+++ b/RDFs/SideM.rdf
@@ -9,7 +9,7 @@
   <rdf:Description rdf:about="Amagase_Toma">
     <schema:name xml:lang="ja">天ヶ瀬冬馬</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">天ヶ瀬冬馬</rdfs:label>
-    <schema:name xml:lang="en">Amagase Toma</schema:name>
+    <schema:name xml:lang="en">Toma Amagase</schema:name>
     <schema:familyName xml:lang="ja">天ヶ瀬</schema:familyName>
     <schema:familyName xml:lang="en">Amagase</schema:familyName>
     <schema:givenName xml:lang="ja">冬馬</schema:givenName>
@@ -44,7 +44,7 @@
   <rdf:Description rdf:about="Mitarai_Shota">
     <schema:name xml:lang="ja">御手洗翔太</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">御手洗翔太</rdfs:label>
-    <schema:name xml:lang="en">Mitarai Shota</schema:name>
+    <schema:name xml:lang="en">Shota Mitarai</schema:name>
     <imas:nameKana xml:lang="ja">みたらいしょうた</imas:nameKana>
     <imas:familyNameKana xml:lang="ja">みたらい</imas:familyNameKana>
     <imas:givenNameKana xml:lang="ja">しょうた</imas:givenNameKana>
@@ -79,7 +79,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</foaf:age>
     <schema:name xml:lang="ja">伊集院北斗</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">伊集院北斗</rdfs:label>
-    <schema:name xml:lang="en">Ijuin Hokuto</schema:name>
+    <schema:name xml:lang="en">Hokuto Ijuin</schema:name>
     <imas:nameKana xml:lang="ja">いじゅういんほくと</imas:nameKana>
     <schema:familyName xml:lang="ja">伊集院</schema:familyName>
     <schema:familyName xml:lang="en">Ijuin</schema:familyName>
@@ -114,7 +114,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">28</foaf:age>
     <schema:name xml:lang="ja">天道輝</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">天道輝</rdfs:label>
-    <schema:name xml:lang="en">Tendo Teru</schema:name>
+    <schema:name xml:lang="en">Teru Tendo</schema:name>
     <imas:nameKana xml:lang="ja">てんどうてる</imas:nameKana>
     <schema:familyName xml:lang="ja">天道</schema:familyName>
     <schema:familyName xml:lang="en">Tendo</schema:familyName>
@@ -148,7 +148,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">26</foaf:age>
     <schema:name xml:lang="ja">桜庭薫</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">桜庭薫</rdfs:label>
-    <schema:name xml:lang="en">Sakuraba Kaoru</schema:name>
+    <schema:name xml:lang="en">Kaoru Sakuraba</schema:name>
     <imas:nameKana xml:lang="ja">さくらばかおる</imas:nameKana>
     <schema:familyName xml:lang="ja">桜庭</schema:familyName>
     <schema:familyName xml:lang="en">Sakuraba</schema:familyName>
@@ -181,7 +181,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">24</foaf:age>
     <schema:name xml:lang="ja">柏木翼</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">柏木翼</rdfs:label>
-    <schema:name xml:lang="en">Kashiwagi Tsubasa</schema:name>
+    <schema:name xml:lang="en">Tsubasa Kashiwagi</schema:name>
     <imas:nameKana xml:lang="ja">かしわぎつばさ</imas:nameKana>
     <schema:familyName xml:lang="ja">柏木</schema:familyName>
     <schema:familyName xml:lang="en">Kashiwagi</schema:familyName>
@@ -217,7 +217,7 @@
     <foaf:age xml:lang="ja">??</foaf:age>
     <schema:name xml:lang="ja">都築圭</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">都築圭</rdfs:label>
-    <schema:name xml:lang="en">Tsuzuki Kei</schema:name>
+    <schema:name xml:lang="en">Kei Tsuzuki</schema:name>
     <imas:nameKana xml:lang="ja">つづきけい</imas:nameKana>
     <schema:familyName xml:lang="ja">都築</schema:familyName>
     <schema:familyName xml:lang="en">Tsuzuki</schema:familyName>
@@ -250,7 +250,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
     <schema:name xml:lang="ja">神楽麗</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">神楽麗</rdfs:label>
-    <schema:name xml:lang="en">Kagura Rei</schema:name>
+    <schema:name xml:lang="en">Rei Kagura</schema:name>
     <imas:nameKana xml:lang="ja">かぐられい</imas:nameKana>
     <schema:familyName xml:lang="ja">神楽</schema:familyName>
     <schema:familyName xml:lang="en">Kagura</schema:familyName>
@@ -283,7 +283,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</foaf:age>
     <schema:name xml:lang="ja">鷹城恭二</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">鷹城恭二</rdfs:label>
-    <schema:name xml:lang="en">Takajo Kyoji</schema:name>
+    <schema:name xml:lang="en">Kyoji Takajo</schema:name>
     <imas:nameKana xml:lang="ja">たかじょうきょうじ</imas:nameKana>
     <schema:familyName xml:lang="ja">鷹城</schema:familyName>
     <schema:familyName xml:lang="en">Takajo</schema:familyName>
@@ -316,7 +316,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
     <schema:name xml:lang="ja">ピエール</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピエール</rdfs:label>
-    <schema:name xml:lang="en">Pierre</schema:name>
+    <schema:name xml:lang="en">ierre P</schema:name>
     <imas:nameKana xml:lang="ja">ぴえーる</imas:nameKana>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-01</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O</imas:BloodType>
@@ -343,7 +343,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">31</foaf:age>
     <schema:name xml:lang="ja">渡辺みのり</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">渡辺みのり</rdfs:label>
-    <schema:name xml:lang="en">Watanabe Minori</schema:name>
+    <schema:name xml:lang="en">Minori Watanabe</schema:name>
     <imas:nameKana xml:lang="ja">わたなべみのり</imas:nameKana>
     <schema:familyName xml:lang="ja">渡辺</schema:familyName>
     <schema:familyName xml:lang="en">Watanabe</schema:familyName>
@@ -376,7 +376,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
     <schema:name xml:lang="ja">蒼井悠介</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">蒼井悠介</rdfs:label>
-    <schema:name xml:lang="en">Aoi Yusuke</schema:name>
+    <schema:name xml:lang="en">Yusuke Aoi</schema:name>
     <imas:nameKana xml:lang="ja">あおいゆうすけ</imas:nameKana>
     <schema:familyName xml:lang="ja">蒼井</schema:familyName>
     <schema:familyName xml:lang="en">Aoi</schema:familyName>
@@ -409,7 +409,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
     <schema:name xml:lang="ja">蒼井享介</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">蒼井享介</rdfs:label>
-    <schema:name xml:lang="en">Aoi Kyosuke</schema:name>
+    <schema:name xml:lang="en">Kyosuke Aoi</schema:name>
     <imas:nameKana xml:lang="ja">あおいきょうすけ</imas:nameKana>
     <schema:familyName xml:lang="ja">蒼井</schema:familyName>
     <schema:familyName xml:lang="en">Aoi</schema:familyName>
@@ -443,7 +443,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</foaf:age>
     <schema:name xml:lang="ja">握野英雄</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">握野英雄</rdfs:label>
-    <schema:name xml:lang="en">Akuno Hideo</schema:name>
+    <schema:name xml:lang="en">Hideo Akuno</schema:name>
     <imas:nameKana xml:lang="ja">あくのひでお</imas:nameKana>
     <schema:familyName xml:lang="ja">握野</schema:familyName>
     <schema:familyName xml:lang="en">Akuno</schema:familyName>
@@ -477,7 +477,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</foaf:age>
     <schema:name xml:lang="ja">木村龍</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">木村龍</rdfs:label>
-    <schema:name xml:lang="en">Kimura Ryu</schema:name>
+    <schema:name xml:lang="en">Ryu Kimura</schema:name>
     <imas:nameKana xml:lang="ja">きむらりゅう</imas:nameKana>
     <schema:familyName xml:lang="ja">木村</schema:familyName>
     <schema:familyName xml:lang="en">Kimura</schema:familyName>
@@ -510,7 +510,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">31</foaf:age>
     <schema:name xml:lang="ja">信玄誠司</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">信玄誠司</rdfs:label>
-    <schema:name xml:lang="en">Shingen Seiji</schema:name>
+    <schema:name xml:lang="en">Seiji Shingen</schema:name>
     <imas:nameKana xml:lang="ja">しんげんせいじ</imas:nameKana>
     <schema:familyName xml:lang="ja">信玄</schema:familyName>
     <schema:familyName xml:lang="en">Shingen</schema:familyName>
@@ -543,7 +543,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
     <schema:name xml:lang="ja">猫柳キリオ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">猫柳キリオ</rdfs:label>
-    <schema:name xml:lang="en">Nekoyanagi Kirio</schema:name>
+    <schema:name xml:lang="en">Kirio Nekoyanagi</schema:name>
     <imas:nameKana xml:lang="ja">ねこやなぎきりお</imas:nameKana>
     <schema:familyName xml:lang="ja">猫柳</schema:familyName>
     <schema:familyName xml:lang="en">Nekoyanagi</schema:familyName>
@@ -576,7 +576,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">27</foaf:age>
     <schema:name xml:lang="ja">華村翔真</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">華村翔真</rdfs:label>
-    <schema:name xml:lang="en">Hanamura Shoma</schema:name>
+    <schema:name xml:lang="en">Shoma Hanamura</schema:name>
     <imas:nameKana xml:lang="ja">はなむらしょうま</imas:nameKana>
     <schema:familyName xml:lang="ja">華村</schema:familyName>
     <schema:familyName xml:lang="en">Hanamura</schema:familyName>
@@ -609,7 +609,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
     <schema:name xml:lang="ja">清澄九郎</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">清澄九郎</rdfs:label>
-    <schema:name xml:lang="en">Kiyosumi Kuro</schema:name>
+    <schema:name xml:lang="en">Kuro Kiyosumi</schema:name>
     <imas:nameKana xml:lang="ja">きよすみくろう</imas:nameKana>
     <schema:familyName xml:lang="ja">清澄</schema:familyName>
     <schema:familyName xml:lang="en">Kiyosumi</schema:familyName>
@@ -643,7 +643,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
     <schema:name xml:lang="ja">秋山隼人</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">秋山隼人</rdfs:label>
-    <schema:name xml:lang="en">Akiyama Hayato</schema:name>
+    <schema:name xml:lang="en">Hayato Akiyama</schema:name>
     <imas:nameKana xml:lang="ja">あきやまはやと</imas:nameKana>
     <schema:familyName xml:lang="ja">秋山</schema:familyName>
     <schema:familyName xml:lang="en">Akiyama</schema:familyName>
@@ -677,7 +677,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
     <schema:name xml:lang="ja">冬美旬</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">冬美旬</rdfs:label>
-    <schema:name xml:lang="en">Fuyumi Jun</schema:name>
+    <schema:name xml:lang="en">Jun Fuyumi</schema:name>
     <imas:nameKana xml:lang="ja">ふゆみじゅん</imas:nameKana>
     <schema:familyName xml:lang="ja">冬美</schema:familyName>
     <schema:familyName xml:lang="en">Fuyumi</schema:familyName>
@@ -710,7 +710,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
     <schema:name xml:lang="ja">榊夏来</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">榊夏来</rdfs:label>
-    <schema:name xml:lang="en">Sakaki Natsuki</schema:name>
+    <schema:name xml:lang="en">Natsuki Sakaki</schema:name>
     <imas:nameKana xml:lang="ja">さかきなつき</imas:nameKana>
     <schema:familyName xml:lang="ja">榊</schema:familyName>
     <schema:familyName xml:lang="en">Sakaki</schema:familyName>
@@ -744,7 +744,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
     <schema:name xml:lang="ja">若里春名</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">若里春名</rdfs:label>
-    <schema:name xml:lang="en">Wakazato Haruna</schema:name>
+    <schema:name xml:lang="en">Haruna Wakazato</schema:name>
     <imas:nameKana xml:lang="ja">わかざとはるな</imas:nameKana>
     <schema:familyName xml:lang="ja">若里</schema:familyName>
     <schema:familyName xml:lang="en">Wakazato</schema:familyName>
@@ -777,7 +777,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
     <schema:name xml:lang="ja">伊瀬谷四季</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">伊瀬谷四季</rdfs:label>
-    <schema:name xml:lang="en">Iseya Shiki</schema:name>
+    <schema:name xml:lang="en">Shiki Iseya</schema:name>
     <imas:nameKana xml:lang="ja">いせやしき</imas:nameKana>
     <schema:familyName xml:lang="ja">伊瀬谷</schema:familyName>
     <schema:familyName xml:lang="en">Iseya</schema:familyName>
@@ -811,7 +811,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
     <schema:name xml:lang="ja">紅井朱雀</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">紅井朱雀</rdfs:label>
-    <schema:name xml:lang="en">Akai Suzaku</schema:name>
+    <schema:name xml:lang="en">Suzaku Akai</schema:name>
     <imas:nameKana xml:lang="ja">あかいすざく</imas:nameKana>
     <schema:familyName xml:lang="ja">紅井</schema:familyName>
     <schema:familyName xml:lang="en">Akai</schema:familyName>
@@ -844,7 +844,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
     <schema:name xml:lang="ja">黒野玄武</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">黒野玄武</rdfs:label>
-    <schema:name xml:lang="en">Kurono Genbu</schema:name>
+    <schema:name xml:lang="en">Genbu Kurono</schema:name>
     <imas:nameKana xml:lang="ja">くろのげんぶ</imas:nameKana>
     <schema:familyName xml:lang="ja">黒野</schema:familyName>
     <schema:familyName xml:lang="en">Kurono</schema:familyName>
@@ -879,7 +879,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</foaf:age>
     <schema:name xml:lang="ja">神谷幸広</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">神谷幸広</rdfs:label>
-    <schema:name xml:lang="en">Kamiya Yukihiro</schema:name>
+    <schema:name xml:lang="en">Yukihiro Kamiya</schema:name>
     <imas:nameKana xml:lang="ja">かみやゆきひろ</imas:nameKana>
     <schema:familyName xml:lang="ja">神谷</schema:familyName>
     <schema:familyName xml:lang="en">Kamiya</schema:familyName>
@@ -914,7 +914,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</foaf:age>
     <schema:name xml:lang="ja">東雲荘一郎</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">東雲荘一郎</rdfs:label>
-    <schema:name xml:lang="en">Shinonome Soichiro</schema:name>
+    <schema:name xml:lang="en">Soichiro Shinonome</schema:name>
     <imas:nameKana xml:lang="ja">しののめそういちろう</imas:nameKana>
     <schema:familyName xml:lang="ja">東雲</schema:familyName>
     <schema:familyName xml:lang="en">Shinonome</schema:familyName>
@@ -977,7 +977,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
     <schema:name xml:lang="ja">卯月巻緒</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">卯月巻緒</rdfs:label>
-    <schema:name xml:lang="en">Uzuki Makio</schema:name>
+    <schema:name xml:lang="en">Makio Uzuki</schema:name>
     <imas:nameKana xml:lang="ja">うづきまきお</imas:nameKana>
     <schema:familyName xml:lang="ja">卯月</schema:familyName>
     <schema:familyName xml:lang="en">Uzuki</schema:familyName>
@@ -1011,7 +1011,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
     <schema:name xml:lang="ja">水嶋咲</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">水嶋咲</rdfs:label>
-    <schema:name xml:lang="en">Mizushima Saki</schema:name>
+    <schema:name xml:lang="en">Saki Mizushima</schema:name>
     <imas:nameKana xml:lang="ja">みずしまさき</imas:nameKana>
     <schema:familyName xml:lang="ja">水嶋</schema:familyName>
     <schema:familyName xml:lang="en">Mizushima</schema:familyName>
@@ -1044,7 +1044,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</foaf:age>
     <schema:name xml:lang="ja">岡村直央</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">岡村直央</rdfs:label>
-    <schema:name xml:lang="en">Okamura Nao</schema:name>
+    <schema:name xml:lang="en">Nao Okamura</schema:name>
     <imas:nameKana xml:lang="ja">おかむらなお</imas:nameKana>
     <schema:familyName xml:lang="ja">岡村</schema:familyName>
     <schema:familyName xml:lang="en">Okamura</schema:familyName>
@@ -1077,7 +1077,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</foaf:age>
     <schema:name xml:lang="ja">橘志狼</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">橘志狼</rdfs:label>
-    <schema:name xml:lang="en">Tachibana Shiro</schema:name>
+    <schema:name xml:lang="en">Shiro Tachibana</schema:name>
     <imas:nameKana xml:lang="ja">たちばなしろう</imas:nameKana>
     <schema:familyName xml:lang="ja">橘</schema:familyName>
     <schema:familyName xml:lang="en">Tachibana</schema:familyName>
@@ -1110,7 +1110,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</foaf:age>
     <schema:name xml:lang="ja">姫野かのん</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">姫野かのん</rdfs:label>
-    <schema:name xml:lang="en">Himeno Kanon</schema:name>
+    <schema:name xml:lang="en">Kanon Himeno</schema:name>
     <imas:nameKana xml:lang="ja">ひめのかのん</imas:nameKana>
     <schema:familyName xml:lang="ja">姫野</schema:familyName>
     <schema:familyName xml:lang="en">Himeno</schema:familyName>
@@ -1143,7 +1143,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">32</foaf:age>
     <schema:name xml:lang="ja">硲道夫</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">硲道夫</rdfs:label>
-    <schema:name xml:lang="en">Hazama Michio</schema:name>
+    <schema:name xml:lang="en">Michio Hazama</schema:name>
     <imas:nameKana xml:lang="ja">はざまみちお</imas:nameKana>
     <schema:familyName xml:lang="ja">硲</schema:familyName>
     <schema:familyName xml:lang="en">Hazama</schema:familyName>
@@ -1177,7 +1177,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</foaf:age>
     <schema:name xml:lang="ja">舞田類</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">舞田類</rdfs:label>
-    <schema:name xml:lang="en">Maita Rui</schema:name>
+    <schema:name xml:lang="en">Rui Maita</schema:name>
     <imas:nameKana xml:lang="ja">まいたるい</imas:nameKana>
     <schema:familyName xml:lang="ja">舞田</schema:familyName>
     <schema:familyName xml:lang="en">Maita</schema:familyName>
@@ -1212,7 +1212,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">30</foaf:age>
     <schema:name xml:lang="ja">山下次郎</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">山下次郎</rdfs:label>
-    <schema:name xml:lang="en">Yamashita Jiro</schema:name>
+    <schema:name xml:lang="en">Jiro Yamashita</schema:name>
     <imas:nameKana xml:lang="ja">やましたじろう</imas:nameKana>
     <schema:familyName xml:lang="ja">山下</schema:familyName>
     <schema:familyName xml:lang="en">Yamashita</schema:familyName>
@@ -1246,7 +1246,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
     <schema:name xml:lang="ja">大河タケル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">大河タケル</rdfs:label>
-    <schema:name xml:lang="en">Taiga Takeru</schema:name>
+    <schema:name xml:lang="en">Takeru Taiga</schema:name>
     <imas:nameKana xml:lang="ja">たいがたける</imas:nameKana>
     <schema:familyName xml:lang="ja">大河</schema:familyName>
     <schema:familyName xml:lang="en">Taiga</schema:familyName>
@@ -1281,7 +1281,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">24</foaf:age>
     <schema:name xml:lang="ja">円城寺道流</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">円城寺道流</rdfs:label>
-    <schema:name xml:lang="en">Enjoji Michiru</schema:name>
+    <schema:name xml:lang="en">Michiru Enjoji</schema:name>
     <imas:nameKana xml:lang="ja">えんじょうじみちる</imas:nameKana>
     <schema:familyName xml:lang="ja">円城寺</schema:familyName>
     <schema:familyName xml:lang="en">Enjoji</schema:familyName>
@@ -1314,7 +1314,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
     <schema:name xml:lang="ja">牙崎漣</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">牙崎漣</rdfs:label>
-    <schema:name xml:lang="en">Kizaki Ren</schema:name>
+    <schema:name xml:lang="en">Ren Kizaki</schema:name>
     <imas:nameKana xml:lang="ja">きざきれん</imas:nameKana>
     <schema:familyName xml:lang="ja">牙崎</schema:familyName>
     <schema:familyName xml:lang="en">Kizaki</schema:familyName>
@@ -1347,7 +1347,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
     <schema:name xml:lang="ja">秋月涼</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">秋月涼</rdfs:label>
-    <schema:name xml:lang="en">Akizuki Ryo</schema:name>
+    <schema:name xml:lang="en">Ryo Akizuki</schema:name>
     <imas:nameKana xml:lang="ja">あきづきりょう</imas:nameKana>
     <schema:familyName xml:lang="ja">秋月</schema:familyName>
     <schema:familyName xml:lang="en">Akizuki</schema:familyName>
@@ -1382,7 +1382,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">14</foaf:age>
     <schema:name xml:lang="ja">兜大吾</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">兜大吾</rdfs:label>
-    <schema:name xml:lang="en">Kabuto Daigo</schema:name>
+    <schema:name xml:lang="en">Daigo Kabuto</schema:name>
     <imas:nameKana xml:lang="ja">かぶとだいご</imas:nameKana>
     <schema:familyName xml:lang="ja">兜</schema:familyName>
     <schema:familyName xml:lang="en">Kabuto</schema:familyName>
@@ -1416,7 +1416,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
     <schema:name xml:lang="ja">九十九一希</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">九十九一希</rdfs:label>
-    <schema:name xml:lang="en">Tsukumo Kazuki</schema:name>
+    <schema:name xml:lang="en">Kazuki Tsukumo</schema:name>
     <imas:nameKana xml:lang="ja">つくもかずき</imas:nameKana>
     <schema:familyName xml:lang="ja">九十九</schema:familyName>
     <schema:familyName xml:lang="en">Tsukumo</schema:familyName>
@@ -1454,7 +1454,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">30</foaf:age>
     <schema:name xml:lang="ja">葛之葉雨彦</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">葛之葉雨彦</rdfs:label>
-    <schema:name xml:lang="en">Kuzunoha Amehiko</schema:name>
+    <schema:name xml:lang="en">Amehiko Kuzunoha</schema:name>
     <imas:nameKana xml:lang="ja">くずのはあめひこ</imas:nameKana>
     <schema:familyName xml:lang="ja">葛之葉</schema:familyName>
     <schema:familyName xml:lang="en">Kuzunoha</schema:familyName>
@@ -1487,7 +1487,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>
     <schema:name xml:lang="ja">北村想楽</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">北村想楽</rdfs:label>
-    <schema:name xml:lang="en">Kitamura Sora</schema:name>
+    <schema:name xml:lang="en">Sora Kitamura</schema:name>
     <imas:nameKana xml:lang="ja">きたむらそら</imas:nameKana>
     <schema:familyName xml:lang="ja">北村</schema:familyName>
     <schema:familyName xml:lang="en">Kitamura</schema:familyName>
@@ -1520,7 +1520,7 @@
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">29</foaf:age>
     <schema:name xml:lang="ja">古論クリス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">古論クリス</rdfs:label>
-    <schema:name xml:lang="en">Koron Chris</schema:name>
+    <schema:name xml:lang="en">Chris Koron</schema:name>
     <imas:nameKana xml:lang="ja">ころんくりす</imas:nameKana>
     <schema:familyName xml:lang="ja">古論</schema:familyName>
     <schema:familyName xml:lang="en">Koron</schema:familyName>

--- a/RDFs/Staff.rdf
+++ b/RDFs/Staff.rdf
@@ -17,7 +17,7 @@
     <imas:nameKana xml:lang="ja">たかぎじゅんいちろう</imas:nameKana>
     <schema:name xml:lang="ja">高木順一朗</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">高木順一朗</rdfs:label>
-    <schema:name xml:lang="en">Takagi Junichiro</schema:name>
+    <schema:name xml:lang="en">Junichiro Takagi</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">55</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">180.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">76.0</schema:weight>
@@ -44,7 +44,7 @@
     <imas:nameKana xml:lang="ja">たかぎじゅんじろう</imas:nameKana>
     <schema:name xml:lang="ja">高木順二朗</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">高木順二朗</rdfs:label>
-    <schema:name xml:lang="en">Takagi Junjiro</schema:name>
+    <schema:name xml:lang="en">Junjiro Takagi</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">56</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">180.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">73.0</schema:weight>
@@ -71,7 +71,7 @@
     <imas:nameKana xml:lang="ja">くろいたかお</imas:nameKana>
     <schema:name xml:lang="ja">黒井崇男</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">黒井崇男</rdfs:label>
-    <schema:name xml:lang="en">Kuroi Takao</schema:name>
+    <schema:name xml:lang="en">Takao Kuroi</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">54</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">178.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">74.0</schema:weight>
@@ -98,7 +98,7 @@
     <imas:nameKana xml:lang="ja">さいとうたかし</imas:nameKana>
     <schema:name xml:lang="ja">齋藤孝司</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">齋藤孝司</rdfs:label>
-    <schema:name xml:lang="en">Saito Takashi</schema:name>
+    <schema:name xml:lang="en">Takashi Saito</schema:name>
     <foaf:age xml:lang="ja">ナイスミドル</foaf:age>
     <imas:cv xml:lang="ja">立木文彦</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/立木文彦"/>
@@ -118,7 +118,7 @@
     <imas:nameKana xml:lang="ja">いしかわみのり</imas:nameKana>
     <schema:name xml:lang="ja">石川実</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">石川実</rdfs:label>
-    <schema:name xml:lang="en">Ishikawa Minori</schema:name>
+    <schema:name xml:lang="en">Minori Ishikawa</schema:name>
     <schema:gender xml:lang="en">female</schema:gender>
     <schema:memberOf xml:lang="en">876Staff</schema:memberOf>
     <schema:position xml:lang="ja">社長</schema:position>
@@ -134,7 +134,7 @@
     <imas:nameKana xml:lang="ja">あまいつとむ</imas:nameKana>
     <schema:name xml:lang="ja">天井努</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">天井努</rdfs:label>
-    <schema:name xml:lang="en">Amai Tsutomu</schema:name>
+    <schema:name xml:lang="en">Tsutomu Amai</schema:name>
     <imas:cv xml:lang="ja">津田健次郎</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/津田健次郎"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1255370"/>
@@ -154,7 +154,7 @@
     <imas:nameKana xml:lang="ja">おとなしことり</imas:nameKana>
     <schema:name xml:lang="ja">音無小鳥</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">音無小鳥</rdfs:label>
-    <schema:name xml:lang="en">Otonashi Kotori</schema:name>
+    <schema:name xml:lang="en">Kotori Otonashi</schema:name>
     <foaf:age xml:lang="ja">?</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">159.0</schema:height>
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">49.0</schema:weight>
@@ -185,7 +185,7 @@
     <imas:nameKana xml:lang="ja">せんかわちひろ</imas:nameKana>
     <schema:name xml:lang="ja">千川ちひろ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">千川ちひろ</rdfs:label>
-    <schema:name xml:lang="en">Senkawa Chihiro</schema:name>
+    <schema:name xml:lang="en">Chihiro Senkawa</schema:name>
     <foaf:age xml:lang="ja">?</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">154.0</schema:height>
     <schema:weight xml:lang="ja">ひ・み・つ</schema:weight>
@@ -217,7 +217,7 @@
     <imas:nameKana xml:lang="ja">やまむらけん</imas:nameKana>
     <schema:name xml:lang="ja">山村賢</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">山村賢</rdfs:label>
-    <schema:name xml:lang="en">Yamamura Ken</schema:name>
+    <schema:name xml:lang="en">Ken Yamamura</schema:name>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--07-02</schema:birthDate>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A</imas:BloodType>
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
@@ -246,7 +246,7 @@
     <imas:nameKana xml:lang="ja">あおばみさき</imas:nameKana>
     <schema:name xml:lang="ja">青羽美咲</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">青羽美咲</rdfs:label>
-    <schema:name xml:lang="en">Aoba Misaki</schema:name>
+    <schema:name xml:lang="en">Misaki Aoba</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</foaf:age>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--06-29</schema:birthDate>
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
@@ -268,7 +268,7 @@
     <imas:nameKana xml:lang="ja">ななくさはづき</imas:nameKana>
     <schema:name xml:lang="ja">七草はづき</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">七草はづき</rdfs:label>
-    <schema:name xml:lang="en">Nanakusa Hazuki</schema:name>
+    <schema:name xml:lang="en">Hazuki Nanakusa</schema:name>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--02-03</schema:birthDate>
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <imas:cv xml:lang="ja">山村響</imas:cv>
@@ -291,7 +291,7 @@
     <imas:nameKana xml:lang="ja">はやさかそら</imas:nameKana>
     <schema:name xml:lang="ja">早坂そら</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">早坂そら</rdfs:label>
-    <schema:name xml:lang="en">Hayasaka Sora</schema:name>
+    <schema:name xml:lang="en">Sora Hayasaka</schema:name>
     <imas:Hobby xml:lang="ja">旅行</imas:Hobby>
     <imas:Talent xml:lang="ja">ランニング</imas:Talent>
     <imas:Favorite xml:lang="ja">気ままに散歩</imas:Favorite>
@@ -314,7 +314,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Staff"/>
     <schema:name xml:lang="ja">青木麗</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">マスタートレーナー</rdfs:label>
-    <schema:name xml:lang="en">Aoki Rei</schema:name>
+    <schema:name xml:lang="en">Rei Aoki</schema:name>
     <imas:nameKana xml:lang="ja">あおきれい</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">166.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">28</foaf:age>
@@ -350,7 +350,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Staff"/>
     <schema:name xml:lang="ja">青木聖</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ベテラントレーナー</rdfs:label>
-    <schema:name xml:lang="en">Aoki Sei</schema:name>
+    <schema:name xml:lang="en">Sei Aoki</schema:name>
     <imas:nameKana xml:lang="ja">あおきせい</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">163.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">26</foaf:age>
@@ -384,7 +384,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Staff"/>
     <schema:name xml:lang="ja">青木明</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">トレーナー</rdfs:label>
-    <schema:name xml:lang="en">Aoki Mei</schema:name>
+    <schema:name xml:lang="en">Mei Aoki</schema:name>
     <imas:nameKana xml:lang="ja">あおきめい</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">160.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</foaf:age>
@@ -418,7 +418,7 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Staff"/>
     <schema:name xml:lang="ja">青木慶</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ルーキートレーナー</rdfs:label>
-    <schema:name xml:lang="en">Aoki Kei</schema:name>
+    <schema:name xml:lang="en">Kei Aoki</schema:name>
     <imas:nameKana xml:lang="ja">あおきけい</imas:nameKana>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">157.0</schema:height>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">19</foaf:age>

--- a/RDFs/Xenoglossia.rdf
+++ b/RDFs/Xenoglossia.rdf
@@ -387,7 +387,7 @@
     <imas:nameKana xml:lang="ja">じょせふ・しんげつ</imas:nameKana>
     <schema:name xml:lang="ja">ジョセフ・真月</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ジョセフ・真月</rdfs:label>
-    <schema:name xml:lang="en">Shingetsu Joseph</schema:name>
+    <schema:name xml:lang="en">Joseph Shingetsu</schema:name>
     <imas:cv xml:lang="ja">中多和宏</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/中多和宏"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q4115613"/>

--- a/RDFs/Xenoglossia.rdf
+++ b/RDFs/Xenoglossia.rdf
@@ -16,7 +16,7 @@
     <imas:nameKana xml:lang="ja">あまみはるか</imas:nameKana>
     <schema:name xml:lang="ja">天海春香</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">天海春香</rdfs:label>
-    <schema:name xml:lang="en">Amami Haruka</schema:name>
+    <schema:name xml:lang="en">Haruka Amami</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">158.0</schema:height>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--04-03</schema:birthDate>
@@ -39,7 +39,7 @@
     <imas:nameKana xml:lang="ja">きさらぎちはや</imas:nameKana>
     <schema:name xml:lang="ja">如月千早</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">如月千早</rdfs:label>
-    <schema:name xml:lang="en">Kisaragi Chihaya</schema:name>
+    <schema:name xml:lang="en">Chihaya Kisaragi</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">167.0</schema:height>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--02-25</schema:birthDate>
@@ -62,7 +62,7 @@
     <imas:nameKana xml:lang="ja">はぎわらゆきほ</imas:nameKana>
     <schema:name xml:lang="ja">萩原雪歩</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">萩原雪歩</rdfs:label>
-    <schema:name xml:lang="en">Hagiwara Yukiho</schema:name>
+    <schema:name xml:lang="en">Yukiho Hagiwara</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">158.0</schema:height>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--12-24</schema:birthDate>
@@ -85,7 +85,7 @@
     <imas:nameKana xml:lang="ja">たかつきやよい</imas:nameKana>
     <schema:name xml:lang="ja">高槻やよい</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">高槻やよい</rdfs:label>
-    <schema:name xml:lang="en">Takatsuki Yayoi</schema:name>
+    <schema:name xml:lang="en">Yayoi Takatsuki</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">154.0</schema:height>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--03-25</schema:birthDate>
@@ -108,7 +108,7 @@
     <imas:nameKana xml:lang="ja">きくちまこと</imas:nameKana>
     <schema:name xml:lang="ja">菊地真</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">菊地真</rdfs:label>
-    <schema:name xml:lang="en">Kikuchi Makoto</schema:name>
+    <schema:name xml:lang="en">Makoto Kikuchi</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">163.0</schema:height>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--08-29</schema:birthDate>
@@ -131,7 +131,7 @@
     <imas:nameKana xml:lang="ja">みなせいおり</imas:nameKana>
     <schema:name xml:lang="ja">水瀬伊織</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">水瀬伊織</rdfs:label>
-    <schema:name xml:lang="en">Minase Iori</schema:name>
+    <schema:name xml:lang="en">Iori Minase</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">156.0</schema:height>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-05</schema:birthDate>
@@ -154,7 +154,7 @@
     <imas:nameKana xml:lang="ja">あきづきりつこ</imas:nameKana>
     <schema:name xml:lang="ja">秋月律子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">秋月律子</rdfs:label>
-    <schema:name xml:lang="en">Akizuki Ritsuko</schema:name>
+    <schema:name xml:lang="en">Ritsuko Akizuki</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">18</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">165.0</schema:height>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--06-23</schema:birthDate>
@@ -177,7 +177,7 @@
     <imas:nameKana xml:lang="ja">みうらあずさ</imas:nameKana>
     <schema:name xml:lang="ja">三浦あずさ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">三浦あずさ</rdfs:label>
-    <schema:name xml:lang="en">Miura Azusa</schema:name>
+    <schema:name xml:lang="en">Azusa Miura</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">20</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">168.0</schema:height>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--07-19</schema:birthDate>
@@ -200,7 +200,7 @@
     <imas:nameKana xml:lang="ja">ふたみあみ</imas:nameKana>
     <schema:name xml:lang="ja">双海亜美</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">双海亜美</rdfs:label>
-    <schema:name xml:lang="en">Futami Ami</schema:name>
+    <schema:name xml:lang="en">Ami Futami</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">148.0</schema:height>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-22</schema:birthDate>
@@ -223,7 +223,7 @@
     <imas:nameKana xml:lang="ja">ふたみまみ</imas:nameKana>
     <schema:name xml:lang="ja">双海真美</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">双海真美</rdfs:label>
-    <schema:name xml:lang="en">Futami Mami</schema:name>
+    <schema:name xml:lang="en">Mami Futami</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</foaf:age>
     <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">148.0</schema:height>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--05-22</schema:birthDate>
@@ -262,7 +262,7 @@
     <imas:nameKana xml:lang="ja">すずきそれわ</imas:nameKana>
     <schema:name xml:lang="ja">鈴木空羽</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">鈴木空羽</rdfs:label>
-    <schema:name xml:lang="en">Suzuki Sorewa</schema:name>
+    <schema:name xml:lang="en">Sorewa Suzuki</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">21</foaf:age>
     <imas:cv xml:lang="ja">高橋美佳子</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/高橋美佳子"/>
@@ -281,7 +281,7 @@
     <imas:nameKana xml:lang="ja">だいどうならば</imas:nameKana>
     <schema:name xml:lang="ja">大道楢馬</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">大道楢馬</rdfs:label>
-    <schema:name xml:lang="en">Daido Naraba</schema:name>
+    <schema:name xml:lang="en">Naraba Daido</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">23</foaf:age>
     <imas:cv xml:lang="ja">小野大輔</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/小野大輔"/>
@@ -300,7 +300,7 @@
     <imas:nameKana xml:lang="ja">むなかたなぜ</imas:nameKana>
     <schema:name xml:lang="ja">宗方名瀬</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">宗方名瀬</rdfs:label>
-    <schema:name xml:lang="en">Munakata Naze</schema:name>
+    <schema:name xml:lang="en">Naze Munakata</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">25</foaf:age>
     <imas:cv xml:lang="ja">能登麻美子</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/能登麻美子"/>
@@ -319,7 +319,7 @@
     <imas:nameKana xml:lang="ja">みなもとちかこ</imas:nameKana>
     <schema:name xml:lang="ja">源千佳子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">源千佳子</rdfs:label>
-    <schema:name xml:lang="en">Minamoto Chikako</schema:name>
+    <schema:name xml:lang="en">Chikako Minamoto</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">26</foaf:age>
     <imas:cv xml:lang="ja">進藤尚美</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/進藤尚美"/>
@@ -338,7 +338,7 @@
     <imas:nameKana xml:lang="ja">やすはらほたる</imas:nameKana>
     <schema:name xml:lang="ja">安原蛍</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">安原蛍</rdfs:label>
-    <schema:name xml:lang="en">Yasuhara Hotaru</schema:name>
+    <schema:name xml:lang="en">Hotaru Yasuhara</schema:name>
     <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">26</foaf:age>
     <imas:cv xml:lang="ja">柚木涼香</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/柚木涼香"/>
@@ -357,7 +357,7 @@
     <imas:nameKana xml:lang="ja">さくひびき</imas:nameKana>
     <schema:name xml:lang="ja">朔響</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">朔響</rdfs:label>
-    <schema:name xml:lang="en">Saku Hibiki</schema:name>
+    <schema:name xml:lang="en">Hibiki Saku</schema:name>
     <imas:cv xml:lang="ja">竹若拓磨</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/竹若拓磨"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q7678565"/>
@@ -387,7 +387,7 @@
     <imas:nameKana xml:lang="ja">じょせふ・しんげつ</imas:nameKana>
     <schema:name xml:lang="ja">ジョセフ・真月</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ジョセフ・真月</rdfs:label>
-    <schema:name xml:lang="en">Joseph Shingetsu</schema:name>
+    <schema:name xml:lang="en">Shingetsu Joseph</schema:name>
     <imas:cv xml:lang="ja">中多和宏</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/中多和宏"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q4115613"/>


### PR DESCRIPTION
基本的にはゲーム内カードの表記に揃える方向で修正

### 姓名を入れ替えなかった方々

- 楊菲菲
- メアリー・コクラン
- キャシー・グラハム
- イヴ・サンタクロース
- エミリー・スチュアート

ソース: ゲーム内カード

- ジョセフ・真月

ソース: [アイマス英語版Wiki](https://www.project-imas.com/wiki/Idolmaster:_Xenoglossia#Characters)