### PR TITLE
MUSIC DAWNの公演情報を追加

### DIFF
--- a/RDFs/Lives/Live_2020.rdf
+++ b/RDFs/Lives/Live_2020.rdf
@@ -253,4 +253,75 @@
     <schema:url rdf:resource="https://idolmaster.jp/event/shinycolors_2nd.php"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Live"/>
   </rdf:Description>
+
+  <rdf:Description rdf:about="THE%20IDOLM@STER%20SHINY%20COLORS%20MUSIC%20DAWN%20Day1">
+    <schema:actor xml:lang="ja">河野ひより</schema:actor>
+    <schema:actor xml:lang="ja">白石晴香</schema:actor>
+    <schema:actor xml:lang="ja">永井真里子</schema:actor>
+    <schema:actor xml:lang="ja">丸岡和佳奈</schema:actor>
+    <schema:actor xml:lang="ja">涼本あきほ</schema:actor>
+    <schema:actor xml:lang="ja">礒部花凜</schema:actor>
+    <schema:actor xml:lang="ja">菅沼千紗</schema:actor>
+    <schema:actor xml:lang="ja">八巻アンナ</schema:actor>
+    <schema:actor xml:lang="ja">成海瑠奈</schema:actor>
+    <schema:actor xml:lang="ja">結名美月</schema:actor>
+    <schema:actor xml:lang="ja">関根瞳</schema:actor>
+    <schema:actor xml:lang="ja">近藤玲奈</schema:actor>
+    <schema:actor xml:lang="ja">峯田茉優</schema:actor>
+    <schema:actor xml:lang="ja">黒木ほの香</schema:actor>
+    <schema:actor xml:lang="ja">前川涼子</schema:actor>
+    <schema:actor xml:lang="ja">芝崎典子</schema:actor>
+    <schema:actor xml:lang="ja">田中有紀</schema:actor>
+    <schema:actor xml:lang="ja">幸村恵理</schema:actor>
+    <schema:actor xml:lang="ja">北原沙弥香</schema:actor>
+    <schema:actor xml:lang="ja">浅倉透</schema:actor>
+    <schema:actor xml:lang="ja">土屋李央</schema:actor>
+    <schema:actor xml:lang="ja">田嶌紗蘭</schema:actor>
+    <schema:actor xml:lang="ja">岡咲美保</schema:actor>
+    <schema:actor xml:lang="ja">津田健次郎</schema:actor>
+    <schema:actor xml:lang="ja">高山祐介</schema:actor>
+    <schema:eventStatus rdf:resource="http://schema.org/EventScheduled" />
+    <schema:eventAttendanceMode rdf:resource="http://schema.org/OnlineEventAttendanceMode" />
+    <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">THE IDOLM@STER SHINY COLORS MUSIC DAWN Day2</schema:name>
+    <schema:location rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ASOBISTAGE</schema:location>
+    <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-10-31</schema:startDate>
+    <schema:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-10-31</schema:endDate>
+    <schema:url rdf:resource="https://idolmaster-official.jp/live_event/shinycolors_musicdawn/"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Live"/>
+  </rdf:Description>
+
+  <rdf:Description rdf:about="THE%20IDOLM@STER%20SHINY%20COLORS%20MUSIC%20DAWN%20Day2">
+    <schema:actor xml:lang="ja">河野ひより</schema:actor>
+    <schema:actor xml:lang="ja">白石晴香</schema:actor>
+    <schema:actor xml:lang="ja">永井真里子</schema:actor>
+    <schema:actor xml:lang="ja">丸岡和佳奈</schema:actor>
+    <schema:actor xml:lang="ja">涼本あきほ</schema:actor>
+    <schema:actor xml:lang="ja">礒部花凜</schema:actor>
+    <schema:actor xml:lang="ja">菅沼千紗</schema:actor>
+    <schema:actor xml:lang="ja">八巻アンナ</schema:actor>
+    <schema:actor xml:lang="ja">成海瑠奈</schema:actor>
+    <schema:actor xml:lang="ja">結名美月</schema:actor>
+    <schema:actor xml:lang="ja">関根瞳</schema:actor>
+    <schema:actor xml:lang="ja">近藤玲奈</schema:actor>
+    <schema:actor xml:lang="ja">峯田茉優</schema:actor>
+    <schema:actor xml:lang="ja">黒木ほの香</schema:actor>
+    <schema:actor xml:lang="ja">前川涼子</schema:actor>
+    <schema:actor xml:lang="ja">芝崎典子</schema:actor>
+    <schema:actor xml:lang="ja">田中有紀</schema:actor>
+    <schema:actor xml:lang="ja">幸村恵理</schema:actor>
+    <schema:actor xml:lang="ja">北原沙弥香</schema:actor>
+    <schema:actor xml:lang="ja">浅倉透</schema:actor>
+    <schema:actor xml:lang="ja">田嶌紗蘭</schema:actor>
+    <schema:actor xml:lang="ja">岡咲美保</schema:actor>
+    <schema:actor xml:lang="ja">山村響</schema:actor>
+    <schema:actor xml:lang="ja">高山祐介</schema:actor>
+    <schema:eventStatus rdf:resource="http://schema.org/EventScheduled" />
+    <schema:eventAttendanceMode rdf:resource="http://schema.org/OnlineEventAttendanceMode" />
+    <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">THE IDOLM@STER SHINY COLORS MUSIC DAWN Day2</schema:name>
+    <schema:location rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ASOBISTAGE</schema:location>
+    <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-11-01</schema:startDate>
+    <schema:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-11-01</schema:endDate>
+    <schema:url rdf:resource="https://idolmaster-official.jp/live_event/shinycolors_musicdawn/"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Live"/>
+  </rdf:Description>
 </rdf:RDF>

