### PR TITLE
ポプマス追加実装アイドルの属性データ追加 2021/7 実装分2

### DIFF
--- a/RDFs/283.rdf
+++ b/RDFs/283.rdf
@@ -207,6 +207,10 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Brand xml:lang="en">ShinyColors</imas:Brand>
     <schema:memberOf rdf:resource="283Production"/>
+    <imas:PopLinksAttribute xml:lang="en">rainbow</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">虹</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">darkness</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">闇</imas:PopLinksAttribute>
     <schema:description xml:lang="ja">自由奔放で掴みどころのないサブカル系眼鏡女子。美人でノリもよく、初対面の人に対しても気後れせずに話しができる。大学1年生。</schema:description>
     <imas:SchoolGrade xml:lang="ja">大学1年生</imas:SchoolGrade>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>

--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -1643,6 +1643,10 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q6127820"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E64A79</imas:Color>
     <imas:Hobby xml:lang="ja">ウサミン星との交信</imas:Hobby>
+    <imas:PopLinksAttribute xml:lang="en">moon</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">月</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">star</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">星</imas:PopLinksAttribute>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20010"/>
   </rdf:Description>
 

--- a/RDFs/SideM.rdf
+++ b/RDFs/SideM.rdf
@@ -415,6 +415,10 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Brand xml:lang="en">SideM</imas:Brand>
     <schema:memberOf rdf:resource="315Production"/>
+    <imas:PopLinksAttribute xml:lang="en">flower</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">花</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">dream</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">夢</imas:PopLinksAttribute>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/40046"/>
   </rdf:Description>


### PR DESCRIPTION
ref. #439
既にポプマス属性が登録されているアイドルと同様に、
ポプマス追加実装アイドルにもポプマス属性データを入れました。

対象：「安部 菜々」「渡辺 みのり」「三峰 結華」
https://twitter.com/imas_poplinks/status/1414185198455902208