### PR TITLE
765AS、デレマス、ミリマス、sideMのアイドルに学年情報を追加

### DIFF
--- a/RDFs/1stVision.rdf
+++ b/RDFs/1stVision.rdf
@@ -37,6 +37,7 @@
     <imas:Brand xml:lang="en">1stVision</imas:Brand>
     <schema:memberOf rdf:resource="765Production"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
+    <imas:SchoolGrade xml:lang="ja">高校1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/10002"/>
   </rdf:Description>
 
@@ -69,6 +70,7 @@
     <imas:Brand xml:lang="en">1stVision</imas:Brand>
     <schema:memberOf rdf:resource="765Production"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
+    <imas:SchoolGrade xml:lang="ja">高校1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/10005"/>
   </rdf:Description>
 
@@ -103,6 +105,7 @@
     <schema:memberOf rdf:resource="765Production"/>
     <schema:memberOf rdf:resource="961Production"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
+    <imas:SchoolGrade xml:lang="ja">中学2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/10011"/>
   </rdf:Description>
 
@@ -136,6 +139,7 @@
     <imas:Brand xml:lang="en">1stVision</imas:Brand>
     <schema:memberOf rdf:resource="765Production"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
+    <imas:SchoolGrade xml:lang="ja">高校2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/10008"/>
   </rdf:Description>
 
@@ -168,6 +172,7 @@
     <imas:Brand xml:lang="en">1stVision</imas:Brand>
     <schema:memberOf rdf:resource="765Production"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
+    <imas:SchoolGrade xml:lang="ja">中学1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/10007"/>
   </rdf:Description>
 
@@ -200,6 +205,7 @@
     <imas:Brand xml:lang="en">1stVision</imas:Brand>
     <schema:memberOf rdf:resource="765Production"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
+    <imas:SchoolGrade xml:lang="ja">高校2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/10004"/>
   </rdf:Description>
 
@@ -233,6 +239,7 @@
     <imas:Brand xml:lang="en">1stVision</imas:Brand>
     <schema:memberOf rdf:resource="765Production"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
+    <imas:SchoolGrade xml:lang="ja">中学2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/10013"/>
   </rdf:Description>
 
@@ -300,6 +307,7 @@
     <imas:Brand xml:lang="en">1stVision</imas:Brand>
     <schema:memberOf rdf:resource="765Production"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
+    <imas:SchoolGrade xml:lang="ja">高校3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/10001"/>
   </rdf:Description>
 
@@ -366,6 +374,7 @@
     <schema:memberOf rdf:resource="765Production"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
     <schema:sibling rdf:resource="Futami_Mami_1st"/>
+    <imas:SchoolGrade xml:lang="ja">小学6年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/10009"/>
   </rdf:Description>
 
@@ -400,6 +409,7 @@
     <schema:memberOf rdf:resource="765Production"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
     <schema:sibling rdf:resource="Futami_Ami_1st"/>
+    <imas:SchoolGrade xml:lang="ja">小学6年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/10010"/>
   </rdf:Description>
 
@@ -432,6 +442,7 @@
     <schema:memberOf rdf:resource="765Production"/>
     <schema:memberOf rdf:resource="961Production"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol_1st"/>
+    <imas:SchoolGrade xml:lang="ja">高校1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/10003"/>
   </rdf:Description>
 </rdf:RDF>

--- a/RDFs/765AS.rdf
+++ b/RDFs/765AS.rdf
@@ -48,6 +48,7 @@
     <imas:PopLinksAttribute xml:lang="en">ocean</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">海</imas:PopLinksAttribute>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">高校2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/10002"/>
   </rdf:Description>
 
@@ -91,6 +92,7 @@
     <imas:PopLinksAttribute xml:lang="en">rainbow</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">虹</imas:PopLinksAttribute>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">高校2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/10005"/>
   </rdf:Description>
 
@@ -136,6 +138,7 @@
     <imas:PopLinksAttribute xml:lang="en">star</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">星</imas:PopLinksAttribute>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">中学3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/10011"/>
   </rdf:Description>
 