--- a/RDFs/Lives/Live_2020.rdf
+++ b/RDFs/Lives/Live_2020.rdf
@@ -281,7 +281,7 @@
     <schema:actor xml:lang="ja">津田健次郎</schema:actor>
     <schema:actor xml:lang="ja">高山祐介</schema:actor>
     <schema:eventStatus rdf:resource="http://schema.org/EventScheduled" />
-    <schema:eventAttendanceMode rdf:resource="http://schema.org/OnlineEventAttendanceMode" />
+    <!-- <schema:eventAttendanceMode rdf:resource="http://schema.org/OnlineEventAttendanceMode" /> -->
     <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">THE IDOLM@STER SHINY COLORS MUSIC DAWN Day2</schema:name>
     <schema:location rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ASOBISTAGE（アソビストア）</schema:location>
     <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-10-31</schema:startDate>
@@ -316,7 +316,7 @@
     <schema:actor xml:lang="ja">山村響</schema:actor>
     <schema:actor xml:lang="ja">高山祐介</schema:actor>
     <schema:eventStatus rdf:resource="http://schema.org/EventScheduled" />
-    <schema:eventAttendanceMode rdf:resource="http://schema.org/OnlineEventAttendanceMode" />
+    <!-- <schema:eventAttendanceMode rdf:resource="http://schema.org/OnlineEventAttendanceMode" /> -->
     <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">THE IDOLM@STER SHINY COLORS MUSIC DAWN Day2</schema:name>
     <schema:location rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ASOBISTAGE（アソビストア）</schema:location>
     <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-11-01</schema:startDate>

--- a/RDFs/Lives/Live_2020.rdf
+++ b/RDFs/Lives/Live_2020.rdf
@@ -274,7 +274,7 @@
     <schema:actor xml:lang="ja">田中有紀</schema:actor>
     <schema:actor xml:lang="ja">幸村恵理</schema:actor>
     <schema:actor xml:lang="ja">北原沙弥香</schema:actor>
-    <schema:actor xml:lang="ja">浅倉透</schema:actor>
+    <schema:actor xml:lang="ja">和久井優</schema:actor>
     <schema:actor xml:lang="ja">土屋李央</schema:actor>
     <schema:actor xml:lang="ja">田嶌紗蘭</schema:actor>
     <schema:actor xml:lang="ja">岡咲美保</schema:actor>
