### PR TITLE
MTWシリーズユニットのよみがなを追加

### DIFF
--- a/RDFs/Units/MillionLive.rdf
+++ b/RDFs/Units/MillionLive.rdf
@@ -841,6 +841,7 @@
   <rdf:Description rdf:about="miraclesonic%E2%98%85expassion">
     <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">miraclesonic★expassion</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">miraclesonic★expassion</rdfs:label>
+    <imas:nameKana xml:lang="ja">みらくるそにっくえくすぱっしょん</imas:nameKana>
     <schema:member rdf:resource="Maihama_Ayumu"/>
     <schema:member rdf:resource="Fukuda_Noriko"/>
     <schema:member rdf:resource="Shimabara_Elena"/>
@@ -860,6 +861,7 @@
   <rdf:Description rdf:about="%E3%83%80%E3%82%A4%E3%83%A4%E3%83%A2%E3%83%B3%E3%83%89%E3%83%80%E3%82%A4%E3%83%90%E3%83%BC%E2%97%87">
     <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ダイヤモンドダイバー◇</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ダイヤモンドダイバー◇</rdfs:label>
+    <imas:nameKana xml:lang="ja">だいやもんどだいばー</imas:nameKana>
     <schema:member rdf:resource="Takatsuki_Yayoi"/>
     <schema:member rdf:resource="Amami_Haruka"/>
     <schema:member rdf:resource="Ganaha_Hibiki"/>

--- a/RDFs/Units/MillionLive.rdf
+++ b/RDFs/Units/MillionLive.rdf
@@ -797,7 +797,7 @@
   <rdf:Description rdf:about="Sherry%20%27n%20Cherry">
     <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sherry 'n Cherry</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sherry 'n Cherry</rdfs:label>
-    <imas:nameKana xml:lang="ja">しぇりー　あん　ちぇりー</imas:nameKana>
+    <imas:nameKana xml:lang="ja">しぇりー あん ちぇりー</imas:nameKana>
     <schema:member rdf:resource="Baba_Konomi"/>
     <schema:member rdf:resource="Momose_Rio"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit"/>

--- a/RDFs/Units/MillionLive.rdf
+++ b/RDFs/Units/MillionLive.rdf
@@ -776,6 +776,7 @@
   <rdf:Description rdf:about="Chrono-Lexica">
     <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chrono-Lexica</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chrono-Lexica</rdfs:label>
+    <imas:nameKana xml:lang="ja">くろのれきしか</imas:nameKana>
     <schema:member rdf:resource="Nanao_Yuriko"/>
     <schema:member rdf:resource="Mochizuki_Anna"/>
     <schema:member rdf:resource="Nagayoshi_Subaru"/>
@@ -786,6 +787,7 @@
   <rdf:Description rdf:about="Xs">
     <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Xs</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Xs</rdfs:label>
+    <imas:nameKana xml:lang="ja">きす</imas:nameKana>
     <schema:member rdf:resource="Hoshii_Miki"/>
     <schema:member rdf:resource="Hagiwara_Yukiho"/>
     <schema:member rdf:resource="Kikuchi_Makoto"/>
@@ -795,6 +797,7 @@
   <rdf:Description rdf:about="Sherry%20%27n%20Cherry">
     <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sherry 'n Cherry</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sherry 'n Cherry</rdfs:label>
+    <imas:nameKana xml:lang="ja">しぇりー　あん　ちぇりー</imas:nameKana>
     <schema:member rdf:resource="Baba_Konomi"/>
     <schema:member rdf:resource="Momose_Rio"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit"/>
@@ -802,6 +805,7 @@
   <rdf:Description rdf:about="ARCANA">
     <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ARCANA</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ARCANA</rdfs:label>
+    <imas:nameKana xml:lang="ja">あるかな</imas:nameKana>
     <schema:member rdf:resource="Miura_Azusa"/>
     <schema:member rdf:resource="Kisaragi_Chihaya"/>
     <schema:member rdf:resource="Shijou_Takane"/>
@@ -810,6 +814,7 @@
   <rdf:Description rdf:about="%E8%8A%B1%E5%92%B2%E5%A4%9C">
     <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">花咲夜</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">花咲夜</rdfs:label>
+    <imas:nameKana xml:lang="ja">はなさくや</imas:nameKana>
     <schema:member rdf:resource="Emily_Stewart"/>
     <schema:member rdf:resource="Shiraishi_Tsumugi"/>
     <schema:member rdf:resource="Tenkubashi_Tomoka"/>