@@ -179,6 +182,7 @@
     <imas:PopLinksAttribute xml:lang="en">snow</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">雪</imas:PopLinksAttribute>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">高校3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/10008"/>
   </rdf:Description>
 
@@ -224,6 +228,7 @@
     <imas:PopLinksAttribute xml:lang="en">heaven</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">天</imas:PopLinksAttribute>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">中学2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/10007"/>
   </rdf:Description>
 
@@ -268,6 +273,7 @@
     <imas:PopLinksAttribute xml:lang="en">dream</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">夢</imas:PopLinksAttribute>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">高校3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/10004"/>
   </rdf:Description>
 
@@ -312,6 +318,7 @@
     <imas:PopLinksAttribute xml:lang="en">thunder</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">雷</imas:PopLinksAttribute>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">中学3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/10013"/>
   </rdf:Description>
 
@@ -488,6 +495,7 @@
     <imas:PopLinksAttribute xml:lang="ja">虹</imas:PopLinksAttribute>
     <schema:sibling rdf:resource="Futami_Mami"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">中学1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/10009"/>
   </rdf:Description>
 
@@ -533,6 +541,7 @@
     <imas:PopLinksAttribute xml:lang="ja">虹</imas:PopLinksAttribute>
     <schema:sibling rdf:resource="Futami_Ami"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">中学1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/10010"/>
   </rdf:Description>
 
@@ -578,6 +587,7 @@
     <imas:PopLinksAttribute xml:lang="en">ocean</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">海</imas:PopLinksAttribute>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">高校2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/10003"/>
   </rdf:Description>
 </rdf:RDF>

--- a/RDFs/765MillionStars.rdf
+++ b/RDFs/765MillionStars.rdf
@@ -498,6 +498,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">中学3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/30039"/>
   </rdf:Description>
 
@@ -540,6 +541,7 @@
     <imas:PopLinksAttribute xml:lang="en">moon</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">月</imas:PopLinksAttribute>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">中学3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/30024"/>
   </rdf:Description>
 
@@ -741,6 +743,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">中学3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/30018"/>
   </rdf:Description>
 
@@ -1382,6 +1385,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">中学3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/30023"/>
   </rdf:Description>
 

--- a/RDFs/765MillionStars.rdf
+++ b/RDFs/765MillionStars.rdf
@@ -168,6 +168,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">高校3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/30017"/>
   </rdf:Description>
 
@@ -210,6 +211,7 @@
     <imas:PopLinksAttribute xml:lang="en">star</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">星</imas:PopLinksAttribute>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">高校2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/30012"/>
   </rdf:Description>
 
@@ -248,6 +250,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">高校3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/30010"/>
   </rdf:Description>
 
@@ -376,6 +379,7 @@
     <imas:PopLinksAttribute xml:lang="en">dream</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">夢</imas:PopLinksAttribute>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">中学1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/30027"/>
   </rdf:Description>
 
@@ -414,6 +418,7 @@
     <schema:birthPlace xml:lang="ja">埼玉</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">高校1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/30026"/>
   </rdf:Description>
 
@@ -574,6 +579,7 @@
     <schema:birthPlace xml:lang="ja">茨城</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">高校2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/30016"/>
   </rdf:Description>
 
@@ -696,6 +702,7 @@
     <imas:PopLinksAttribute xml:lang="en">rainbow</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">虹</imas:PopLinksAttribute>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">小学4年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/30022"/>
   </rdf:Description>
 
@@ -1097,6 +1104,7 @@
     <imas:PopLinksAttribute xml:lang="en">rainbow</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">虹</imas:PopLinksAttribute>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">小学6年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/30003"/>
   </rdf:Description>
 
@@ -1178,6 +1186,7 @@
     <imas:PopLinksAttribute xml:lang="en">love</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">愛</imas:PopLinksAttribute>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">高校2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/30033"/>
   </rdf:Description>
 