@@ -282,7 +282,7 @@
     <schema:actor xml:lang="ja">高山祐介</schema:actor>
     <schema:eventStatus rdf:resource="http://schema.org/EventScheduled" />
     <!-- <schema:eventAttendanceMode rdf:resource="http://schema.org/OnlineEventAttendanceMode" /> -->
-    <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">THE IDOLM@STER SHINY COLORS MUSIC DAWN Day2</schema:name>
+    <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">THE IDOLM@STER SHINY COLORS MUSIC DAWN Day1</schema:name>
     <schema:location rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ASOBISTAGE（アソビストア）</schema:location>
     <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-10-31</schema:startDate>
     <schema:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-10-31</schema:endDate>
@@ -310,7 +310,7 @@
     <schema:actor xml:lang="ja">田中有紀</schema:actor>
     <schema:actor xml:lang="ja">幸村恵理</schema:actor>
     <schema:actor xml:lang="ja">北原沙弥香</schema:actor>
-    <schema:actor xml:lang="ja">浅倉透</schema:actor>
+    <schema:actor xml:lang="ja">和久井優</schema:actor>
     <schema:actor xml:lang="ja">田嶌紗蘭</schema:actor>
     <schema:actor xml:lang="ja">岡咲美保</schema:actor>
     <schema:actor xml:lang="ja">山村響</schema:actor>

--- a/RDFs/Lives/Live_2020.rdf
+++ b/RDFs/Lives/Live_2020.rdf
@@ -283,10 +283,10 @@
     <schema:eventStatus rdf:resource="http://schema.org/EventScheduled" />
     <schema:eventAttendanceMode rdf:resource="http://schema.org/OnlineEventAttendanceMode" />
     <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">THE IDOLM@STER SHINY COLORS MUSIC DAWN Day2</schema:name>
-    <schema:location rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ASOBISTAGE</schema:location>
+    <schema:location rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ASOBISTAGE（アソビストア）</schema:location>
     <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-10-31</schema:startDate>
     <schema:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-10-31</schema:endDate>
-    <schema:url rdf:resource="https://idolmaster-official.jp/live_event/shinycolors_musicdawn/"/>
+    <schema:url rdf:resource="https://idolmaster-official.jp/live_event/shinycolors_musicdawn/index.php"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Live"/>
   </rdf:Description>
 
@@ -318,10 +318,10 @@
     <schema:eventStatus rdf:resource="http://schema.org/EventScheduled" />
     <schema:eventAttendanceMode rdf:resource="http://schema.org/OnlineEventAttendanceMode" />
     <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">THE IDOLM@STER SHINY COLORS MUSIC DAWN Day2</schema:name>
-    <schema:location rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ASOBISTAGE</schema:location>
+    <schema:location rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ASOBISTAGE（アソビストア）</schema:location>
     <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-11-01</schema:startDate>
     <schema:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2020-11-01</schema:endDate>
-    <schema:url rdf:resource="https://idolmaster-official.jp/live_event/shinycolors_musicdawn/"/>
+    <schema:url rdf:resource="https://idolmaster-official.jp/live_event/shinycolors_musicdawn/index.php"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Live"/>
   </rdf:Description>
 </rdf:RDF>


### PR DESCRIPTION
### 気になるところ

- オンライン配信のみのライブの扱いをどうするか
  - ~`schema:eventAttendanceMode`を新たに利用: https://schema.org/eventAttendanceMode~
  - ~これまでのライブに`<schema:eventAttendanceMode rdf:resource="http://schema.org/OfflineEventAttendanceMode" />`を付け足すべき？~
  - まだ正式採用されてなかった 😢 : https://github.com/schemaorg/schemaorg/issues/1842
  - rdflintにバンドルされているschema.orgが古い説: https://github.com/imas/imasparql/pull/386#issuecomment-750239781
- 場所の情報をどうするか
  - 公式サイト上の表記は「ASOBISTAGE（アソビストア）」だったのでとりあえずそのまま転記: https://idolmaster-official.jp/live_event/shinycolors_musicdawn/index.php

### 相談して解決したところ

- 演者に「高山祐介」を入れるべきか否か
  - これまでのデータもアイドル名ではなく演者名を入れていたので特に問題ない
  - 番組MCを表すのは`schema:actor`が適切と判断