@@ -818,6 +823,7 @@
   <rdf:Description rdf:about="Jus-2-Mint">
     <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Jus-2-Mint</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Jus-2-Mint</rdfs:label>
+    <imas:nameKana xml:lang="ja">じゃすみん</imas:nameKana>
     <schema:member rdf:resource="Satake_Minako"/>
     <schema:member rdf:resource="Yokoyama_Nao"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit"/>
@@ -825,6 +831,7 @@
   <rdf:Description rdf:about="%E3%82%AA%E3%83%9A%E3%83%A9%E3%82%BB%E3%83%AA%E3%82%A2%E3%83%BB%E7%85%8C%E8%BC%9D%E5%BA%A7">
     <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">オペラセリア・煌輝座</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">オペラセリア・煌輝座</rdfs:label>
+    <imas:nameKana xml:lang="ja">おぺらせりあ・きらめきざ</imas:nameKana>
     <schema:member rdf:resource="Kitazawa_Shiho"/>
     <schema:member rdf:resource="Sakuramori_Kaori"/>
     <schema:member rdf:resource="Tokugawa_Matsuri"/>
@@ -843,6 +850,7 @@
   <rdf:Description rdf:about="Fleuranges">
     <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fleuranges</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fleuranges</rdfs:label>
+    <imas:nameKana xml:lang="ja">ふるらんじゅ</imas:nameKana>
     <schema:member rdf:resource="Shinomiya_Karen"/>
     <schema:member rdf:resource="Hakozaki_Serika"/>
     <schema:member rdf:resource="Miyao_Miya"/>
@@ -860,6 +868,7 @@
   <rdf:Description rdf:about="TIntMe!">
     <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TIntMe!</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TIntMe!</rdfs:label>
+    <imas:nameKana xml:lang="ja">てぃんとみー</imas:nameKana>
     <schema:member rdf:resource="Ogami_Tamaki"/>
     <schema:member rdf:resource="Nakatani_Iku"/>
     <schema:member rdf:resource="Suou_Momoko"/>
@@ -868,6 +877,7 @@
   <rdf:Description rdf:about="TRICK%26TREAT">
     <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TRICK&amp;TREAT</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TRICK&amp;TREAT</rdfs:label>
+    <imas:nameKana xml:lang="ja">とりっくあんどとりーと</imas:nameKana>
     <schema:member rdf:resource="Kitakami_Reika"/>
     <schema:member rdf:resource="Nonohara_Akane"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit"/>
@@ -875,6 +885,7 @@
   <rdf:Description rdf:about="%E2%89%A1%E5%90%9B%E5%BD%A9%E2%89%A1">
     <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">≡君彩≡</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">≡君彩≡</rdfs:label>
+    <imas:nameKana xml:lang="ja">きみどり</imas:nameKana>
     <schema:member rdf:resource="Tokoro_Megumi"/>
     <schema:member rdf:resource="Matsuda_Arisa"/>
     <schema:member rdf:resource="Yabuki_Kana"/>
@@ -883,6 +894,7 @@
   <rdf:Description rdf:about="ARMooo">
     <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ARMooo</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ARMooo</rdfs:label>
+    <imas:nameKana xml:lang="ja">あーむおー</imas:nameKana>
     <schema:member rdf:resource="Futami_Mami"/>
     <schema:member rdf:resource="Akizuki_Ritsuko"/>
     <schema:member rdf:resource="Futami_Ami"/>
@@ -891,6 +903,7 @@
   <rdf:Description rdf:about="chicAAmor">
     <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chicAAmor</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chicAAmor</rdfs:label>
+    <imas:nameKana xml:lang="ja">ちかあもーる</imas:nameKana>
     <schema:member rdf:resource="Takayama_Sayoko"/>
     <schema:member rdf:resource="Toyokawa_Fuka"/>
     <schema:member rdf:resource="Julia"/>
@@ -908,6 +921,7 @@
   <rdf:Description rdf:about="ZWEIGLANZ">
     <schema:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ZWEIGLANZ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ZWEIGLANZ</rdfs:label>
+    <imas:nameKana xml:lang="ja">つゔぁいぐらんつ</imas:nameKana>
     <schema:member rdf:resource="Leon"/>
     <schema:member rdf:resource="Shika"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Unit"/>


### PR DESCRIPTION
ユニットのよみかたは、lantis CDページ, アイマス公式ブログ、ドラマCD、メモリアルコミュで確認しました。
miraclesonic☆expassionとダイヤモンドダイバー◇のよみかたは確認できませんでした。