@@ -1216,6 +1225,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">大学1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/30029"/>
   </rdf:Description>
 
@@ -1448,6 +1458,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">小学5年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/30015"/>
   </rdf:Description>
 

--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -43,6 +43,7 @@
     <imas:PopLinksAttribute xml:lang="ja">月</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="en">dream</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">夢</imas:PopLinksAttribute>
+    <imas:SchoolGrade xml:lang="ja">高校2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20084"/>
   </rdf:Description>
 
@@ -77,6 +78,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17159583"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">CB78B0</imas:Color>
     <imas:Hobby xml:lang="ja">空手</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">高校3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20112"/>
   </rdf:Description>
 
@@ -175,6 +177,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17161754"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EA495B</imas:Color>
     <imas:Hobby xml:lang="ja">新作ドーナツの試食</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">中学1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20080"/>
   </rdf:Description>
 
@@ -363,6 +366,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q901835"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">C64796</imas:Color>
     <imas:Hobby xml:lang="ja">ひなたぼっこ</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">高校2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20065"/>
   </rdf:Description>
 
@@ -397,6 +401,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q15731362"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">69B64C</imas:Color>
     <imas:Hobby xml:lang="ja">四葉のクローバー集め</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">高校2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20037"/>
   </rdf:Description>
 
@@ -431,6 +436,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q3183413"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F567C6</imas:Color>
     <imas:Hobby xml:lang="ja">家事全般</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">高校1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20016"/>
   </rdf:Description>
 
@@ -499,6 +505,7 @@
     <imas:PopLinksAttribute xml:lang="ja">花</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="en">love</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">愛</imas:PopLinksAttribute>
+    <imas:SchoolGrade xml:lang="ja">小学6年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20075"/>
   </rdf:Description>
 
@@ -590,6 +597,7 @@
     <imas:Constellation xml:lang="ja">射手座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">宮崎</schema:birthPlace>
     <imas:Hobby xml:lang="ja">魔法少女ごっこ</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">小学3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20183"/>
   </rdf:Description>
 
@@ -898,6 +906,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1107456"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">CA113A</imas:Color>
     <imas:Hobby xml:lang="ja">猫カフェ巡り</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">高校1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20147"/>
   </rdf:Description>
 
@@ -1066,6 +1075,7 @@
     <imas:PopLinksAttribute xml:lang="ja">風</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="en">flower</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">花</imas:PopLinksAttribute>
+    <imas:SchoolGrade xml:lang="ja">高校1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20064"/>
   </rdf:Description>
 
@@ -1822,6 +1832,7 @@
     <imas:PopLinksAttribute xml:lang="ja">風</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="en">flower</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">花</imas:PopLinksAttribute>
+    <imas:SchoolGrade xml:lang="ja">中学3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20167"/>
   </rdf:Description>
 
@@ -1960,6 +1971,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F2C0C1</imas:Color>
     <imas:Hobby xml:lang="ja">ミックスジュース作り</imas:Hobby>
     <imas:Hobby xml:lang="ja">スクラップブック作り</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">中学1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20039"/>
   </rdf:Description>
 
@@ -2092,6 +2104,7 @@
     <schema:birthPlace xml:lang="ja">北海道</schema:birthPlace>
     <imas:Hobby xml:lang="ja">料理</imas:Hobby>
     <imas:Hobby xml:lang="ja">睡眠</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">高校2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20090"/>
   </rdf:Description>
 
@@ -2126,6 +2139,7 @@
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Hobby xml:lang="ja">美味しいものを食べること</imas:Hobby>
     <imas:Hobby xml:lang="ja">月光浴</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">高校3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20059"/>
   </rdf:Description>
 
@@ -2198,6 +2212,7 @@
     <imas:PopLinksAttribute xml:lang="ja">空</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="en">wind</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">風</imas:PopLinksAttribute>
+    <imas:SchoolGrade xml:lang="ja">高校1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20083"/>
   </rdf:Description>
 
@@ -2417,6 +2432,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11529115"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">8D75B3</imas:Color>
     <imas:Hobby xml:lang="ja">アニメ鑑賞</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">高校2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20042"/>
   </rdf:Description>
 
@@ -2553,6 +2569,7 @@
     <imas:PopLinksAttribute xml:lang="ja">風</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="en">thunder</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">雷</imas:PopLinksAttribute>
+    <imas:SchoolGrade xml:lang="ja">高校2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20103"/>
   </rdf:Description>
 
@@ -2617,6 +2634,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q8972760"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">006AB6</imas:Color>
     <imas:Hobby xml:lang="ja">裁縫</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">小学5年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20076"/>
   </rdf:Description>
 
@@ -2787,6 +2805,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">6DBCDB</imas:Color>
     <imas:Hobby xml:lang="ja">ラクロス</imas:Hobby>
     <imas:Hobby xml:lang="ja">資格取得</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">大学2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20120"/>
   </rdf:Description>
 
@@ -2817,6 +2836,7 @@
     <imas:Constellation xml:lang="ja">射手座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">愛知</schema:birthPlace>
     <imas:Hobby xml:lang="ja">弓道</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">高校3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20158"/>
   </rdf:Description>
 
@@ -2883,6 +2903,7 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">5881C1</imas:Color>
     <imas:Hobby xml:lang="ja">読書（ミステリー）</imas:Hobby>
     <imas:Hobby xml:lang="ja">ゲーム</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">小学6年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20104"/>
   </rdf:Description>
 
@@ -2947,6 +2968,7 @@
     <imas:Constellation xml:lang="ja">蠍座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">岐阜</schema:birthPlace>
     <imas:Hobby xml:lang="ja">諜報活動</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">高校3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20175"/>
   </rdf:Description>
 
@@ -3200,6 +3222,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q44552"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">7E3188</imas:Color>
     <imas:Hobby xml:lang="ja">絵を描くこと</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">中学2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20044"/>
   </rdf:Description>
 
@@ -3294,6 +3317,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q9307208"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">38BAB8</imas:Color>
     <imas:Hobby xml:lang="ja">ネイル</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">高校1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20143"/>
   </rdf:Description>
 
@@ -3860,6 +3884,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11666486"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">0D386D</imas:Color>
     <imas:Hobby xml:lang="ja">映画鑑賞</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">高校2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20128"/>
   </rdf:Description>
 
@@ -3894,6 +3919,7 @@
     <imas:PopLinksAttribute xml:lang="ja">空</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="en">ocean</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">海</imas:PopLinksAttribute>
+    <imas:SchoolGrade xml:lang="ja">中学3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20030"/>
   </rdf:Description>
 
@@ -4066,6 +4092,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q20039931"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">45BDB4</imas:Color>
     <imas:Hobby xml:lang="ja">サッカー</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">小学6年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20180"/>
   </rdf:Description>
 
@@ -4102,6 +4129,7 @@
     <imas:Hobby xml:lang="ja">ヘアアレンジ</imas:Hobby>
     <imas:Hobby xml:lang="ja">ラジオを聴くこと</imas:Hobby>
     <imas:Hobby xml:lang="ja">漫画を描くこと</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">中学2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20121"/>
   </rdf:Description>
 
@@ -4137,6 +4165,7 @@
     <imas:Hobby xml:lang="ja">異業種交流</imas:Hobby>
     <imas:Hobby xml:lang="ja">ホットヨガ</imas:Hobby>
     <imas:Hobby xml:lang="ja">ぬか床の世話</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">高校3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20053"/>
   </rdf:Description>
 
@@ -4272,6 +4301,7 @@
     <imas:Hobby xml:lang="ja">ファッション</imas:Hobby>
     <imas:Hobby xml:lang="ja">流行りの店巡り</imas:Hobby>
     <schema:sibling rdf:resource="Hisakawa_Nagi"/>
+    <imas:SchoolGrade xml:lang="ja">中学2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20132"/>
   </rdf:Description>
 
@@ -4336,6 +4366,7 @@
     <imas:PopLinksAttribute xml:lang="ja">夢</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="en">light</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">光</imas:PopLinksAttribute>
+    <imas:SchoolGrade xml:lang="ja">高校1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20146"/>
   </rdf:Description>
 
@@ -4370,6 +4401,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q4358562"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">C5DD7F</imas:Color>
     <imas:Hobby xml:lang="ja">近所の公園をお散歩</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">高校1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20102"/>
   </rdf:Description>
 
@@ -4434,6 +4466,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q24875141"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F4D956</imas:Color>
     <imas:Hobby xml:lang="ja">料理</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">小学3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20187"/>
   </rdf:Description>
 
@@ -4626,6 +4659,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1955926"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F8C715</imas:Color>
     <imas:Hobby xml:lang="ja">おしゃべり</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">小学5年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20005"/>
   </rdf:Description>
 
@@ -4724,6 +4758,7 @@
     <imas:PopLinksAttribute xml:lang="ja">天</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="en">sky</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">空</imas:PopLinksAttribute>
+    <imas:SchoolGrade xml:lang="ja">高校3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20032"/>
   </rdf:Description>
 
@@ -5127,6 +5162,7 @@
     <!-- <imas:cv rdf:resource="http://www.wikidata.org/entity/Q0000000"/> -->
     <imas:Hobby xml:lang="ja">ダンス</imas:Hobby>
     <imas:Hobby xml:lang="ja">パパとデート</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">小学6年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20154"/>
   </rdf:Description>
 
@@ -5232,6 +5268,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q18048266"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EAE28D</imas:Color>
     <imas:Hobby xml:lang="ja">ガーデニング</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">大学1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20003"/>
   </rdf:Description>
 
@@ -5365,6 +5402,7 @@
     <imas:PopLinksAttribute xml:lang="en">rainbow</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">虹</imas:PopLinksAttribute>
     <schema:sibling rdf:resource="Jougasaki_Rika"/>
+    <imas:SchoolGrade xml:lang="ja">高校3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20086"/>
   </rdf:Description>
 
@@ -5404,6 +5442,7 @@
     <imas:PopLinksAttribute xml:lang="en">fire</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">炎</imas:PopLinksAttribute>
     <schema:sibling rdf:resource="Jougasaki_Mika"/>
+    <imas:SchoolGrade xml:lang="ja">中学1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20087"/>
   </rdf:Description>
 
@@ -5540,6 +5579,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1046994"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E9425C</imas:Color>
     <imas:Hobby xml:lang="ja">ケーキ作り</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">大学1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20110"/>
   </rdf:Description>
 
@@ -5665,6 +5705,7 @@
     <imas:PopLinksAttribute xml:lang="ja">炎</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="en">thunder</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">雷</imas:PopLinksAttribute>
+    <imas:SchoolGrade xml:lang="ja">高校3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20164"/>
   </rdf:Description>
 
@@ -5699,6 +5740,7 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11369771"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F7DE8C</imas:Color>
     <imas:Hobby xml:lang="ja">着ぐるみ集め</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">小学3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20020"/>
   </rdf:Description>
 
@@ -5767,6 +5809,7 @@
     <imas:Constellation xml:lang="ja">蟹座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">山口</schema:birthPlace>
     <imas:Hobby xml:lang="ja">ウインドサーフィン</imas:Hobby>
+    <imas:SchoolGrade xml:lang="ja">短大1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20091"/>
   </rdf:Description>
 
@@ -6065,6 +6108,7 @@
     <imas:PopLinksAttribute xml:lang="ja">星</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="en">dream</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">夢</imas:PopLinksAttribute>
+    <imas:SchoolGrade xml:lang="ja">中学3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20107"/>
   </rdf:Description>
 
@@ -6302,6 +6346,7 @@
     <imas:Hobby xml:lang="ja">ポエム</imas:Hobby>
     <imas:Hobby xml:lang="ja">読書（新書）</imas:Hobby>
     <schema:sibling rdf:resource="Hisakawa_Hayate"/>
+    <imas:SchoolGrade xml:lang="ja">中学2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20131"/>
   </rdf:Description>
 

--- a/RDFs/SideM.rdf
+++ b/RDFs/SideM.rdf
@@ -744,6 +744,7 @@
     <imas:Brand xml:lang="en">SideM</imas:Brand>
     <schema:memberOf rdf:resource="315Production"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">高校2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/40005"/>
   </rdf:Description>
 
@@ -778,6 +779,7 @@
     <imas:Brand xml:lang="en">SideM</imas:Brand>
     <schema:memberOf rdf:resource="315Production"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">高校2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/40040"/>
   </rdf:Description>
 
@@ -813,6 +815,7 @@
     <imas:Brand xml:lang="en">SideM</imas:Brand>
     <schema:memberOf rdf:resource="315Production"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">高校2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/40025"/>
   </rdf:Description>
 
@@ -847,6 +850,7 @@
     <imas:Brand xml:lang="en">SideM</imas:Brand>
     <schema:memberOf rdf:resource="315Production"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">高校2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/40045"/>
   </rdf:Description>
 
@@ -886,6 +890,7 @@
     <imas:PopLinksAttribute xml:lang="en">thunder</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">雷</imas:PopLinksAttribute>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">高校1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/40010"/>
   </rdf:Description>
 

--- a/RDFs/SideM.rdf
+++ b/RDFs/SideM.rdf
@@ -929,6 +929,7 @@
     <imas:PopLinksAttribute xml:lang="en">wind</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">風</imas:PopLinksAttribute>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">高校1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/40003"/>
   </rdf:Description>
 
@@ -969,6 +970,7 @@
     <imas:PopLinksAttribute xml:lang="en">snow</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">雪</imas:PopLinksAttribute>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">高校1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/40023"/>
   </rdf:Description>
 
@@ -1181,6 +1183,7 @@
     <imas:PopLinksAttribute xml:lang="en">rainbow</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">虹</imas:PopLinksAttribute>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">小学6年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/40013"/>
   </rdf:Description>
 
@@ -1219,6 +1222,7 @@
     <imas:PopLinksAttribute xml:lang="en">moon</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">月</imas:PopLinksAttribute>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:SchoolGrade xml:lang="ja">小学5年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/40031"/>
   </rdf:Description>
 


### PR DESCRIPTION
ref. #119

デレマスアイドルの学年追記
ソースは下記2つ
https://seesaawiki.jp/imascg/d/%A5%A2%A5%A4%A5%C9%A5%EB%C7%AF%CE%F0%C1%E1%B8%AB%C9%BD#footer-footnote38
https://dic.nicovideo.jp/a/%E3%82%A2%E3%82%A4%E3%83%89%E3%83%AB%E3%83%9E%E3%82%B9%E3%82%BF%E3%83%BC%E3%82%B7%E3%83%B3%E3%83%87%E3%83%AC%E3%83%A9%E3%82%AC%E3%83%BC%E3%83%AB%E3%82%BA%3A%E5%AD%A6%E5%B9%B4%E8%A1%A8

sideMの学年追記
ソース：https://w.atwiki.jp/aniwotawiki/pages/38819.html

765ASの学年表記追記
ソース：https://ja.wikipedia.org/wiki/THE_IDOLM@STER%E3%81%AE%E7%99%BB%E5%A0%B4%E4%BA%BA%E7%89%A9#765%E3%82%A2%E3%82%A4%E3%83%89%E3%83%AB%E5%9F%BA%E6%9C%AC%E3%83%87%E3%83%BC%E3%82%BF%E4%B8%80%E8%A6%A7

ミリマスアイドルの学年追記
ソース：https://greemas.doorblog.jp/archives/53151476.html

いずれも、ソースのサイトで明らかに学年が分かるもののみを追加