### PR TITLE
ポプマス衣装を追加(一部説明文章未記載有)

### DIFF
--- a/RDFs/Clothes/PopLinks.rdf
+++ b/RDFs/Clothes/PopLinks.rdf
@@ -172,7 +172,7 @@
     <imas:Whose rdf:resource="Kikuchi_Makoto"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Charming_Checked">
+  <rdf:Description rdf:about="Charming_Check">
     <schema:name xml:lang="ja">チャーミング・チェック</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">チャーミング・チェック</rdfs:label>
     <schema:description xml:lang="ja">大胆なチェックが特徴的な、着る人の内面の魅力まで引き出すチャーミングな衣装です。可愛いだけじゃないんだから♪</schema:description>
@@ -883,7 +883,7 @@
     <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Hokago_Checked">
+  <rdf:Description rdf:about="Hokago_Check">
     <schema:name xml:lang="ja">ホーカゴチェック!</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ホーカゴチェック!</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>

--- a/RDFs/Clothes/PopLinks.rdf
+++ b/RDFs/Clothes/PopLinks.rdf
@@ -118,648 +118,756 @@
     <imas:Whose rdf:resource="Serizawa_Asahi"/>
     <imas:Whose rdf:resource="Yukoku_Kiriko"/>
     <imas:Whose rdf:resource="Morino_Rinze"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Purely_pop">
     <schema:name xml:lang="ja">ピュアリーポップ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピュアリーポップ</rdfs:label>
     <schema:description xml:lang="ja">ポップでカジュアルな見た目に、ひらひら揺れるリボンが特徴的。頭のコサージュのように、ステージで可愛く花開きます。</schema:description>
     <imas:Whose rdf:resource="Amami_Haruka"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Cynthia_Mart">
     <schema:name xml:lang="ja">シンシアリアニマート</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シンシアリアニマート</rdfs:label>
     <schema:description xml:lang="ja">夢見た場所へ、仲間と共に。新たな可能性を引き出す装い。昂ぶる想いを旋律にのせ、あなたに届くよう歌い上げます。</schema:description>
     <imas:Whose rdf:resource="Kisaragi_Chihaya"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Sparkle_butterfly">
     <schema:name xml:lang="ja">スパークルバタフライ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スパークルバタフライ</rdfs:label>
     <schema:description xml:lang="ja">優雅さと活発さをあわせ持つアトラクティブなドレス。これさえ着れば、みんなの視線はぜ～んぶキミのモノ！</schema:description>
     <imas:Whose rdf:resource="Hoshii_Miki"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Suite_chiffon">
     <schema:name xml:lang="ja">スイートシフォン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スイートシフォン</rdfs:label>
     <schema:description xml:lang="ja">内気な心を柔らかく包み込み、一歩を踏み出す勇気をくれる、優しい素材の衣装。甘い気持ち、あなたにも届くかな？</schema:description>
     <imas:Whose rdf:resource="Hagiwara_Yukiho"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Poppin_casual">
     <schema:name xml:lang="ja">ポッピンカジュアル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ポッピンカジュアル</rdfs:label>
     <schema:description xml:lang="ja">明るくて元気いっぱいな子にぴったりの、爽やかな衣装。特売のお野菜を見つけた時のように、心がぴょんとはずみます。</schema:description>
     <imas:Whose rdf:resource="Takatsuki_Yayoi"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Brilliant_Bloom">
     <schema:name xml:lang="ja">ブリリアントブルーム</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブリリアントブルーム</rdfs:label>
     <schema:description xml:lang="ja">シャープなフォルムに、キュートなフリフリのクロス。カッコよくも、カワイくもなれる魅力的な衣装です。</schema:description>
     <imas:Whose rdf:resource="Kikuchi_Makoto"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Charming_checked">
     <schema:name xml:lang="ja">チャーミング・チェック</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">チャーミング・チェック</rdfs:label>
     <schema:description xml:lang="ja">大胆なチェックが特徴的な、着る人の内面の魅力まで引き出すチャーミングな衣装です。可愛いだけじゃないんだから♪</schema:description>
     <imas:Whose rdf:resource="Minase_Iori"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Noble_Moonlight">
     <schema:name xml:lang="ja">ノーブルムーンライト</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ノーブルムーンライト</rdfs:label>
     <schema:description xml:lang="ja">髪の揺れる音さえ聞こえそうな夜の帳。その雲間から射す、ただ一筋の月光のように幻想的で孤高の気高さを持つドレスです。</schema:description>
     <imas:Whose rdf:resource="Shijou_Takane"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Wisley_Wind">
     <schema:name xml:lang="ja">ワイズリー・ウィンド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ワイズリー・ウィンド</rdfs:label>
     <schema:description xml:lang="ja">知的なイメージの中に、可愛らしさを漂わせる衣装です。風にはためく大きなスカートが人々の心を沸き立たせます。</schema:description>
     <imas:Whose rdf:resource="Akizuki_Ritsuko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Wonder_Venus">
     <schema:name xml:lang="ja">ワンダー・ヴィーナス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ワンダー・ヴィーナス</rdfs:label>
     <schema:description xml:lang="ja">繊細かつ大胆なシルエットはまるで、うつし世に迷い降りた女神のよう。あなたの目に留まるのは、運命だったのかも……。</schema:description>
     <imas:Whose rdf:resource="Miura_Azusa"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Ukiuki_Passion">
     <schema:name xml:lang="ja">ウキウキ☆パッション</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ウキウキ☆パッション</rdfs:label>
     <schema:description xml:lang="ja">サンサンと輝く太陽の下、元気ハツラツなステージをイメージして作られた衣装。ジョーネツ的に踊っちゃえ！</schema:description>
     <imas:Whose rdf:resource="Futami_Ami"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Dokidoki_fine">
     <schema:name xml:lang="ja">ドキドキ☆ファイン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ドキドキ☆ファイン</rdfs:label>
     <schema:description xml:lang="ja">心も身体も楽しくなっちゃう、メチャメチャキュートな衣装。これを着てステージに立てば、タイクツな日常にさようなら！</schema:description>
     <imas:Whose rdf:resource="Futami_Mami"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="High_tide_sunrise">
     <schema:name xml:lang="ja">ハイタイドサンライズ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ハイタイドサンライズ</rdfs:label>
     <schema:description xml:lang="ja">おてんばな人魚をイメージしたトロピカルな衣装です。溢れ出る情熱で、見る人の心は満ち潮のように大フィーバー！</schema:description>
     <imas:Whose rdf:resource="Ganaha_Hibiki"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Twinkle_smile">
     <schema:name xml:lang="ja">トゥインクルスマイル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">トゥインクルスマイル</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Shimamura_Uzuki"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Sing_to_Zenith">
     <schema:name xml:lang="ja">シング・トゥ・ゼニス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シング・トゥ・ゼニス</rdfs:label>
     <schema:description xml:lang="ja">今よりもずっと、高い場所へ。妥協点なんてどこにもない。終わりの見えないこの道の上で、歌い続ける彼女のために。</schema:description>
     <imas:Whose rdf:resource="Shibuya_Rin"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Illuminas_Active">
     <schema:name xml:lang="ja">イルミナスアクティブ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">イルミナスアクティブ</rdfs:label>
     <schema:description xml:lang="ja">首元に巻いた動きのあるリボンとタイトなパンツが躍動的な元気いっぱいの衣装。動きの激しいダンスで、より輝きます。</schema:description>
     <imas:Whose rdf:resource="Honda_Mio"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Tear_drop">
     <schema:name xml:lang="ja">ティアードロップ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ティアードロップ</rdfs:label>
     <schema:description xml:lang="ja">感動で流れ落ちた一粒の涙のように、キラリと輝く衣装。涙の後には、満面の笑みが咲き誇ります。</schema:description>
     <imas:Whose rdf:resource="Ohnuma_Kurumi"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Chemical_perfume">
     <schema:name xml:lang="ja">ケミカルパフューム</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ケミカルパフューム</rdfs:label>
     <schema:description xml:lang="ja">視覚も嗅覚も……五感すべてを支配し妄想心を呼び覚ます。気分はまるでトリッパー。踊ればたちまちケミカルな香りが漂う。</schema:description>
     <imas:Whose rdf:resource="Ichinose_Shiki"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Kimagure_Tutu">
     <schema:name xml:lang="ja">きまぐれチュチュ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">きまぐれチュチュ</rdfs:label>
     <schema:description xml:lang="ja">辛めのライダースに甘めのスカートを組み合わせた気まぐれコーデが魅惑的。本当のアタシは、どっち？</schema:description>
     <imas:Whose rdf:resource="Miyamoto_Frederica"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Idling_idol">
     <schema:name xml:lang="ja">アイドリングアイドル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アイドリングアイドル</rdfs:label>
     <schema:description xml:lang="ja">働くアイドルにオススメ。いっときの夢と希望を全世界の疲れた人たちへと。小柄な女の子にも重たくない、動きやすい衣装です。</schema:description>
     <imas:Whose rdf:resource="Futaba_Anzu"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Smiley_Wave">
     <schema:name xml:lang="ja">スマイリーウェーブ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スマイリーウェーブ</rdfs:label>
     <schema:description xml:lang="ja">みんなに元気とニコニコ笑顔を届ける、王道なアイドル衣装。大きく咲いたいくつものリボンがとってもかわいいでぇす♪</schema:description>
     <imas:Whose rdf:resource="Muramatsu_Sakura"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Scratch_Devil">
     <schema:name xml:lang="ja">スクラッチデビル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スクラッチデビル</rdfs:label>
     <schema:description xml:lang="ja">他人かどうか関係ない。自分が本当に好きなものを着たときにだけ、世界に爪痕を残すことができるのだから。</schema:description>
     <imas:Whose rdf:resource="Hayasaka_Mirei"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Genius_Court_No2">
     <schema:name xml:lang="ja">ジーニアスコート2号</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ジーニアスコート2号</rdfs:label>
     <schema:description xml:lang="ja">日の目を見るまで、倉庫の奥深く厳重に保管されていた秘密兵器。改造は施されているのか、1号はどうなったのか、謎が尽きない。</schema:description>
     <imas:Whose rdf:resource="Ikebukuro_Akiha"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Mellow_Adagio">
     <schema:name xml:lang="ja">メロウ・アダージオ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">メロウ・アダージオ</rdfs:label>
     <schema:description xml:lang="ja">見る人全てを惹き付ける、艶やかなシルエットのドレス。高鳴る鼓動の中で、私との時間をただゆっくりと楽しんで。</schema:description>
     <imas:Whose rdf:resource="Mifune_Miyu"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Coral_splash">
     <schema:name xml:lang="ja">コーラルスプラッシュ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">コーラルスプラッシュ</rdfs:label>
     <schema:description xml:lang="ja">サンゴ礁を優雅に泳ぐ熱帯魚のように、ひらひら揺らぐリボンが見る人の心を絡め取ります。お魚みたいに舞うのれす～。</schema:description>
     <imas:Whose rdf:resource="Asari_Nanami"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Grand_Super_Nova">
     <schema:name xml:lang="ja">グランスーパーノヴァ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">グランスーパーノヴァ</rdfs:label>
     <schema:description xml:lang="ja">満天の片隅で輝く一つの光を、永遠の閃光へと昇華させるサイバーな衣装。一目見れば、瞼の裏に焼き付いて離れない。</schema:description>
     <imas:Whose rdf:resource="Takamine_Noa"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Inspire_Wave">
     <schema:name xml:lang="ja">インスパイアウェーブ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">インスパイアウェーブ</rdfs:label>
     <schema:description xml:lang="ja">バンダナリボンが大胆なドレス。アイドル×ロジック＝無限大。計算以上の反応が、少女を可愛くアップデートするでしょう。</schema:description>
     <imas:Whose rdf:resource="Ohishi_Izumi"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="No_no_negative">
     <schema:name xml:lang="ja">ノーノー・ネガティブ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ノーノー・ネガティブ</rdfs:label>
     <schema:description xml:lang="ja">クラシカルなチェックがキュートでファンシーな衣装。ちょっぴりいじらしい少女の、変わりたい気持ちを応援します。</schema:description>
     <imas:Whose rdf:resource="Morikubo_Nono"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Pure_snake">
     <schema:name xml:lang="ja">ピュア・スニェーク</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピュア・スニェーク</rdfs:label>
     <schema:description xml:lang="ja">冬の夜。澄み切った空気。星の灯りに照らされ、ふわりと舞い降りた雪の結晶。純粋で、神秘的な衣装です。</schema:description>
     <imas:Whose rdf:resource="Anastasia"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Dicotomy_Grown">
     <schema:name xml:lang="ja">ディコトミーグロウン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディコトミーグロウン</rdfs:label>
     <schema:description xml:lang="ja">可愛さもカッコよさも引き立てる一着です。見た人の心は雷に打たれたキノコのように立ち上がること間違いなし！</schema:description>
     <imas:Whose rdf:resource="Hoshi_Syoko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Gloria_Squeen">
     <schema:name xml:lang="ja">グロリアスクイーン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">グロリアスクイーン</rdfs:label>
     <schema:description xml:lang="ja">愚図な豚に言葉など不要。エックセレントな佇まいに無駄口をつぐみ、いやしく見惚れることこそが務めなのです。</schema:description>
     <imas:Whose rdf:resource="Zaizen_Tokiko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Cheerful_marching">
     <schema:name xml:lang="ja">チアフルマーチング</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">チアフルマーチング</rdfs:label>
     <schema:description xml:lang="ja">頑張る全ての人へ、エールを！そんな気持ちがたっぷり詰まったマーチング風の衣装です。キープオンスマイル！</schema:description>
     <imas:Whose rdf:resource="Wakabayashi_Tomoka"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Frontier_Mode">
     <schema:name xml:lang="ja">フロンティア★モード</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フロンティア★モード</rdfs:label>
     <schema:description xml:lang="ja">歩き出したからには、一歩だって立ち止まれない。誰もが想像したことのない最先端を歩き続ける。妥協のない彼女のための一着</schema:description>
     <imas:Whose rdf:resource="Jougasaki_Mika"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Poppin_Decorate">
     <schema:name xml:lang="ja">ポッピン☆デコレート</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ポッピン☆デコレート</rdfs:label>
     <schema:description xml:lang="ja">元気と好奇心が弾け出しそうな、セクシーでポップな衣装。みんなと一緒に楽しくなれるエネルギッシュなライブに最適！</schema:description>
     <imas:Whose rdf:resource="Jougasaki_Rika"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Hapy_Plincesse">
     <schema:name xml:lang="ja">ハピハピプリンセス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ハピハピプリンセス</rdfs:label>
     <schema:description xml:lang="ja">大胆にデコレーションされた、元気いっぱいなハピハピドレス。きゃわいく散りばめられたアクセは自前で用意したらしい。</schema:description>
     <imas:Whose rdf:resource="Moroboshi_Kirari"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Shining_wave">
     <schema:name xml:lang="ja">シャイニングウェーブ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シャイニングウェーブ</rdfs:label>
     <schema:description xml:lang="ja">着た人と見た人にご利益があるという噂が、まことしやかに流れるエンターテイナーなドレス。儲かりまっか～！</schema:description>
     <imas:Whose rdf:resource="Tsuchiya_Ako"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Angelic_Cute">
     <schema:name xml:lang="ja">エンジェリックキュート</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エンジェリックキュート</rdfs:label>
     <schema:description xml:lang="ja">カワイイリボン、カワイイ靴、カワイイフリルにネックレス。カワイイをありったけ詰め込んだカワイイ彼女のための一着。</schema:description>
     <imas:Whose rdf:resource="Koshimizu_Sachiko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Lollipop_Soleil">
     <schema:name xml:lang="ja">ロリポップソレイユ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ロリポップソレイユ</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Ohtsuki_Yui"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Heroes_Hope">
     <schema:name xml:lang="ja">ヒーローズホープ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ヒーローズホープ</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Nanjo_Hikaru"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Rocking_heartbeat">
     <schema:name xml:lang="ja">ロッキングハートビート</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ロッキングハートビート</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Kimura_Natsuki"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Natural_rocker">
     <schema:name xml:lang="ja">ナチュラルロッカー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ナチュラルロッカー</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Tada_Riina"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Fairytale_Dreamer">
     <schema:name xml:lang="ja">メルヒェンドリーマー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">メルヒェンドリーマー</rdfs:label>
     <schema:description xml:lang="ja">無限大の妄想を形にした、キュートなプリンセス風ドレス。夢見る乙女は止まらない。待っててね、運命の王子様♪</schema:description>
     <imas:Whose rdf:resource="Kita_Hinako"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Eternal_Feather">
     <schema:name xml:lang="ja">エターナル・フェザー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エターナル・フェザー</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Takagaki_Kaede"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Smash_sparkle">
     <schema:name xml:lang="ja">スマッシュスパークル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スマッシュスパークル</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Mukai_Takumi"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Innocent_rose">
     <schema:name xml:lang="ja">イノセントローズ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">イノセントローズ</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Sakurai_Momoka"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Sweet_destiny">
     <schema:name xml:lang="ja">スイートデスティニー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スイートデスティニー</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Sakuma_Mayu"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Panic_Nightmare">
     <schema:name xml:lang="ja">パニックナイトメア</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">パニックナイトメア</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Shirasaka_Koume"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Maboroba_no_utahime">
     <schema:name xml:lang="ja">まぼろばの舞姫</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">まぼろばの舞姫</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Kobayakawa_Sae"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Step_future">
     <schema:name xml:lang="ja">ステップフューチャー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ステップフューチャー</rdfs:label>
     <schema:description xml:lang="ja">チューブトップのスパンコールが笑顔と一緒に輝くコーデ。いつも未来を夢見る少女は新たな夢意を抱いて前進！</schema:description>
     <imas:Whose rdf:resource="Kasuga_Mirai"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Ambitious_Tender">
     <schema:name xml:lang="ja">アンビシャステンダー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アンビシャステンダー</rdfs:label>
     <schema:description xml:lang="ja">大きなリボンとファースカートで可愛くも優雅に仕立てた衣装。これからも仲間と手を取り合って優しい歌声を響かせます。</schema:description>
     <imas:Whose rdf:resource="Mogami_Shizuka"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Charming_flap">
     <schema:name xml:lang="ja">チャーミングフラップ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">チャーミングフラップ</rdfs:label>
     <schema:description xml:lang="ja">持ち前の元気な明るさと、ちょっぴり小悪魔なセクシーさを引き出す衣装。イタズラな笑顔が見た人の心をくすぐります。</schema:description>
     <imas:Whose rdf:resource="Ibuki_Tsubasa"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Sunlight_Moment">
     <schema:name xml:lang="ja">サンライトモーメント</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">サンライトモーメント</rdfs:label>
     <schema:description xml:lang="ja">頭のひまわりがワンポイントの爽やかな衣装。輝く太陽のような笑顔で、みんな心はカーニバル！ワタシと一緒に踊ろうヨ♪</schema:description>
     <imas:Whose rdf:resource="Shimabara_Elena"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Parfe_Princess">
     <schema:name xml:lang="ja">パルフェ・プリンセス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">パルフェ・プリンセス</rdfs:label>
     <schema:description xml:lang="ja">スイーツのように、甘く可愛くキラキラに飾り付けたお姫様のための衣装。ポイントはスカートに散りばめた、好物のマカロン。</schema:description>
     <imas:Whose rdf:resource="Tokugawa_Matsuri"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Romance_dreamer">
     <schema:name xml:lang="ja">ロマンスドリーマー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ロマンスドリーマー</rdfs:label>
     <schema:description xml:lang="ja">フリルをふんだんにあしらい上品で可憐に仕立てたドレス。舞台の上で踊る姿は、物語のヒロインのよう。</schema:description>
     <imas:Whose rdf:resource="Nanao_Yuriko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Star_spirit">
     <schema:name xml:lang="ja">スター・スピリット</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スター・スピリット</rdfs:label>
     <schema:description xml:lang="ja">アイドル研究の専門家も大満足の正統派アイドル衣装。この衣装をまとって輝く姿は誰よりもアイドル。</schema:description>
     <imas:Whose rdf:resource="Matsuda_Arisa"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Pretty_essence">
     <schema:name xml:lang="ja">プリティエッセンス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プリティエッセンス</rdfs:label>
     <schema:description xml:lang="ja">真っ直ぐで純真で、大人になりたいと背伸びする少女。その姿を、フリルとレースでキュートに包み込んだ一着。</schema:description>
     <imas:Whose rdf:resource="Nakatani_Iku"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Irodori_komachi">
     <schema:name xml:lang="ja">彩り小町</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">彩り小町</rdfs:label>
     <schema:description xml:lang="ja">奥ゆかしい大和撫子のために仕立て上げた彩り豊かな衣装。憧れへと歩き続ける少女の姿は、きっと誰かの憧れに。</schema:description>
     <imas:Whose rdf:resource="Emily_Stewart"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Secret_pride">
     <schema:name xml:lang="ja">シークレットプライド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シークレットプライド</rdfs:label>
     <schema:description xml:lang="ja">静かに輝く月をデザインに加えた気品を感じる一着。夢に向かって弛まぬ努力を続ける誇り高い少女にぴったり。</schema:description>
     <imas:Whose rdf:resource="Kitazawa_Shiho"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Fluffy_Happiness">
     <schema:name xml:lang="ja">ふわもこハピネス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ふわもこハピネス</rdfs:label>
     <schema:description xml:lang="ja">散りばめられた星がキラキラと瞬き、牧歌的で幻想的な空間を演出。幸せに満ちた笑顔が仲間もファンも癒します。</schema:description>
     <imas:Whose rdf:resource="Miyao_Miya"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Mystery_joker">
     <schema:name xml:lang="ja">ミステリージョーカー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ミステリージョーカー</rdfs:label>
     <schema:description xml:lang="ja">見た目はミステリアス。でも、心の中はいつだって色彩豊か。秘められたその色が見えたとき、あなたの心は彼女の手中に……。</schema:description>
     <imas:Whose rdf:resource="Makabe_Mizuki"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Platonic_Iris">
     <schema:name xml:lang="ja">プラトニックアイリス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プラトニックアイリス</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Shiraishi_Tsumugi"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Advanced_Garley">
     <schema:name xml:lang="ja">アドバンスドガーリー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アドバンスドガーリー</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Tokoro_Megumi"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Exciting_Explorer">
     <schema:name xml:lang="ja">わくわくエクスプローラ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">わくわくエクスプローラ</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Ogami_Tamaki"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Starlight_tune">
     <schema:name xml:lang="ja">スターライトチューン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スターライトチューン</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Julia"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Elegant_Fleur">
     <schema:name xml:lang="ja">エレガントフルール</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エレガントフルール</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Baba_Konomi"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Tokimeki_Flowers">
     <schema:name xml:lang="ja">トキメキフラワーズ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">トキメキフラワーズ</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Hakozaki_Serika"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Happy_surprise">
     <schema:name xml:lang="ja">ハッピーサプライズ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ハッピーサプライズ</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Maihama_Ayumu"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Majesty_Anima">
     <schema:name xml:lang="ja">マジェスティアニマ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">マジェスティアニマ</rdfs:label>
     <schema:description xml:lang="ja">彩られたナポレオンジャケットが甘さと堅さを感じさせる正統派アイドル衣装。積み重ねた経験を糧にして、トップを目指す！</schema:description>
     <imas:Whose rdf:resource="Amagase_Toma"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Dolce_Amore">
     <schema:name xml:lang="ja">ドルチェ・アモーレ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ドルチェ・アモーレ</rdfs:label>
     <schema:description xml:lang="ja">落ち着いたジャケットに合わせた遊び心のあるスカーフが、大人の余裕を感じさせます。甘い囁きを、天使の君に。</schema:description>
     <imas:Whose rdf:resource="Ijuin_Hokuto"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Shakit_off">
     <schema:name xml:lang="ja">シェイキットオフ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シェイキットオフ</rdfs:label>
     <schema:description xml:lang="ja">素肌が眩しいノースリーブが、軽快で大胆なダンスを魅せる。つまんないことは忘れちゃって、みんなで楽しく踊ろうよ！</schema:description>
     <imas:Whose rdf:resource="Mitarai_Shota"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Playful_shine">
     <schema:name xml:lang="ja">プレイフルシャイン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プレイフルシャイン</rdfs:label>
     <schema:description xml:lang="ja">場所は変われど見上げたお天道様は変わらない。ステージ上で輝く笑顔が心を明るく照らします。この衣装、一生大事にするぜ！</schema:description>
     <imas:Whose rdf:resource="Tendo_Teru"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Lancet_flash">
     <schema:name xml:lang="ja">ランセットフラッシュ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ランセットフラッシュ</rdfs:label>
     <schema:description xml:lang="ja">品格と矜持を感じさせる絢爛な一着。鋭い輝きを放つその姿は心の壁をも切り拓き、見るもの全ての記憶に残る。</schema:description>
     <imas:Whose rdf:resource="Sakuraba_Kaoru"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Eye_tail_wing">
     <schema:name xml:lang="ja">アイテールウイング</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アイテールウイング</rdfs:label>
     <schema:description xml:lang="ja">風を背に受けステージへ！ジャケットをはためかせ舞台を走る姿、空を舞う鳥のよう。雲の上に、テイクオフ！</schema:description>
     <imas:Whose rdf:resource="Kashiwagi_Tsubasa"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Seele_Spielen">
     <schema:name xml:lang="ja">ゼーレ・シュピーレン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ゼーレ・シュピーレン</rdfs:label>
     <schema:description xml:lang="ja">クレッシェンド、君を想って奏でよう。ディミヌエンド、僕の想いを奏でよう。全てを込めた音を、君に。</schema:description>
     <imas:Whose rdf:resource="Tsuzuki_Kei"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Noble_Concerto">
     <schema:name xml:lang="ja">ノーブルコンチェルト</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ノーブルコンチェルト</rdfs:label>
     <schema:description xml:lang="ja">ゆったりしたジャケットコートを羽織り、奏でる曲に合わせて、ふわりと袖を揺らす。音に揺れるは布か、心か。</schema:description>
     <imas:Whose rdf:resource="Kagura_Rei"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Brazing_hero">
     <schema:name xml:lang="ja">ブレイジングヒーロー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブレイジングヒーロー</rdfs:label>
     <schema:description xml:lang="ja">いつもの鋭い眼光も、爽やかな着こなしで優しく見えるかも？みんなの笑顔を守るため、次のステージへ今日も出動！</schema:description>
     <imas:Whose rdf:resource="Akuno_Hideo"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Peaceful_rack">
     <schema:name xml:lang="ja">ピースフルラック</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピースフルラック</rdfs:label>
     <schema:description xml:lang="ja">何があっても前へ進む、不撓不屈の精神がモチーフ。夢へ向かって燃え上がれ！※火の取り扱いにはご用心。</schema:description>
     <imas:Whose rdf:resource="Kimura_Ryu"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Smile_Commander">
     <schema:name xml:lang="ja">スマイル・コマンダー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スマイル・コマンダー</rdfs:label>
     <schema:description xml:lang="ja">ノースリーブのトップスがワイルドさを感じさせる一着。鍛えた肉体を存分に活かしてあなたの笑顔を守ります。</schema:description>
     <imas:Whose rdf:resource="Shingen_Seiji"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Pure_flavor">
     <schema:name xml:lang="ja">ピュアフレーバー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピュアフレーバー</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Okamura_Nao"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Minimom_Bigster">
     <schema:name xml:lang="ja">ミニマムビッグスター</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ミニマムビッグスター</rdfs:label>
     <schema:description xml:lang="ja">小さな体につまった、だれにも負けないビッグな目標。最強にカッコいいアイドルを目指す姿が光ります。</schema:description>
     <imas:Whose rdf:resource="Tachibana_Shiro"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Yumekawa_Angel">
     <schema:name xml:lang="ja">ゆめかわエンジェル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ゆめかわエンジェル</rdfs:label>
     <schema:description xml:lang="ja">「だーいすき」なかわいいが詰め込まれた一着。甘くてやわらかい衣装をまとう天使の笑顔に、みんなの心も夢の中。</schema:description>
     <imas:Whose rdf:resource="Himeno_Kanon"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Wave_the_flag">
     <schema:name xml:lang="ja">ウェイブザフラッグ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ウェイブザフラッグ</rdfs:label>
     <schema:description xml:lang="ja">大きなシルエットを背負うのはこれまで仲間たちと紡いできたたくさんの物語があるから。夢に向かって、これからも。</schema:description>
     <imas:Whose rdf:resource="Akizuki_Ryo_315"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Blooming_smile">
     <schema:name xml:lang="ja">ブルーミングスマイル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブルーミングスマイル</rdfs:label>
     <schema:description xml:lang="ja">足回りを警戒にまとめたコーデ。躍動感にあふれるパフォーマンスで、みんなの顔をはなまる笑顔にしてみせるけぇのぉ！</schema:description>
     <imas:Whose rdf:resource="Kabuto_Daigo"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Primal_sail">
     <schema:name xml:lang="ja">プライマルセイル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プライマルセイル</rdfs:label>
     <schema:description xml:lang="ja">色鮮やかなロングストールが、動きに大胆な印象をプラス。新たな舞台で紡がれる物語を、どうぞご期待ください。</schema:description>
     <imas:Whose rdf:resource="Tsukumo_Kazuki"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Stoic_sweeper">
     <schema:name xml:lang="ja">ストイックスイーパー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ストイックスイーパー</rdfs:label>
     <schema:description xml:lang="ja">飄々とした態度の裏にある、他人を想う優しさを織り込んだ一着。磨き上げた歌と踊りで、見るものの心を浄化します。</schema:description>
     <imas:Whose rdf:resource="Kuzunoha_Amehiko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Swinging_Bird">
     <schema:name xml:lang="ja">スインギング・バード</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スインギング・バード</rdfs:label>
     <schema:description xml:lang="ja">自然体な立ち居振る舞いの中にキラリと光る魅力を際立たせる遊び心のある衣装。ありのまま夢の舞台にいざ立たん。</schema:description>
     <imas:Whose rdf:resource="Kitamura_Sora"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Wonderful_Marine">
     <schema:name xml:lang="ja">ワンダフルマリン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ワンダフルマリン</rdfs:label>
     <schema:description xml:lang="ja">未知なるフロンティアを求める探検家をイメージした一着。新たなステージと言う名の大海原へ、いざ漕ぎ出そう！</schema:description>
     <imas:Whose rdf:resource="Koron_Chris"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="My_Favorite">
     <schema:name xml:lang="ja">マイ・フェイバリット</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">マイ・フェイバリット</rdfs:label>
     <schema:description xml:lang="ja">「大好き」が詰まった衣装でパピッとカワイくドレスアップ！まるで魔法をかけたみたいに、自分らしい自分でいられます。</schema:description>
     <imas:Whose rdf:resource="Mizushima_Saki"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Majimega_Emotion">
     <schema:name xml:lang="ja">マジメガエモーション</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">マジメガエモーション</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Iseya_Shiki"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Shiawase_Magic">
     <schema:name xml:lang="ja">シアワセ・マジック</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シアワセ・マジック</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Pierre"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Conversion_Heart">
     <schema:name xml:lang="ja">コンバウンド・ハート</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">コンバウンド・ハート</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Yamashita_Jiro"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Blaze_soul">
     <schema:name xml:lang="ja">ブレイズソウル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブレイズソウル</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Akai_Suzaku"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Ice_due_diligence">
     <schema:name xml:lang="ja">アイスディリジェンス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アイスディリジェンス</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Kurono_Genbu"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Snap_fang">
     <schema:name xml:lang="ja">スナップファング</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スナップファング</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Kizaki_Ren"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Kabuku_honryu_no_shirabe">
     <schema:name xml:lang="ja">傾く奔流の調べ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">傾く奔流の調べ</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Hanamura_Shoma"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Flappy_wing">
     <schema:name xml:lang="ja">フラッピーウィング</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フラッピーウィング</rdfs:label>
     <schema:description xml:lang="ja">テーラードジャネットに合わせたふわふわのスカートがキュートなコーデ。新たな空への期待を胸に少女はステージへと羽ばたく。</schema:description>
     <imas:Whose rdf:resource="Sakuragi_Mano"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Brink_wish">
     <schema:name xml:lang="ja">ブリンクウィッシュ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブリンクウィッシュ</rdfs:label>
     <schema:description xml:lang="ja">会場の視線を独り占めしてしまうこと間違い無しの豪華な一着。期待も不安もドレスが包む、お守りが入る隠しポケット付き。</schema:description>
     <imas:Whose rdf:resource="Kazano_Hiori"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Sprinkles_smile">
     <schema:name xml:lang="ja">スプリンクルスマイル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スプリンクルスマイル</rdfs:label>
     <schema:description xml:lang="ja">太陽のような明るい笑顔が輝けば誰もが心の中まで晴れ渡る。元気いっぱいな少女のための、動きやすさを重視した衣装。</schema:description>
     <imas:Whose rdf:resource="Hachimiya_Meguru"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Urban_Blossom">
     <schema:name xml:lang="ja">アーバンブロッサム</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アーバンブロッサム</rdfs:label>
     <schema:description xml:lang="ja">ガーリッシュなコーデはいつだってティーンの憧れ。可愛く着こなす姿を見せてみんなのことを魅了しちゃうよ☆</schema:description>
     <imas:Whose rdf:resource="Osaki_Amana"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Lovely_Bloom">
     <schema:name xml:lang="ja">ラブリーブルーム</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ラブリーブルーム</rdfs:label>
     <schema:description xml:lang="ja">にげたくなっても勇気を出して、へやの外に飛び出せばスターに大へんしん！自信を引き出し、先へと進む勇気をくれる一着です。</schema:description>
     <imas:Whose rdf:resource="Osaki_Tenka"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Graceful_Lillian">
     <schema:name xml:lang="ja">グレイスフルリリアン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">グレイスフルリリアン</rdfs:label>
     <schema:description xml:lang="ja">ゆったりとしたストールが大人のエレガントさを演出。ステージに立てば大輪の花が咲き誇り、夢のような世界が広がる。</schema:description>
     <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Reversed_cute">
     <schema:name xml:lang="ja">リバースド♡キュート</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">リバースド♡キュート</rdfs:label>
     <schema:description xml:lang="ja">ふんわりフォルムのトップスとタイトスカートのメリハリが素敵な衣装。可愛い表情を、バッチリ際立たせます。</schema:description>
     <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Hokago_checked">
     <schema:name xml:lang="ja">ホーカゴチェック!</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ホーカゴチェック!</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Komiya_Kaho"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Afascinale_of_fleeting_moment">
     <schema:name xml:lang="ja">玉響のアファシナーレ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">玉響のアファシナーレ</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Shirase_Sakuya"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Unknown_Eyes">
     <schema:name xml:lang="ja">アンノウンアイズ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アンノウンアイズ</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Serizawa_Asahi"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Onnkeirinnrinn">
     <schema:name xml:lang="ja">音・繋・輪・輪</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">音・繋・輪・輪</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Yukoku_Kiriko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Irodoru_omohi">
     <schema:name xml:lang="ja">彩る想ひ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">彩る想ひ</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Morino_Rinze"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Starley_Futures_Poplinks">
     <schema:name xml:lang="ja">スターリー・フューチャーズ</schema:name>
@@ -770,77 +878,90 @@
     <imas:Whose rdf:resource="Kasuga_Mirai"/>
     <imas:Whose rdf:resource="Tendo_Teru"/>
     <imas:Whose rdf:resource="Sakuragi_Mano"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Bunny_pastel">
     <schema:name xml:lang="ja">バニー・パステル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">バニー・パステル</rdfs:label>
     <schema:description xml:lang="ja">うさちゃんがくれる幸せを、ファンの皆にプレゼント。可愛い仕草とイタズラな発想でエッグハントを盛り上げます。</schema:description>
     <imas:Whose rdf:resource="Minase_Iori"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Poppin_pastel">
     <schema:name xml:lang="ja">ポッピン・パステル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ポッピン・パステル</rdfs:label>
     <schema:description xml:lang="ja">春めく季節にぴったりの、心が弾むような一着。躍動感のあるステップで、爽やかな春風をお届けします。</schema:description>
     <imas:Whose rdf:resource="Akizuki_Ryo_315"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Fluffy_pastel">
     <schema:name xml:lang="ja">フラッフィ・パステル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フラッフィ・パステル</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Osaki_Amana"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Secret_maid">
     <schema:name xml:lang="ja">ナイショノメイド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ナイショノメイド</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Miyamoto_Frederica"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Himeyaka_kyushi">
     <schema:name xml:lang="ja">秘めやか給仕</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">秘めやか給仕</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Emily_Stewart"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Marvelous_Batler">
     <schema:name xml:lang="ja">マーベラスバトラー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">マーベラスバトラー</rdfs:label>
     <schema:description xml:lang="ja">一癖も二癖もある使用人達をまとめ上げる、一流の使用人頭。数多ある仕事を完璧にこなす。最も得意な家事は掃除。</schema:description>
     <imas:Whose rdf:resource="Kuzunoha_Amehiko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Step_On_Beat">
     <schema:name xml:lang="ja">ステップオンビート</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ステップオンビート</rdfs:label>
     <schema:description xml:lang="ja">軽やかで動きやすい衣装。爽やかな初夏の風に乗って、走り出したら止まらない。さあ、一緒に駆け出そう！</schema:description>
     <imas:Whose rdf:resource="Kikuchi_Makoto"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Top_speed">
     <schema:name xml:lang="ja">トップスピード!</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">トップスピード!</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Amagase_Toma"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="shooting_star">
     <schema:name xml:lang="ja">シューティングスター</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シューティングスター</rdfs:label>
     <schema:description xml:lang="ja">アクティブな動きにぴったりな輝く素材の衣装。ステージの上を走る姿は煌めく流星のよう。あなたの願いを形にします！</schema:description>
     <imas:Whose rdf:resource="Hachimiya_Meguru"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Purery_bride">
     <schema:name xml:lang="ja">ピュアリーブライド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピュアリーブライド</rdfs:label>
     <schema:description xml:lang="ja">純粋な心を優しく彩るウェディングドレス風の衣装。小鳥のさえずりに乗せ、溢れそうな愛と幸運を届けたい。</schema:description>
     <imas:Whose rdf:resource="Hoshii_Miki"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Brilliant_Bride">
     <schema:name xml:lang="ja">ブリリアントブライド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブリリアントブライド</rdfs:label>
     <schema:description xml:lang="ja">煌めき続ける彼女にふさわしいウェディングドレス風の衣装。輝くガラスの靴を履いて、あなたと一緒に歩んでいきたい。</schema:description>
     <imas:Whose rdf:resource="Jougasaki_Mika"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Floral_bride">
     <schema:name xml:lang="ja">フローラルブライド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローラルブライド</rdfs:label>
     <schema:description xml:lang="ja">祝福の風に花の香りが満ちるウェディングドレス風の衣装。胸の奥にある言葉にできないこの想い、歌に乗せて伝えたい。</schema:description>
     <imas:Whose rdf:resource="Shiraishi_Tsumugi"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
 </rdf:RDF>

--- a/RDFs/Clothes/PopLinks.rdf
+++ b/RDFs/Clothes/PopLinks.rdf
@@ -418,7 +418,7 @@
     <imas:Whose rdf:resource="Tada_Riina"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Fairytale_Dreamer">
+  <rdf:Description rdf:about="Maerchen_Dreamer">
     <schema:name xml:lang="ja">メルヒェンドリーマー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">メルヒェンドリーマー</rdfs:label>
     <schema:description xml:lang="ja">無限大の妄想を形にした、キュートなプリンセス風ドレス。夢見る乙女は止まらない。待っててね、運命の王子様♪</schema:description>

--- a/RDFs/Clothes/PopLinks.rdf
+++ b/RDFs/Clothes/PopLinks.rdf
@@ -129,6 +129,7 @@
     <imas:Whose rdf:resource="Fuyumi_Jun"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+<!--765AS-->
   <rdf:Description rdf:about="Purely_Pop">
     <schema:name xml:lang="ja">ピュアリーポップ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピュアリーポップ</rdfs:label>
@@ -220,6 +221,7 @@
     <imas:Whose rdf:resource="Ganaha_Hibiki"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+<!--CinderellaGirls-->
   <rdf:Description rdf:about="Twinkle_Smile">
     <schema:name xml:lang="ja">トゥインクルスマイル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">トゥインクルスマイル</rdfs:label>
@@ -486,6 +488,7 @@
     <imas:Whose rdf:resource="Ninomiya_Asuka"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+<!--MillionLive-->
   <rdf:Description rdf:about="Step_Future">
     <schema:name xml:lang="ja">ステップフューチャー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ステップフューチャー</rdfs:label>
@@ -619,6 +622,7 @@
     <imas:Whose rdf:resource="Maihama_Ayumu"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+<!--sideM-->
   <rdf:Description rdf:about="Majesty_Anima">
     <schema:name xml:lang="ja">マジェスティアニマ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">マジェスティアニマ</rdfs:label>
@@ -829,6 +833,7 @@
     <imas:Whose rdf:resource="Asselin_BB_2"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+<!--ShinyColors-->
   <rdf:Description rdf:about="Flappy_Wing">
     <schema:name xml:lang="ja">フラッピーウィング</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フラッピーウィング</rdfs:label>
@@ -920,6 +925,7 @@
     <imas:Whose rdf:resource="Mitsumine_Yuika"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+<!--限定系-->
   <rdf:Description rdf:about="Starry_Futures_Poplinks">
     <schema:name xml:lang="ja">スターリー・フューチャーズ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スターリー・フューチャーズ</rdfs:label>

--- a/RDFs/Clothes/PopLinks.rdf
+++ b/RDFs/Clothes/PopLinks.rdf
@@ -124,37 +124,40 @@
     <imas:Whose rdf:resource="Yukoku_Kiriko"/>
     <imas:Whose rdf:resource="Morino_Rinze"/>
     <imas:Whose rdf:resource="Mitsumine_Yuika"/>
+    <imas:Whose rdf:resource="Mizumoto_Yukari"/>
+    <imas:Whose rdf:resource="Sakuramori_Kaori"/>
+    <imas:Whose rdf:resource="Fuyumi_Jun"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Purely_pop">
+  <rdf:Description rdf:about="Purely_Pop">
     <schema:name xml:lang="ja">ピュアリーポップ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピュアリーポップ</rdfs:label>
     <schema:description xml:lang="ja">ポップでカジュアルな見た目に、ひらひら揺れるリボンが特徴的。頭のコサージュのように、ステージで可愛く花開きます。</schema:description>
     <imas:Whose rdf:resource="Amami_Haruka"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Cynthia_Mart">
+  <rdf:Description rdf:about="Sincerely_Animato">
     <schema:name xml:lang="ja">シンシアリアニマート</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シンシアリアニマート</rdfs:label>
     <schema:description xml:lang="ja">夢見た場所へ、仲間と共に。新たな可能性を引き出す装い。昂ぶる想いを旋律にのせ、あなたに届くよう歌い上げます。</schema:description>
     <imas:Whose rdf:resource="Kisaragi_Chihaya"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Sparkle_butterfly">
+  <rdf:Description rdf:about="Sparkle_Butterfly">
     <schema:name xml:lang="ja">スパークルバタフライ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スパークルバタフライ</rdfs:label>
     <schema:description xml:lang="ja">優雅さと活発さをあわせ持つアトラクティブなドレス。これさえ着れば、みんなの視線はぜ～んぶキミのモノ！</schema:description>
     <imas:Whose rdf:resource="Hoshii_Miki"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Suite_chiffon">
+  <rdf:Description rdf:about="Sweet_Chiffon">
     <schema:name xml:lang="ja">スイートシフォン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スイートシフォン</rdfs:label>
     <schema:description xml:lang="ja">内気な心を柔らかく包み込み、一歩を踏み出す勇気をくれる、優しい素材の衣装。甘い気持ち、あなたにも届くかな？</schema:description>
     <imas:Whose rdf:resource="Hagiwara_Yukiho"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Poppin_casual">
+  <rdf:Description rdf:about="Poppin_Casual">
     <schema:name xml:lang="ja">ポッピンカジュアル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ポッピンカジュアル</rdfs:label>
     <schema:description xml:lang="ja">明るくて元気いっぱいな子にぴったりの、爽やかな衣装。特売のお野菜を見つけた時のように、心がぴょんとはずみます。</schema:description>
@@ -168,7 +171,7 @@
     <imas:Whose rdf:resource="Kikuchi_Makoto"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Charming_checked">
+  <rdf:Description rdf:about="Charming_Checked">
     <schema:name xml:lang="ja">チャーミング・チェック</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">チャーミング・チェック</rdfs:label>
     <schema:description xml:lang="ja">大胆なチェックが特徴的な、着る人の内面の魅力まで引き出すチャーミングな衣装です。可愛いだけじゃないんだから♪</schema:description>
@@ -182,7 +185,7 @@
     <imas:Whose rdf:resource="Shijou_Takane"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Wisley_Wind">
+  <rdf:Description rdf:about="Wisely_Wind">
     <schema:name xml:lang="ja">ワイズリー・ウィンド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ワイズリー・ウィンド</rdfs:label>
     <schema:description xml:lang="ja">知的なイメージの中に、可愛らしさを漂わせる衣装です。風にはためく大きなスカートが人々の心を沸き立たせます。</schema:description>
@@ -203,49 +206,49 @@
     <imas:Whose rdf:resource="Futami_Ami"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Dokidoki_fine">
+  <rdf:Description rdf:about="Dokidoki_Fine">
     <schema:name xml:lang="ja">ドキドキ☆ファイン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ドキドキ☆ファイン</rdfs:label>
     <schema:description xml:lang="ja">心も身体も楽しくなっちゃう、メチャメチャキュートな衣装。これを着てステージに立てば、タイクツな日常にさようなら！</schema:description>
     <imas:Whose rdf:resource="Futami_Mami"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="High_tide_sunrise">
+  <rdf:Description rdf:about="High_Tide_Sunrise">
     <schema:name xml:lang="ja">ハイタイドサンライズ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ハイタイドサンライズ</rdfs:label>
     <schema:description xml:lang="ja">おてんばな人魚をイメージしたトロピカルな衣装です。溢れ出る情熱で、見る人の心は満ち潮のように大フィーバー！</schema:description>
     <imas:Whose rdf:resource="Ganaha_Hibiki"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Twinkle_smile">
+  <rdf:Description rdf:about="Twinkle_Smile">
     <schema:name xml:lang="ja">トゥインクルスマイル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">トゥインクルスマイル</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Shimamura_Uzuki"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Sing_to_Zenith">
+  <rdf:Description rdf:about="Sing_To_Zenith">
     <schema:name xml:lang="ja">シング・トゥ・ゼニス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シング・トゥ・ゼニス</rdfs:label>
     <schema:description xml:lang="ja">今よりもずっと、高い場所へ。妥協点なんてどこにもない。終わりの見えないこの道の上で、歌い続ける彼女のために。</schema:description>
     <imas:Whose rdf:resource="Shibuya_Rin"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Illuminas_Active">
+  <rdf:Description rdf:about="Illuminus_Active">
     <schema:name xml:lang="ja">イルミナスアクティブ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">イルミナスアクティブ</rdfs:label>
     <schema:description xml:lang="ja">首元に巻いた動きのあるリボンとタイトなパンツが躍動的な元気いっぱいの衣装。動きの激しいダンスで、より輝きます。</schema:description>
     <imas:Whose rdf:resource="Honda_Mio"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Tear_drop">
+  <rdf:Description rdf:about="Tear_Drop">
     <schema:name xml:lang="ja">ティアードロップ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ティアードロップ</rdfs:label>
     <schema:description xml:lang="ja">感動で流れ落ちた一粒の涙のように、キラリと輝く衣装。涙の後には、満面の笑みが咲き誇ります。</schema:description>
     <imas:Whose rdf:resource="Ohnuma_Kurumi"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Chemical_perfume">
+  <rdf:Description rdf:about="Chemical_Perfume">
     <schema:name xml:lang="ja">ケミカルパフューム</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ケミカルパフューム</rdfs:label>
     <schema:description xml:lang="ja">視覚も嗅覚も……五感すべてを支配し妄想心を呼び覚ます。気分はまるでトリッパー。踊ればたちまちケミカルな香りが漂う。</schema:description>
@@ -259,7 +262,7 @@
     <imas:Whose rdf:resource="Miyamoto_Frederica"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Idling_idol">
+  <rdf:Description rdf:about="Idling_Idol">
     <schema:name xml:lang="ja">アイドリングアイドル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アイドリングアイドル</rdfs:label>
     <schema:description xml:lang="ja">働くアイドルにオススメ。いっときの夢と希望を全世界の疲れた人たちへと。小柄な女の子にも重たくない、動きやすい衣装です。</schema:description>
@@ -280,7 +283,7 @@
     <imas:Whose rdf:resource="Hayasaka_Mirei"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Genius_Court_No2">
+  <rdf:Description rdf:about="Genius_Coat_No2">
     <schema:name xml:lang="ja">ジーニアスコート2号</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ジーニアスコート2号</rdfs:label>
     <schema:description xml:lang="ja">日の目を見るまで、倉庫の奥深く厳重に保管されていた秘密兵器。改造は施されているのか、1号はどうなったのか、謎が尽きない。</schema:description>
@@ -294,7 +297,7 @@
     <imas:Whose rdf:resource="Mifune_Miyu"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Coral_splash">
+  <rdf:Description rdf:about="Coral_Splash">
     <schema:name xml:lang="ja">コーラルスプラッシュ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">コーラルスプラッシュ</rdfs:label>
     <schema:description xml:lang="ja">サンゴ礁を優雅に泳ぐ熱帯魚のように、ひらひら揺らぐリボンが見る人の心を絡め取ります。お魚みたいに舞うのれす～。</schema:description>
@@ -315,14 +318,14 @@
     <imas:Whose rdf:resource="Ohishi_Izumi"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="No_no_negative">
+  <rdf:Description rdf:about="No_No_Negative">
     <schema:name xml:lang="ja">ノーノー・ネガティブ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ノーノー・ネガティブ</rdfs:label>
     <schema:description xml:lang="ja">クラシカルなチェックがキュートでファンシーな衣装。ちょっぴりいじらしい少女の、変わりたい気持ちを応援します。</schema:description>
     <imas:Whose rdf:resource="Morikubo_Nono"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Pure_snake">
+  <rdf:Description rdf:about="Pure_Snake">
     <schema:name xml:lang="ja">ピュア・スニェーク</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピュア・スニェーク</rdfs:label>
     <schema:description xml:lang="ja">冬の夜。澄み切った空気。星の灯りに照らされ、ふわりと舞い降りた雪の結晶。純粋で、神秘的な衣装です。</schema:description>
@@ -336,14 +339,14 @@
     <imas:Whose rdf:resource="Hoshi_Syoko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Gloria_Squeen">
+  <rdf:Description rdf:about="Glorious_Queen">
     <schema:name xml:lang="ja">グロリアスクイーン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">グロリアスクイーン</rdfs:label>
     <schema:description xml:lang="ja">愚図な豚に言葉など不要。エックセレントな佇まいに無駄口をつぐみ、いやしく見惚れることこそが務めなのです。</schema:description>
     <imas:Whose rdf:resource="Zaizen_Tokiko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Cheerful_marching">
+  <rdf:Description rdf:about="Cheerful_Marching">
     <schema:name xml:lang="ja">チアフルマーチング</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">チアフルマーチング</rdfs:label>
     <schema:description xml:lang="ja">頑張る全ての人へ、エールを！そんな気持ちがたっぷり詰まったマーチング風の衣装です。キープオンスマイル！</schema:description>
@@ -364,14 +367,14 @@
     <imas:Whose rdf:resource="Jougasaki_Rika"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Hapy_Plincesse">
+  <rdf:Description rdf:about="Happy_Happy_Princess">
     <schema:name xml:lang="ja">ハピハピプリンセス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ハピハピプリンセス</rdfs:label>
     <schema:description xml:lang="ja">大胆にデコレーションされた、元気いっぱいなハピハピドレス。きゃわいく散りばめられたアクセは自前で用意したらしい。</schema:description>
     <imas:Whose rdf:resource="Moroboshi_Kirari"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Shining_wave">
+  <rdf:Description rdf:about="Shining_Wave">
     <schema:name xml:lang="ja">シャイニングウェーブ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シャイニングウェーブ</rdfs:label>
     <schema:description xml:lang="ja">着た人と見た人にご利益があるという噂が、まことしやかに流れるエンターテイナーなドレス。儲かりまっか～！</schema:description>
@@ -399,14 +402,14 @@
     <imas:Whose rdf:resource="Nanjo_Hikaru"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Rocking_heartbeat">
+  <rdf:Description rdf:about="Rocking_Heartbeat">
     <schema:name xml:lang="ja">ロッキングハートビート</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ロッキングハートビート</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Kimura_Natsuki"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Natural_rocker">
+  <rdf:Description rdf:about="Natural_Rocker">
     <schema:name xml:lang="ja">ナチュラルロッカー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ナチュラルロッカー</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
@@ -427,21 +430,21 @@
     <imas:Whose rdf:resource="Takagaki_Kaede"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Smash_sparkle">
+  <rdf:Description rdf:about="Smash_Sparkle">
     <schema:name xml:lang="ja">スマッシュスパークル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スマッシュスパークル</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Mukai_Takumi"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Innocent_rose">
+  <rdf:Description rdf:about="Innocent_Rose">
     <schema:name xml:lang="ja">イノセントローズ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">イノセントローズ</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Sakurai_Momoka"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Sweet_destiny">
+  <rdf:Description rdf:about="Sweet_Destiny">
     <schema:name xml:lang="ja">スイートデスティニー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スイートデスティニー</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
@@ -455,9 +458,9 @@
     <imas:Whose rdf:resource="Shirasaka_Koume"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Maboroba_no_utahime">
-    <schema:name xml:lang="ja">まぼろばの舞姫</schema:name>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">まぼろばの舞姫</rdfs:label>
+  <rdf:Description rdf:about="Mahoroba_No_Utahime">
+    <schema:name xml:lang="ja">まほろばの舞姫</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">まほろばの舞姫</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Kobayakawa_Sae"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
@@ -476,14 +479,14 @@
     <imas:Whose rdf:resource="Kanzaki_Ranko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Pulse_flying_in_the_dawn_sky">
+  <rdf:Description rdf:about="Pulse_Flying_In_The_Dawn_Sky">
     <schema:name xml:lang="ja">暁天を翔るパルス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">暁天を翔るパルス</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Ninomiya_Asuka"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Step_future">
+  <rdf:Description rdf:about="Step_Future">
     <schema:name xml:lang="ja">ステップフューチャー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ステップフューチャー</rdfs:label>
     <schema:description xml:lang="ja">チューブトップのスパンコールが笑顔と一緒に輝くコーデ。いつも未来を夢見る少女は新たな夢意を抱いて前進！</schema:description>
@@ -497,7 +500,7 @@
     <imas:Whose rdf:resource="Mogami_Shizuka"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Charming_flap">
+  <rdf:Description rdf:about="Charming_Flap">
     <schema:name xml:lang="ja">チャーミングフラップ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">チャーミングフラップ</rdfs:label>
     <schema:description xml:lang="ja">持ち前の元気な明るさと、ちょっぴり小悪魔なセクシーさを引き出す衣装。イタズラな笑顔が見た人の心をくすぐります。</schema:description>
@@ -511,42 +514,42 @@
     <imas:Whose rdf:resource="Shimabara_Elena"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Parfe_Princess">
+  <rdf:Description rdf:about="Parfait_Princess">
     <schema:name xml:lang="ja">パルフェ・プリンセス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">パルフェ・プリンセス</rdfs:label>
     <schema:description xml:lang="ja">スイーツのように、甘く可愛くキラキラに飾り付けたお姫様のための衣装。ポイントはスカートに散りばめた、好物のマカロン。</schema:description>
     <imas:Whose rdf:resource="Tokugawa_Matsuri"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Romance_dreamer">
+  <rdf:Description rdf:about="Romance_Dreamer">
     <schema:name xml:lang="ja">ロマンスドリーマー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ロマンスドリーマー</rdfs:label>
     <schema:description xml:lang="ja">フリルをふんだんにあしらい上品で可憐に仕立てたドレス。舞台の上で踊る姿は、物語のヒロインのよう。</schema:description>
     <imas:Whose rdf:resource="Nanao_Yuriko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Star_spirit">
+  <rdf:Description rdf:about="Star_Spirit">
     <schema:name xml:lang="ja">スター・スピリット</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スター・スピリット</rdfs:label>
     <schema:description xml:lang="ja">アイドル研究の専門家も大満足の正統派アイドル衣装。この衣装をまとって輝く姿は誰よりもアイドル。</schema:description>
     <imas:Whose rdf:resource="Matsuda_Arisa"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Pretty_essence">
+  <rdf:Description rdf:about="Pretty_Essence">
     <schema:name xml:lang="ja">プリティエッセンス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プリティエッセンス</rdfs:label>
     <schema:description xml:lang="ja">真っ直ぐで純真で、大人になりたいと背伸びする少女。その姿を、フリルとレースでキュートに包み込んだ一着。</schema:description>
     <imas:Whose rdf:resource="Nakatani_Iku"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Irodori_komachi">
+  <rdf:Description rdf:about="Irodori_Komachi">
     <schema:name xml:lang="ja">彩り小町</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">彩り小町</rdfs:label>
     <schema:description xml:lang="ja">奥ゆかしい大和撫子のために仕立て上げた彩り豊かな衣装。憧れへと歩き続ける少女の姿は、きっと誰かの憧れに。</schema:description>
     <imas:Whose rdf:resource="Emily_Stewart"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Secret_pride">
+  <rdf:Description rdf:about="Secret_Pride">
     <schema:name xml:lang="ja">シークレットプライド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シークレットプライド</rdfs:label>
     <schema:description xml:lang="ja">静かに輝く月をデザインに加えた気品を感じる一着。夢に向かって弛まぬ努力を続ける誇り高い少女にぴったり。</schema:description>
@@ -560,7 +563,7 @@
     <imas:Whose rdf:resource="Miyao_Miya"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Mystery_joker">
+  <rdf:Description rdf:about="Mystery_Joker">
     <schema:name xml:lang="ja">ミステリージョーカー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ミステリージョーカー</rdfs:label>
     <schema:description xml:lang="ja">見た目はミステリアス。でも、心の中はいつだって色彩豊か。秘められたその色が見えたとき、あなたの心は彼女の手中に……。</schema:description>
@@ -588,7 +591,7 @@
     <imas:Whose rdf:resource="Ogami_Tamaki"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Starlight_tune">
+  <rdf:Description rdf:about="Starlight_Tune">
     <schema:name xml:lang="ja">スターライトチューン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スターライトチューン</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
@@ -609,7 +612,7 @@
     <imas:Whose rdf:resource="Hakozaki_Serika"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Happy_surprise">
+  <rdf:Description rdf:about="Happy_Surprise">
     <schema:name xml:lang="ja">ハッピーサプライズ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ハッピーサプライズ</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
@@ -630,28 +633,28 @@
     <imas:Whose rdf:resource="Ijuin_Hokuto"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Shakit_off">
+  <rdf:Description rdf:about="Shakit_Off">
     <schema:name xml:lang="ja">シェイキットオフ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シェイキットオフ</rdfs:label>
     <schema:description xml:lang="ja">素肌が眩しいノースリーブが、軽快で大胆なダンスを魅せる。つまんないことは忘れちゃって、みんなで楽しく踊ろうよ！</schema:description>
     <imas:Whose rdf:resource="Mitarai_Shota"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Playful_shine">
+  <rdf:Description rdf:about="Playful_Shine">
     <schema:name xml:lang="ja">プレイフルシャイン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プレイフルシャイン</rdfs:label>
     <schema:description xml:lang="ja">場所は変われど見上げたお天道様は変わらない。ステージ上で輝く笑顔が心を明るく照らします。この衣装、一生大事にするぜ！</schema:description>
     <imas:Whose rdf:resource="Tendo_Teru"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Lancet_flash">
+  <rdf:Description rdf:about="Lancet_Flash">
     <schema:name xml:lang="ja">ランセットフラッシュ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ランセットフラッシュ</rdfs:label>
     <schema:description xml:lang="ja">品格と矜持を感じさせる絢爛な一着。鋭い輝きを放つその姿は心の壁をも切り拓き、見るもの全ての記憶に残る。</schema:description>
     <imas:Whose rdf:resource="Sakuraba_Kaoru"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Eye_tail_wing">
+  <rdf:Description rdf:about="Eye_Tail_Wing">
     <schema:name xml:lang="ja">アイテールウイング</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アイテールウイング</rdfs:label>
     <schema:description xml:lang="ja">風を背に受けステージへ！ジャケットをはためかせ舞台を走る姿、空を舞う鳥のよう。雲の上に、テイクオフ！</schema:description>
@@ -672,14 +675,14 @@
     <imas:Whose rdf:resource="Kagura_Rei"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Brazing_hero">
+  <rdf:Description rdf:about="Brazing_Hero">
     <schema:name xml:lang="ja">ブレイジングヒーロー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブレイジングヒーロー</rdfs:label>
     <schema:description xml:lang="ja">いつもの鋭い眼光も、爽やかな着こなしで優しく見えるかも？みんなの笑顔を守るため、次のステージへ今日も出動！</schema:description>
     <imas:Whose rdf:resource="Akuno_Hideo"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Peaceful_rack">
+  <rdf:Description rdf:about="Peaceful_Rack">
     <schema:name xml:lang="ja">ピースフルラック</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピースフルラック</rdfs:label>
     <schema:description xml:lang="ja">何があっても前へ進む、不撓不屈の精神がモチーフ。夢へ向かって燃え上がれ！※火の取り扱いにはご用心。</schema:description>
@@ -693,7 +696,7 @@
     <imas:Whose rdf:resource="Shingen_Seiji"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Pure_flavor">
+  <rdf:Description rdf:about="Pure_Flavor">
     <schema:name xml:lang="ja">ピュアフレーバー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピュアフレーバー</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
@@ -714,28 +717,28 @@
     <imas:Whose rdf:resource="Himeno_Kanon"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Wave_the_flag">
+  <rdf:Description rdf:about="Wave_The_Flag">
     <schema:name xml:lang="ja">ウェイブザフラッグ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ウェイブザフラッグ</rdfs:label>
     <schema:description xml:lang="ja">大きなシルエットを背負うのはこれまで仲間たちと紡いできたたくさんの物語があるから。夢に向かって、これからも。</schema:description>
     <imas:Whose rdf:resource="Akizuki_Ryo_315"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Blooming_smile">
+  <rdf:Description rdf:about="Blooming_Smile">
     <schema:name xml:lang="ja">ブルーミングスマイル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブルーミングスマイル</rdfs:label>
     <schema:description xml:lang="ja">足回りを警戒にまとめたコーデ。躍動感にあふれるパフォーマンスで、みんなの顔をはなまる笑顔にしてみせるけぇのぉ！</schema:description>
     <imas:Whose rdf:resource="Kabuto_Daigo"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Primal_sail">
+  <rdf:Description rdf:about="Primal_Sail">
     <schema:name xml:lang="ja">プライマルセイル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プライマルセイル</rdfs:label>
     <schema:description xml:lang="ja">色鮮やかなロングストールが、動きに大胆な印象をプラス。新たな舞台で紡がれる物語を、どうぞご期待ください。</schema:description>
     <imas:Whose rdf:resource="Tsukumo_Kazuki"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Stoic_sweeper">
+  <rdf:Description rdf:about="Stoic_Sweeper">
     <schema:name xml:lang="ja">ストイックスイーパー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ストイックスイーパー</rdfs:label>
     <schema:description xml:lang="ja">飄々とした態度の裏にある、他人を想う優しさを織り込んだ一着。磨き上げた歌と踊りで、見るものの心を浄化します。</schema:description>
@@ -784,28 +787,28 @@
     <imas:Whose rdf:resource="Yamashita_Jiro"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Blaze_soul">
+  <rdf:Description rdf:about="Blaze_Soul">
     <schema:name xml:lang="ja">ブレイズソウル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブレイズソウル</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Akai_Suzaku"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Ice_due_diligence">
+  <rdf:Description rdf:about="Ice_Due_Diligence">
     <schema:name xml:lang="ja">アイスディリジェンス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アイスディリジェンス</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Kurono_Genbu"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Snap_fang">
+  <rdf:Description rdf:about="Snap_Fang">
     <schema:name xml:lang="ja">スナップファング</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スナップファング</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Kizaki_Ren"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Kabuku_honryu_no_shirabe">
+  <rdf:Description rdf:about="Kabuku_Honryu_No_Shirabe">
     <schema:name xml:lang="ja">傾く奔流の調べ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">傾く奔流の調べ</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
@@ -819,28 +822,28 @@
     <imas:Whose rdf:resource="Watanabe_Minori"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Twilight_aperitif">
+  <rdf:Description rdf:about="Twilight_Aperitif">
     <schema:name xml:lang="ja">黄昏のアペリティフ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">黄昏のアペリティフ</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Asselin_BB_2"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Flappy_wing">
+  <rdf:Description rdf:about="Flappy_Wing">
     <schema:name xml:lang="ja">フラッピーウィング</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フラッピーウィング</rdfs:label>
     <schema:description xml:lang="ja">テーラードジャネットに合わせたふわふわのスカートがキュートなコーデ。新たな空への期待を胸に少女はステージへと羽ばたく。</schema:description>
     <imas:Whose rdf:resource="Sakuragi_Mano"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Brink_wish">
+  <rdf:Description rdf:about="Brink_Wish">
     <schema:name xml:lang="ja">ブリンクウィッシュ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブリンクウィッシュ</rdfs:label>
     <schema:description xml:lang="ja">会場の視線を独り占めしてしまうこと間違い無しの豪華な一着。期待も不安もドレスが包む、お守りが入る隠しポケット付き。</schema:description>
     <imas:Whose rdf:resource="Kazano_Hiori"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Sprinkles_smile">
+  <rdf:Description rdf:about="Sprinkles_Smile">
     <schema:name xml:lang="ja">スプリンクルスマイル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スプリンクルスマイル</rdfs:label>
     <schema:description xml:lang="ja">太陽のような明るい笑顔が輝けば誰もが心の中まで晴れ渡る。元気いっぱいな少女のための、動きやすさを重視した衣装。</schema:description>
@@ -868,21 +871,21 @@
     <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Reversed_cute">
+  <rdf:Description rdf:about="Reversed_Cute">
     <schema:name xml:lang="ja">リバースド♡キュート</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">リバースド♡キュート</rdfs:label>
     <schema:description xml:lang="ja">ふんわりフォルムのトップスとタイトスカートのメリハリが素敵な衣装。可愛い表情を、バッチリ際立たせます。</schema:description>
     <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Hokago_checked">
+  <rdf:Description rdf:about="Hokago_Checked">
     <schema:name xml:lang="ja">ホーカゴチェック!</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ホーカゴチェック!</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Komiya_Kaho"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Afascinale_of_fleeting_moment">
+  <rdf:Description rdf:about="Afascinale_Of_Fleeting_Moment">
     <schema:name xml:lang="ja">玉響のアファシナーレ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">玉響のアファシナーレ</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
@@ -903,7 +906,7 @@
     <imas:Whose rdf:resource="Yukoku_Kiriko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Irodoru_omohi">
+  <rdf:Description rdf:about="Irodoru_Omohi">
     <schema:name xml:lang="ja">彩る想ひ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">彩る想ひ</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
@@ -928,35 +931,35 @@
     <imas:Whose rdf:resource="Sakuragi_Mano"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Bunny_pastel">
+  <rdf:Description rdf:about="Bunny_Pastel">
     <schema:name xml:lang="ja">バニー・パステル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">バニー・パステル</rdfs:label>
     <schema:description xml:lang="ja">うさちゃんがくれる幸せを、ファンの皆にプレゼント。可愛い仕草とイタズラな発想でエッグハントを盛り上げます。</schema:description>
     <imas:Whose rdf:resource="Minase_Iori"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Poppin_pastel">
+  <rdf:Description rdf:about="Poppin_Pastel">
     <schema:name xml:lang="ja">ポッピン・パステル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ポッピン・パステル</rdfs:label>
     <schema:description xml:lang="ja">春めく季節にぴったりの、心が弾むような一着。躍動感のあるステップで、爽やかな春風をお届けします。</schema:description>
     <imas:Whose rdf:resource="Akizuki_Ryo_315"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Fluffy_pastel">
+  <rdf:Description rdf:about="Fluffy_Pastel">
     <schema:name xml:lang="ja">フラッフィ・パステル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フラッフィ・パステル</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Osaki_Amana"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Secret_maid">
+  <rdf:Description rdf:about="Secret_Maid">
     <schema:name xml:lang="ja">ナイショノメイド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ナイショノメイド</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Miyamoto_Frederica"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Himeyaka_kyushi">
+  <rdf:Description rdf:about="Himeyaka_Kyushi">
     <schema:name xml:lang="ja">秘めやか給仕</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">秘めやか給仕</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
@@ -977,21 +980,21 @@
     <imas:Whose rdf:resource="Kikuchi_Makoto"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Top_speed">
+  <rdf:Description rdf:about="Top_Speed">
     <schema:name xml:lang="ja">トップスピード!</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">トップスピード!</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Amagase_Toma"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="shooting_star">
+  <rdf:Description rdf:about="shooting_Star">
     <schema:name xml:lang="ja">シューティングスター</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シューティングスター</rdfs:label>
     <schema:description xml:lang="ja">アクティブな動きにぴったりな輝く素材の衣装。ステージの上を走る姿は煌めく流星のよう。あなたの願いを形にします！</schema:description>
     <imas:Whose rdf:resource="Hachimiya_Meguru"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Purery_bride">
+  <rdf:Description rdf:about="Purery_Bride">
     <schema:name xml:lang="ja">ピュアリーブライド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピュアリーブライド</rdfs:label>
     <schema:description xml:lang="ja">純粋な心を優しく彩るウェディングドレス風の衣装。小鳥のさえずりに乗せ、溢れそうな愛と幸運を届けたい。</schema:description>
@@ -1005,28 +1008,28 @@
     <imas:Whose rdf:resource="Jougasaki_Mika"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Floral_bride">
+  <rdf:Description rdf:about="Floral_Bride">
     <schema:name xml:lang="ja">フローラルブライド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローラルブライド</rdfs:label>
     <schema:description xml:lang="ja">祝福の風に花の香りが満ちるウェディングドレス風の衣装。胸の奥にある言葉にできないこの想い、歌に乗せて伝えたい。</schema:description>
     <imas:Whose rdf:resource="Shiraishi_Tsumugi"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Yuunagi_no_myojo">
+  <rdf:Description rdf:about="Yuunagi_No_Myojo">
     <schema:name xml:lang="ja">夕凪の明星</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">夕凪の明星</rdfs:label>
     <schema:description xml:lang="ja">傾く陽、吹き止む風。仄かな夏が香る。だんだんと辺りは暗く、心は疾く……一番星、見つけた。</schema:description>
     <imas:Whose rdf:resource="Anastasia"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Mijikayo_no_suzukaze">
+  <rdf:Description rdf:about="Mijikayo_No_Suzukaze">
     <schema:name xml:lang="ja">短夜の涼風</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">短夜の涼風</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Miyao_Miya"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Hizakari_no_matsuribayashi">
+  <rdf:Description rdf:about="Hizakari_No_Matsuribayashi">
     <schema:name xml:lang="ja">日盛りの祭囃子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">日盛りの祭囃子</rdfs:label>
     <schema:description xml:lang="ja">軽快に下駄を鳴らす、向日葵のような笑顔に手を引かれて。耳を澄ませば、かすかに笛の音。今年もこの季節がやってきた。</schema:description>

--- a/RDFs/Clothes/PopLinks.rdf
+++ b/RDFs/Clothes/PopLinks.rdf
@@ -993,7 +993,7 @@
     <imas:Whose rdf:resource="Amagase_Toma"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="shooting_Star">
+  <rdf:Description rdf:about="Shooting_Star">
     <schema:name xml:lang="ja">シューティングスター</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シューティングスター</rdfs:label>
     <schema:description xml:lang="ja">アクティブな動きにぴったりな輝く素材の衣装。ステージの上を走る姿は煌めく流星のよう。あなたの願いを形にします！</schema:description>

--- a/RDFs/Clothes/PopLinks.rdf
+++ b/RDFs/Clothes/PopLinks.rdf
@@ -6,4 +6,841 @@
     xmlns:imas="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#"
     xml:base="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/"
     >
+
+  <rdf:Description rdf:about="Celestera_Unison">
+    <schema:name xml:lang="ja">セレステラユニゾン</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">セレステラユニゾン</rdfs:label>
+    <schema:description xml:lang="ja">色鮮やかな星々が、より一層輝いてお互いを照らし合う。つながりが奏でるハーモニーは新たな未来を祝福します。</rdfs:label>
+    <imas:Whose rdf:resource="Amami_Haruka"/>
+    <imas:Whose rdf:resource="Kisaragi_Chihaya"/>
+    <imas:Whose rdf:resource="Hoshii_Miki"/>
+    <imas:Whose rdf:resource="Hagiwara_Yukiho"/>
+    <imas:Whose rdf:resource="Takatsuki_Yayoi"/>
+    <imas:Whose rdf:resource="Kikuchi_Makoto"/>
+    <imas:Whose rdf:resource="Minase_Iori"/>
+    <imas:Whose rdf:resource="Shijou_Takane"/>
+    <imas:Whose rdf:resource="Akizuki_Ritsuko"/>
+    <imas:Whose rdf:resource="Miura_Azusa"/>
+    <imas:Whose rdf:resource="Futami_Ami"/>
+    <imas:Whose rdf:resource="Futami_Mami"/>
+    <imas:Whose rdf:resource="Ganaha_Hibiki"/>
+    <imas:Whose rdf:resource="Shimamura_Uzuki"/>
+    <imas:Whose rdf:resource="Shibuya_Rin"/>
+    <imas:Whose rdf:resource="Honda_Mio"/>
+    <imas:Whose rdf:resource="Ohnuma_Kurumi"/>
+    <imas:Whose rdf:resource="Ichinose_Shiki"/>
+    <imas:Whose rdf:resource="Miyamoto_Frederica"/>
+    <imas:Whose rdf:resource="Futaba_Anzu"/>
+    <imas:Whose rdf:resource="Muramatsu_Sakura"/>
+    <imas:Whose rdf:resource="Hayasaka_Mirei"/>
+    <imas:Whose rdf:resource="Ikebukuro_Akiha"/>
+    <imas:Whose rdf:resource="Mifune_Miyu"/>
+    <imas:Whose rdf:resource="Asari_Nanami"/>
+    <imas:Whose rdf:resource="Takamine_Noa"/>
+    <imas:Whose rdf:resource="Ohishi_Izumi"/>
+    <imas:Whose rdf:resource="Morikubo_Nono"/>
+    <imas:Whose rdf:resource="Anastasia"/>
+    <imas:Whose rdf:resource="Hoshi_Syoko"/>
+    <imas:Whose rdf:resource="Zaizen_Tokiko"/>
+    <imas:Whose rdf:resource="Wakabayashi_Tomoka"/>
+    <imas:Whose rdf:resource="Jougasaki_Mika"/>
+    <imas:Whose rdf:resource="Jougasaki_Rika"/>
+    <imas:Whose rdf:resource="Moroboshi_Kirari"/>
+    <imas:Whose rdf:resource="Tsuchiya_Ako"/>
+    <imas:Whose rdf:resource="Koshimizu_Sachiko"/>
+    <imas:Whose rdf:resource="Ohtsuki_Yui"/>
+    <imas:Whose rdf:resource="Nanjo_Hikaru"/>
+    <imas:Whose rdf:resource="Kimura_Natsuki"/>
+    <imas:Whose rdf:resource="Tada_Riina"/>
+    <imas:Whose rdf:resource="Kita_Hinako"/>
+    <imas:Whose rdf:resource="Takagaki_Kaede"/>
+    <imas:Whose rdf:resource="Mukai_Takumi"/>
+    <imas:Whose rdf:resource="Sakurai_Momoka"/>
+    <imas:Whose rdf:resource="Sakuma_Mayu"/>
+    <imas:Whose rdf:resource="Shirasaka_Koume"/>
+    <imas:Whose rdf:resource="Kobayakawa_Sae"/>
+    <imas:Whose rdf:resource="Kasuga_Mirai"/>
+    <imas:Whose rdf:resource="Mogami_Shizuka"/>
+    <imas:Whose rdf:resource="Ibuki_Tsubasa"/>
+    <imas:Whose rdf:resource="Shimabara_Elena"/>
+    <imas:Whose rdf:resource="Tokugawa_Matsuri"/>
+    <imas:Whose rdf:resource="Nanao_Yuriko"/>
+    <imas:Whose rdf:resource="Matsuda_Arisa"/>
+    <imas:Whose rdf:resource="Nakatani_Iku"/>
+    <imas:Whose rdf:resource="Emily_Stewart"/>
+    <imas:Whose rdf:resource="Kitazawa_Shiho"/>
+    <imas:Whose rdf:resource="Miyao_Miya"/>
+    <imas:Whose rdf:resource="Makabe_Mizuki"/>
+    <imas:Whose rdf:resource="Shiraishi_Tsumugi"/>
+    <imas:Whose rdf:resource="Tokoro_Megumi"/>
+    <imas:Whose rdf:resource="Ogami_Tamaki"/>
+    <imas:Whose rdf:resource="Julia"/>
+    <imas:Whose rdf:resource="Baba_Konomi"/>
+    <imas:Whose rdf:resource="Hakozaki_Serika"/>
+    <imas:Whose rdf:resource="Maihama_Ayumu"/>
+    <imas:Whose rdf:resource="Amagase_Toma"/>
+    <imas:Whose rdf:resource="Ijuin_Hokuto"/>
+    <imas:Whose rdf:resource="Mitarai_Shota"/>
+    <imas:Whose rdf:resource="Tendo_Teru"/>
+    <imas:Whose rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Whose rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Whose rdf:resource="Tsuzuki_Kei"/>
+    <imas:Whose rdf:resource="Kagura_Rei"/>
+    <imas:Whose rdf:resource="Akuno_Hideo"/>
+    <imas:Whose rdf:resource="Kimura_Ryu"/>
+    <imas:Whose rdf:resource="Shingen_Seiji"/>
+    <imas:Whose rdf:resource="Okamura_Nao"/>
+    <imas:Whose rdf:resource="Tachibana_Shiro"/>
+    <imas:Whose rdf:resource="Himeno_Kanon"/>
+    <imas:Whose rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Whose rdf:resource="Kabuto_Daigo"/>
+    <imas:Whose rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Whose rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Whose rdf:resource="Kitamura_Sora"/>
+    <imas:Whose rdf:resource="Koron_Chris"/>
+    <imas:Whose rdf:resource="Mizushima_Saki"/>
+    <imas:Whose rdf:resource="Iseya_Shiki"/>
+    <imas:Whose rdf:resource="Pierre"/>
+    <imas:Whose rdf:resource="Yamashita_Jiro"/>
+    <imas:Whose rdf:resource="Akai_Suzaku"/>
+    <imas:Whose rdf:resource="Kurono_Genbu"/>
+    <imas:Whose rdf:resource="Kizaki_Ren"/>
+    <imas:Whose rdf:resource="Hanamura_Shoma"/>
+    <imas:Whose rdf:resource="Sakuragi_Mano"/>
+    <imas:Whose rdf:resource="Kazano_Hiori"/>
+    <imas:Whose rdf:resource="Hachimiya_Meguru"/>
+    <imas:Whose rdf:resource="Osaki_Amana"/>
+    <imas:Whose rdf:resource="Osaki_Tenka"/>
+    <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
+    <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Whose rdf:resource="Komiya_Kaho"/>
+    <imas:Whose rdf:resource="Shirase_Sakuya"/>
+    <imas:Whose rdf:resource="Serizawa_Asahi"/>
+    <imas:Whose rdf:resource="Yukoku_Kiriko"/>
+    <imas:Whose rdf:resource="Morino_Rinze"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Purely_pop">
+    <schema:name xml:lang="ja">ピュアリーポップ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピュアリーポップ</rdfs:label>
+    <schema:description xml:lang="ja">ポップでカジュアルな見た目に、ひらひら揺れるリボンが特徴的。頭のコサージュのように、ステージで可愛く花開きます。</rdfs:label>
+    <imas:Whose rdf:resource="Amami_Haruka"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Cynthia_Mart">
+    <schema:name xml:lang="ja">シンシアリアニマート</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シンシアリアニマート</rdfs:label>
+    <schema:description xml:lang="ja">夢見た場所へ、仲間と共に。新たな可能性を引き出す装い。昂ぶる想いを旋律にのせ、あなたに届くよう歌い上げます。</rdfs:label>
+    <imas:Whose rdf:resource="Kisaragi_Chihaya"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sparkle_butterfly">
+    <schema:name xml:lang="ja">スパークルバタフライ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スパークルバタフライ</rdfs:label>
+    <schema:description xml:lang="ja">優雅さと活発さをあわせ持つアトラクティブなドレス。これさえ着れば、みんなの視線はぜ～んぶキミのモノ！</rdfs:label>
+    <imas:Whose rdf:resource="Hoshii_Miki"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Suite_chiffon">
+    <schema:name xml:lang="ja">スイートシフォン</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スイートシフォン</rdfs:label>
+    <schema:description xml:lang="ja">内気な心を柔らかく包み込み、一歩を踏み出す勇気をくれる、優しい素材の衣装。甘い気持ち、あなたにも届くかな？</rdfs:label>
+    <imas:Whose rdf:resource="Hagiwara_Yukiho"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Poppin_casual">
+    <schema:name xml:lang="ja">ポッピンカジュアル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ポッピンカジュアル</rdfs:label>
+    <schema:description xml:lang="ja">明るくて元気いっぱいな子にぴったりの、爽やかな衣装。特売のお野菜を見つけた時のように、心がぴょんとはずみます。</rdfs:label>
+    <imas:Whose rdf:resource="Takatsuki_Yayoi"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Brilliant_Bloom">
+    <schema:name xml:lang="ja">ブリリアントブルーム</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブリリアントブルーム</rdfs:label>
+    <schema:description xml:lang="ja">シャープなフォルムに、キュートなフリフリのクロス。カッコよくも、カワイくもなれる魅力的な衣装です。</rdfs:label>
+    <imas:Whose rdf:resource="Kikuchi_Makoto"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Charming_check">
+    <schema:name xml:lang="ja">チャーミング・チェック</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">チャーミング・チェック</rdfs:label>
+    <schema:description xml:lang="ja">大胆なチェックが特徴的な、着る人の内面の魅力まで引き出すチャーミングな衣装です。可愛いだけじゃないんだから♪</rdfs:label>
+    <imas:Whose rdf:resource="Minase_Iori"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Noble_Moonlight">
+    <schema:name xml:lang="ja">ノーブルムーンライト</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ノーブルムーンライト</rdfs:label>
+    <schema:description xml:lang="ja">髪の揺れる音さえ聞こえそうな夜の帳。その雲間から射す、ただ一筋の月光のように幻想的で孤高の気高さを持つドレスです。</rdfs:label>
+    <imas:Whose rdf:resource="Shijou_Takane"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wisley_Wind">
+    <schema:name xml:lang="ja">ワイズリー・ウィンド</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ワイズリー・ウィンド</rdfs:label>
+    <schema:description xml:lang="ja">知的なイメージの中に、可愛らしさを漂わせる衣装です。風にはためく大きなスカートが人々の心を沸き立たせます。</rdfs:label>
+    <imas:Whose rdf:resource="Akizuki_Ritsuko"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wonder_Venus">
+    <schema:name xml:lang="ja">ワンダー・ヴィーナス</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ワンダー・ヴィーナス</rdfs:label>
+    <schema:description xml:lang="ja">繊細かつ大胆なシルエットはまるで、うつし世に迷い降りた女神のよう。あなたの目に留まるのは、運命だったのかも……。</rdfs:label>
+    <imas:Whose rdf:resource="Miura_Azusa"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ukiuki_Passion">
+    <schema:name xml:lang="ja">ウキウキ☆パッション</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ウキウキ☆パッション</rdfs:label>
+    <schema:description xml:lang="ja">サンサンと輝く太陽の下、元気ハツラツなステージをイメージして作られた衣装。ジョーネツ的に踊っちゃえ！</rdfs:label>
+    <imas:Whose rdf:resource="Futami_Ami"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Dokidoki_fine">
+    <schema:name xml:lang="ja">ドキドキ☆ファイン</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ドキドキ☆ファイン</rdfs:label>
+    <schema:description xml:lang="ja">心も身体も楽しくなっちゃう、メチャメチャキュートな衣装。これを着てステージに立てば、タイクツな日常にさようなら！</rdfs:label>
+    <imas:Whose rdf:resource="Futami_Mami"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="High_tide_sunrise">
+    <schema:name xml:lang="ja">ハイタイドサンライズ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ハイタイドサンライズ</rdfs:label>
+    <schema:description xml:lang="ja">おてんばな人魚をイメージしたトロピカルな衣装です。溢れ出る情熱で、見る人の心は満ち潮のように大フィーバー！</rdfs:label>
+    <imas:Whose rdf:resource="Ganaha_Hibiki"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Twinkle_smile">
+    <schema:name xml:lang="ja">トゥインクルスマイル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">トゥインクルスマイル</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Shimamura_Uzuki"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sing_to_Zenith">
+    <schema:name xml:lang="ja">シング・トゥ・ゼニス</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シング・トゥ・ゼニス</rdfs:label>
+    <schema:description xml:lang="ja">今よりもずっと、高い場所へ。妥協点なんてどこにもない。終わりの見えないこの道の上で、歌い続ける彼女のために。</rdfs:label>
+    <imas:Whose rdf:resource="Shibuya_Rin"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Illuminas_Active">
+    <schema:name xml:lang="ja">イルミナスアクティブ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">イルミナスアクティブ</rdfs:label>
+    <schema:description xml:lang="ja">首元に巻いた動きのあるリボンとタイトなパンツが躍動的な元気いっぱいの衣装。動きの激しいダンスで、より輝きます。</rdfs:label>
+    <imas:Whose rdf:resource="Honda_Mio"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tear_drop">
+    <schema:name xml:lang="ja">ティアードロップ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ティアードロップ</rdfs:label>
+    <schema:description xml:lang="ja">感動で流れ落ちた一粒の涙のように、キラリと輝く衣装。涙の後には、満面の笑みが咲き誇ります。</rdfs:label>
+    <imas:Whose rdf:resource="Ohnuma_Kurumi"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Chemical_perfume">
+    <schema:name xml:lang="ja">ケミカルパフューム</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ケミカルパフューム</rdfs:label>
+    <schema:description xml:lang="ja">視覚も嗅覚も……五感すべてを支配し妄想心を呼び覚ます。気分はまるでトリッパー。踊ればたちまちケミカルな香りが漂う。</rdfs:label>
+    <imas:Whose rdf:resource="Ichinose_Shiki"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimagure_Tutu">
+    <schema:name xml:lang="ja">きまぐれチュチュ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">きまぐれチュチュ</rdfs:label>
+    <schema:description xml:lang="ja">辛めのライダースに甘めのスカートを組み合わせた気まぐれコーデが魅惑的。本当のアタシは、どっち？</rdfs:label>
+    <imas:Whose rdf:resource="Miyamoto_Frederica"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Idling_idol">
+    <schema:name xml:lang="ja">アイドリングアイドル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アイドリングアイドル</rdfs:label>
+    <schema:description xml:lang="ja">働くアイドルにオススメ。いっときの夢と希望を全世界の疲れた人たちへと。小柄な女の子にも重たくない、動きやすい衣装です。</rdfs:label>
+    <imas:Whose rdf:resource="Futaba_Anzu"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Smiley_Wave">
+    <schema:name xml:lang="ja">スマイリーウェーブ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スマイリーウェーブ</rdfs:label>
+    <schema:description xml:lang="ja">みんなに元気とニコニコ笑顔を届ける、王道なアイドル衣装。大きく咲いたいくつものリボンがとってもかわいいでぇす♪</rdfs:label>
+    <imas:Whose rdf:resource="Muramatsu_Sakura"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Scratch_Devil">
+    <schema:name xml:lang="ja">スクラッチデビル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スクラッチデビル</rdfs:label>
+    <schema:description xml:lang="ja">他人かどうか関係ない。自分が本当に好きなものを着たときにだけ、世界に爪痕を残すことができるのだから。</rdfs:label>
+    <imas:Whose rdf:resource="Hayasaka_Mirei"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Genius_Court_No2">
+    <schema:name xml:lang="ja">ジーニアスコート2号</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ジーニアスコート2号</rdfs:label>
+    <schema:description xml:lang="ja">日の目を見るまで、倉庫の奥深く厳重に保管されていた秘密兵器。改造は施されているのか、1号はどうなったのか、謎が尽きない。</rdfs:label>
+    <imas:Whose rdf:resource="Ikebukuro_Akiha"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mellow_Adagio">
+    <schema:name xml:lang="ja">メロウ・アダージオ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">メロウ・アダージオ</rdfs:label>
+    <schema:description xml:lang="ja">見る人全てを惹き付ける、艶やかなシルエットのドレス。高鳴る鼓動の中で、私との時間をただゆっくりと楽しんで。</rdfs:label>
+    <imas:Whose rdf:resource="Mifune_Miyu"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Coral_splash">
+    <schema:name xml:lang="ja">コーラルスプラッシュ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">コーラルスプラッシュ</rdfs:label>
+    <schema:description xml:lang="ja">サンゴ礁を優雅に泳ぐ熱帯魚のように、ひらひら揺らぐリボンが見る人の心を絡め取ります。お魚みたいに舞うのれす～。</rdfs:label>
+    <imas:Whose rdf:resource="Asari_Nanami"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Grand_Super_Nova">
+    <schema:name xml:lang="ja">グランスーパーノヴァ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">グランスーパーノヴァ</rdfs:label>
+    <schema:description xml:lang="ja">満天の片隅で輝く一つの光を、永遠の閃光へと昇華させるサイバーな衣装。一目見れば、瞼の裏に焼き付いて離れない。</rdfs:label>
+    <imas:Whose rdf:resource="Takamine_Noa"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Inspire_Wave">
+    <schema:name xml:lang="ja">インスパイアウェーブ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">インスパイアウェーブ</rdfs:label>
+    <schema:description xml:lang="ja">バンダナリボンが大胆なドレス。アイドル×ロジック＝無限大。計算以上の反応が、少女を可愛くアップデートするでしょう。</rdfs:label>
+    <imas:Whose rdf:resource="Ohishi_Izumi"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="No_no_negative">
+    <schema:name xml:lang="ja">ノーノー・ネガティブ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ノーノー・ネガティブ</rdfs:label>
+    <schema:description xml:lang="ja">クラシカルなチェックがキュートでファンシーな衣装。ちょっぴりいじらしい少女の、変わりたい気持ちを応援します。</rdfs:label>
+    <imas:Whose rdf:resource="Morikubo_Nono"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pure_snake">
+    <schema:name xml:lang="ja">ピュア・スニェーク</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピュア・スニェーク</rdfs:label>
+    <schema:description xml:lang="ja">冬の夜。澄み切った空気。星の灯りに照らされ、ふわりと舞い降りた雪の結晶。純粋で、神秘的な衣装です。</rdfs:label>
+    <imas:Whose rdf:resource="Anastasia"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Dicotomy_Grown">
+    <schema:name xml:lang="ja">ディコトミーグロウン</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディコトミーグロウン</rdfs:label>
+    <schema:description xml:lang="ja">可愛さもカッコよさも引き立てる一着です。見た人の心は雷に打たれたキノコのように立ち上がること間違いなし！</rdfs:label>
+    <imas:Whose rdf:resource="Hoshi_Syoko"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Gloria_Squeen">
+    <schema:name xml:lang="ja">グロリアスクイーン</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">グロリアスクイーン</rdfs:label>
+    <schema:description xml:lang="ja">愚図な豚に言葉など不要。エックセレントな佇まいに無駄口をつぐみ、いやしく見惚れることこそが務めなのです。</rdfs:label>
+    <imas:Whose rdf:resource="Zaizen_Tokiko"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Cheerful_marching">
+    <schema:name xml:lang="ja">チアフルマーチング</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">チアフルマーチング</rdfs:label>
+    <schema:description xml:lang="ja">頑張る全ての人へ、エールを！そんな気持ちがたっぷり詰まったマーチング風の衣装です。キープオンスマイル！</rdfs:label>
+    <imas:Whose rdf:resource="Wakabayashi_Tomoka"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Frontier_Mode">
+    <schema:name xml:lang="ja">フロンティア★モード</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フロンティア★モード</rdfs:label>
+    <schema:description xml:lang="ja">歩き出したからには、一歩だって立ち止まれない。誰もが想像したことのない最先端を歩き続ける。妥協のない彼女のための一着</rdfs:label>
+    <imas:Whose rdf:resource="Jougasaki_Mika"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Poppin_Decorate">
+    <schema:name xml:lang="ja">ポッピン☆デコレート</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ポッピン☆デコレート</rdfs:label>
+    <schema:description xml:lang="ja">元気と好奇心が弾け出しそうな、セクシーでポップな衣装。みんなと一緒に楽しくなれるエネルギッシュなライブに最適！</rdfs:label>
+    <imas:Whose rdf:resource="Jougasaki_Rika"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hapy_Plincesse">
+    <schema:name xml:lang="ja">ハピハピプリンセス</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ハピハピプリンセス</rdfs:label>
+    <schema:description xml:lang="ja">大胆にデコレーションされた、元気いっぱいなハピハピドレス。きゃわいく散りばめられたアクセは自前で用意したらしい。</rdfs:label>
+    <imas:Whose rdf:resource="Moroboshi_Kirari"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shining_wave">
+    <schema:name xml:lang="ja">シャイニングウェーブ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シャイニングウェーブ</rdfs:label>
+    <schema:description xml:lang="ja">着た人と見た人にご利益があるという噂が、まことしやかに流れるエンターテイナーなドレス。儲かりまっか～！</rdfs:label>
+    <imas:Whose rdf:resource="Tsuchiya_Ako"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Angelic_Cute">
+    <schema:name xml:lang="ja">エンジェリックキュート</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エンジェリックキュート</rdfs:label>
+    <schema:description xml:lang="ja">カワイイリボン、カワイイ靴、カワイイフリルにネックレス。カワイイをありったけ詰め込んだカワイイ彼女のための一着。</rdfs:label>
+    <imas:Whose rdf:resource="Koshimizu_Sachiko"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Lollipop_Soleil">
+    <schema:name xml:lang="ja">ロリポップソレイユ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ロリポップソレイユ</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Ohtsuki_Yui"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Heroes_Hope">
+    <schema:name xml:lang="ja">ヒーローズホープ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ヒーローズホープ</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Nanjo_Hikaru"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Locking_heartbeat">
+    <schema:name xml:lang="ja">ロッキングハートビート</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ロッキングハートビート</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Kimura_Natsuki"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Natural_locker">
+    <schema:name xml:lang="ja">ナチュラルロッカー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ナチュラルロッカー</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Tada_Riina"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fairytale_Dreamer">
+    <schema:name xml:lang="ja">メルヒェンドリーマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">メルヒェンドリーマー</rdfs:label>
+    <schema:description xml:lang="ja">無限大の妄想を形にした、キュートなプリンセス風ドレス。夢見る乙女は止まらない。待っててね、運命の王子様♪</rdfs:label>
+    <imas:Whose rdf:resource="Kita_Hinako"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Eternal_Feather">
+    <schema:name xml:lang="ja">エターナル・フェザー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エターナル・フェザー</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Takagaki_Kaede"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Smash_sparkle">
+    <schema:name xml:lang="ja">スマッシュスパークル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スマッシュスパークル</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Mukai_Takumi"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Innocent_rose">
+    <schema:name xml:lang="ja">イノセントローズ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">イノセントローズ</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Sakurai_Momoka"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sweet_destiny">
+    <schema:name xml:lang="ja">スイートデスティニー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スイートデスティニー</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Sakuma_Mayu"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Panic_Nightmare">
+    <schema:name xml:lang="ja">パニックナイトメア</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">パニックナイトメア</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Shirasaka_Koume"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maboroba_no_utahime">
+    <schema:name xml:lang="ja">まぼろばの舞姫</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">まぼろばの舞姫</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Kobayakawa_Sae"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Step_future">
+    <schema:name xml:lang="ja">ステップフューチャー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ステップフューチャー</rdfs:label>
+    <schema:description xml:lang="ja">チューブトップのスパンコールが笑顔と一緒に輝くコーデ。いつも未来を夢見る少女は新たな夢意を抱いて前進！</rdfs:label>
+    <imas:Whose rdf:resource="Kasuga_Mirai"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ambitious_Tender">
+    <schema:name xml:lang="ja">アンビシャステンダー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アンビシャステンダー</rdfs:label>
+    <schema:description xml:lang="ja">大きなリボンとファースカートで可愛くも優雅に仕立てた衣装。これからも仲間と手を取り合って優しい歌声を響かせます。</rdfs:label>
+    <imas:Whose rdf:resource="Mogami_Shizuka"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Charming_flap">
+    <schema:name xml:lang="ja">チャーミングフラップ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">チャーミングフラップ</rdfs:label>
+    <schema:description xml:lang="ja">持ち前の元気な明るさと、ちょっぴり小悪魔なセクシーさを引き出す衣装。イタズラな笑顔が見た人の心をくすぐります。</rdfs:label>
+    <imas:Whose rdf:resource="Ibuki_Tsubasa"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sunlight_Moment">
+    <schema:name xml:lang="ja">サンライトモーメント</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">サンライトモーメント</rdfs:label>
+    <schema:description xml:lang="ja">頭のひまわりがワンポイントの爽やかな衣装。輝く太陽のような笑顔で、みんな心はカーニバル！ワタシと一緒に踊ろうヨ♪</rdfs:label>
+    <imas:Whose rdf:resource="Shimabara_Elena"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Parfe_Princess">
+    <schema:name xml:lang="ja">パルフェ・プリンセス</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">パルフェ・プリンセス</rdfs:label>
+    <schema:description xml:lang="ja">スイーツのように、甘く可愛くキラキラに飾り付けたお姫様のための衣装。ポイントはスカートに散りばめた、好物のマカロン。</rdfs:label>
+    <imas:Whose rdf:resource="Tokugawa_Matsuri"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Romance_dreamer">
+    <schema:name xml:lang="ja">ロマンスドリーマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ロマンスドリーマー</rdfs:label>
+    <schema:description xml:lang="ja">フリルをふんだんにあしらい上品で可憐に仕立てたドレス。舞台の上で踊る姿は、物語のヒロインのよう。</rdfs:label>
+    <imas:Whose rdf:resource="Nanao_Yuriko"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Star_spirit">
+    <schema:name xml:lang="ja">スター・スピリット</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スター・スピリット</rdfs:label>
+    <schema:description xml:lang="ja">アイドル研究の専門家も大満足の正統派アイドル衣装。この衣装をまとって輝く姿は誰よりもアイドル。</rdfs:label>
+    <imas:Whose rdf:resource="Matsuda_Arisa"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pretty_essence">
+    <schema:name xml:lang="ja">プリティエッセンス</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プリティエッセンス</rdfs:label>
+    <schema:description xml:lang="ja">真っ直ぐで純真で、大人になりたいと背伸びする少女。その姿を、フリルとレースでキュートに包み込んだ一着。</rdfs:label>
+    <imas:Whose rdf:resource="Nakatani_Iku"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Irodori_komachi">
+    <schema:name xml:lang="ja">彩り小町</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">彩り小町</rdfs:label>
+    <schema:description xml:lang="ja">奥ゆかしい大和撫子のために仕立て上げた彩り豊かな衣装。憧れへと歩き続ける少女の姿は、きっと誰かの憧れに。</rdfs:label>
+    <imas:Whose rdf:resource="Emily_Stewart"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Secret_pride">
+    <schema:name xml:lang="ja">シークレットプライド</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シークレットプライド</rdfs:label>
+    <schema:description xml:lang="ja">静かに輝く月をデザインに加えた気品を感じる一着。夢に向かって弛まぬ努力を続ける誇り高い少女にぴったり。</rdfs:label>
+    <imas:Whose rdf:resource="Kitazawa_Shiho"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fluffy_Happiness">
+    <schema:name xml:lang="ja">ふわもこハピネス</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ふわもこハピネス</rdfs:label>
+    <schema:description xml:lang="ja">散りばめられた星がキラキラと瞬き、牧歌的で幻想的な空間を演出。幸せに満ちた笑顔が仲間もファンも癒します。</rdfs:label>
+    <imas:Whose rdf:resource="Miyao_Miya"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mystery_joker">
+    <schema:name xml:lang="ja">ミステリージョーカー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ミステリージョーカー</rdfs:label>
+    <schema:description xml:lang="ja">見た目はミステリアス。でも、心の中はいつだって色彩豊か。秘められたその色が見えたとき、あなたの心は彼女の手中に……。</rdfs:label>
+    <imas:Whose rdf:resource="Makabe_Mizuki"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Platonic_Iris">
+    <schema:name xml:lang="ja">プラトニックアイリス</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プラトニックアイリス</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Shiraishi_Tsumugi"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Advanced_Garley">
+    <schema:name xml:lang="ja">アドバンスドガーリー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アドバンスドガーリー</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Tokoro_Megumi"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Exciting_Explorer">
+    <schema:name xml:lang="ja">わくわくエクスプローラ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">わくわくエクスプローラ</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Ogami_Tamaki"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Starlight_tune">
+    <schema:name xml:lang="ja">スターライトチューン</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スターライトチューン</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Julia"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Elegant_Fleur">
+    <schema:name xml:lang="ja">エレガントフルール</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エレガントフルール</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Baba_Konomi"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tokimeki_Flowers">
+    <schema:name xml:lang="ja">トキメキフラワーズ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">トキメキフラワーズ</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Hakozaki_Serika"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Happy_surprise">
+    <schema:name xml:lang="ja">ハッピーサプライズ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ハッピーサプライズ</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Maihama_Ayumu"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Majesty_Anima">
+    <schema:name xml:lang="ja">マジェスティアニマ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">マジェスティアニマ</rdfs:label>
+    <schema:description xml:lang="ja">彩られたナポレオンジャケットが甘さと堅さを感じさせる正統派アイドル衣装。積み重ねた経験を糧にして、トップを目指す！</rdfs:label>
+    <imas:Whose rdf:resource="Amagase_Toma"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Dolce_Amore">
+    <schema:name xml:lang="ja">ドルチェ・アモーレ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ドルチェ・アモーレ</rdfs:label>
+    <schema:description xml:lang="ja">落ち着いたジャケットに合わせた遊び心のあるスカーフが、大人の余裕を感じさせます。甘い囁きを、天使の君に。</rdfs:label>
+    <imas:Whose rdf:resource="Ijuin_Hokuto"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shakit_off">
+    <schema:name xml:lang="ja">シェイキットオフ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シェイキットオフ</rdfs:label>
+    <schema:description xml:lang="ja">素肌が眩しいノースリーブが、軽快で大胆なダンスを魅せる。つまんないことは忘れちゃって、みんなで楽しく踊ろうよ！</rdfs:label>
+    <imas:Whose rdf:resource="Mitarai_Shota"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Playful_shine">
+    <schema:name xml:lang="ja">プレイフルシャイン</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プレイフルシャイン</rdfs:label>
+    <schema:description xml:lang="ja">場所は変われど見上げたお天道様は変わらない。ステージ上で輝く笑顔が心を明るく照らします。この衣装、一生大事にするぜ！</rdfs:label>
+    <imas:Whose rdf:resource="Tendo_Teru"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Lancet_flash">
+    <schema:name xml:lang="ja">ランセットフラッシュ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ランセットフラッシュ</rdfs:label>
+    <schema:description xml:lang="ja">品格と矜持を感じさせる絢爛な一着。鋭い輝きを放つその姿は心の壁をも切り拓き、見るもの全ての記憶に残る。</rdfs:label>
+    <imas:Whose rdf:resource="Sakuraba_Kaoru"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Eye_tail_wing">
+    <schema:name xml:lang="ja">アイテールウイング</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アイテールウイング</rdfs:label>
+    <schema:description xml:lang="ja">風を背に受けステージへ！ジャケットをはためかせ舞台を走る姿、空を舞う鳥のよう。雲の上に、テイクオフ！</rdfs:label>
+    <imas:Whose rdf:resource="Kashiwagi_Tsubasa"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Seele_Spielen">
+    <schema:name xml:lang="ja">ゼーレ・シュピーレン</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ゼーレ・シュピーレン</rdfs:label>
+    <schema:description xml:lang="ja">クレッシェンド、君を想って奏でよう。ディミヌエンド、僕の想いを奏でよう。全てを込めた音を、君に。</rdfs:label>
+    <imas:Whose rdf:resource="Tsuzuki_Kei"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Noble_Concerto">
+    <schema:name xml:lang="ja">ノーブルコンチェルト</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ノーブルコンチェルト</rdfs:label>
+    <schema:description xml:lang="ja">ゆったりしたジャケットコートを羽織り、奏でる曲に合わせて、ふわりと袖を揺らす。音に揺れるは布か、心か。</rdfs:label>
+    <imas:Whose rdf:resource="Kagura_Rei"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Brazing_hero">
+    <schema:name xml:lang="ja">ブレイジングヒーロー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブレイジングヒーロー</rdfs:label>
+    <schema:description xml:lang="ja">いつもの鋭い眼光も、爽やかな着こなしで優しく見えるかも？みんなの笑顔を守るため、次のステージへ今日も出動！</rdfs:label>
+    <imas:Whose rdf:resource="Akuno_Hideo"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Peaceful_rack">
+    <schema:name xml:lang="ja">ピースフルラック</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピースフルラック</rdfs:label>
+    <schema:description xml:lang="ja">何があっても前へ進む、不撓不屈の精神がモチーフ。夢へ向かって燃え上がれ！※火の取り扱いにはご用心。</rdfs:label>
+    <imas:Whose rdf:resource="Kimura_Ryu"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Smile_Commander">
+    <schema:name xml:lang="ja">スマイル・コマンダー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スマイル・コマンダー</rdfs:label>
+    <schema:description xml:lang="ja">ノースリーブのトップスがワイルドさを感じさせる一着。鍛えた肉体を存分に活かしてあなたの笑顔を守ります。</rdfs:label>
+    <imas:Whose rdf:resource="Shingen_Seiji"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pure_flavor">
+    <schema:name xml:lang="ja">ピュアフレーバー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピュアフレーバー</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Okamura_Nao"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Minimom_Bigster">
+    <schema:name xml:lang="ja">ミニマムビッグスター</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ミニマムビッグスター</rdfs:label>
+    <schema:description xml:lang="ja">小さな体につまった、だれにも負けないビッグな目標。最強にカッコいいアイドルを目指す姿が光ります。</rdfs:label>
+    <imas:Whose rdf:resource="Tachibana_Shiro"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yumekawa_Angel">
+    <schema:name xml:lang="ja">ゆめかわエンジェル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ゆめかわエンジェル</rdfs:label>
+    <schema:description xml:lang="ja">「だーいすき」なかわいいが詰め込まれた一着。甘くてやわらかい衣装をまとう天使の笑顔に、みんなの心も夢の中。</rdfs:label>
+    <imas:Whose rdf:resource="Himeno_Kanon"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wave_the_flag">
+    <schema:name xml:lang="ja">ウェイブザフラッグ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ウェイブザフラッグ</rdfs:label>
+    <schema:description xml:lang="ja">大きなシルエットを背負うのはこれまで仲間たちと紡いできたたくさんの物語があるから。夢に向かって、これからも。</rdfs:label>
+    <imas:Whose rdf:resource="Akizuki_Ryo_315"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Blooming_smile">
+    <schema:name xml:lang="ja">ブルーミングスマイル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブルーミングスマイル</rdfs:label>
+    <schema:description xml:lang="ja">足回りを警戒にまとめたコーデ。躍動感にあふれるパフォーマンスで、みんなの顔をはなまる笑顔にしてみせるけぇのぉ！</rdfs:label>
+    <imas:Whose rdf:resource="Kabuto_Daigo"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Primal_sail">
+    <schema:name xml:lang="ja">プライマルセイル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プライマルセイル</rdfs:label>
+    <schema:description xml:lang="ja">色鮮やかなロングストールが、動きに大胆な印象をプラス。新たな舞台で紡がれる物語を、どうぞご期待ください。</rdfs:label>
+    <imas:Whose rdf:resource="Tsukumo_Kazuki"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Stoic_sweeper">
+    <schema:name xml:lang="ja">ストイックスイーパー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ストイックスイーパー</rdfs:label>
+    <schema:description xml:lang="ja">飄々とした態度の裏にある、他人を想う優しさを織り込んだ一着。磨き上げた歌と踊りで、見るものの心を浄化します。</rdfs:label>
+    <imas:Whose rdf:resource="Kuzunoha_Amehiko"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Swinging_Bird">
+    <schema:name xml:lang="ja">スインギング・バード</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スインギング・バード</rdfs:label>
+    <schema:description xml:lang="ja">自然体な立ち居振る舞いの中にキラリと光る魅力を際立たせる遊び心のある衣装。ありのまま夢の舞台にいざ立たん。</rdfs:label>
+    <imas:Whose rdf:resource="Kitamura_Sora"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wonderful_Marine">
+    <schema:name xml:lang="ja">ワンダフルマリン</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ワンダフルマリン</rdfs:label>
+    <schema:description xml:lang="ja">未知なるフロンティアを求める探検家をイメージした一着。新たなステージと言う名の大海原へ、いざ漕ぎ出そう！</rdfs:label>
+    <imas:Whose rdf:resource="Koron_Chris"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="My_Favorite">
+    <schema:name xml:lang="ja">マイ・フェイバリット</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">マイ・フェイバリット</rdfs:label>
+    <schema:description xml:lang="ja">「大好き」が詰まった衣装でパピッとカワイくドレスアップ！まるで魔法をかけたみたいに、自分らしい自分でいられます。</rdfs:label>
+    <imas:Whose rdf:resource="Mizushima_Saki"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Majimega_Emotion">
+    <schema:name xml:lang="ja">マジメガエモーション</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">マジメガエモーション</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Iseya_Shiki"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shiawase_Magic">
+    <schema:name xml:lang="ja">シアワセ・マジック</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シアワセ・マジック</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Pierre"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Conversion_Heart">
+    <schema:name xml:lang="ja">コンバウンド・ハート</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">コンバウンド・ハート</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Yamashita_Jiro"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Blaze_soul">
+    <schema:name xml:lang="ja">ブレイズソウル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブレイズソウル</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Akai_Suzaku"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ice_due_diligence">
+    <schema:name xml:lang="ja">アイスディリジェンス</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アイスディリジェンス</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Kurono_Genbu"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Snap_fang">
+    <schema:name xml:lang="ja">スナップファング</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スナップファング</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Kizaki_Ren"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuku_honryu_no_shirabe">
+    <schema:name xml:lang="ja">傾く奔流の調べ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">傾く奔流の調べ</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Hanamura_Shoma"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Flappy_wing">
+    <schema:name xml:lang="ja">フラッピーウィング</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フラッピーウィング</rdfs:label>
+    <schema:description xml:lang="ja">テーラードジャネットに合わせたふわふわのスカートがキュートなコーデ。新たな空への期待を胸に少女はステージへと羽ばたく。</rdfs:label>
+    <imas:Whose rdf:resource="Sakuragi_Mano"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Brink_wish">
+    <schema:name xml:lang="ja">ブリンクウィッシュ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブリンクウィッシュ</rdfs:label>
+    <schema:description xml:lang="ja">会場の視線を独り占めしてしまうこと間違い無しの豪華な一着。期待も不安もドレスが包む、お守りが入る隠しポケット付き。</rdfs:label>
+    <imas:Whose rdf:resource="Kazano_Hiori"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sprinkles_smile">
+    <schema:name xml:lang="ja">スプリンクルスマイル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スプリンクルスマイル</rdfs:label>
+    <schema:description xml:lang="ja">太陽のような明るい笑顔が輝けば誰もが心の中まで晴れ渡る。元気いっぱいな少女のための、動きやすさを重視した衣装。</rdfs:label>
+    <imas:Whose rdf:resource="Hachimiya_Meguru"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Urban_Blossom">
+    <schema:name xml:lang="ja">アーバンブロッサム</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アーバンブロッサム</rdfs:label>
+    <schema:description xml:lang="ja">ガーリッシュなコーデはいつだってティーンの憧れ。可愛く着こなす姿を見せてみんなのことを魅了しちゃうよ☆</rdfs:label>
+    <imas:Whose rdf:resource="Osaki_Amana"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Lovely_Bloom">
+    <schema:name xml:lang="ja">ラブリーブルーム</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ラブリーブルーム</rdfs:label>
+    <schema:description xml:lang="ja">にげたくなっても勇気を出して、へやの外に飛び出せばスターに大へんしん！自信を引き出し、先へと進む勇気をくれる一着です。</rdfs:label>
+    <imas:Whose rdf:resource="Osaki_Tenka"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Graceful_Lillian">
+    <schema:name xml:lang="ja">グレイスフルリリアン</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">グレイスフルリリアン</rdfs:label>
+    <schema:description xml:lang="ja">ゆったりとしたストールが大人のエレガントさを演出。ステージに立てば大輪の花が咲き誇り、夢のような世界が広がる。</rdfs:label>
+    <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Reversed_cute">
+    <schema:name xml:lang="ja">リバースド♡キュート</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">リバースド♡キュート</rdfs:label>
+    <schema:description xml:lang="ja">ふんわりフォルムのトップスとタイトスカートのメリハリが素敵な衣装。可愛い表情を、バッチリ際立たせます。</rdfs:label>
+    <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hokago_checked">
+    <schema:name xml:lang="ja">ホーカゴチェック!</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ホーカゴチェック!</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Komiya_Kaho"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Afascinale_of_fleeting_moment">
+    <schema:name xml:lang="ja">玉響のアファシナーレ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">玉響のアファシナーレ</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Shirase_Sakuya"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Unknown_Eyes">
+    <schema:name xml:lang="ja">アンノウンアイズ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アンノウンアイズ</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Serizawa_Asahi"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Onnkeirinnrinn">
+    <schema:name xml:lang="ja">音・繋・輪・輪</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">音・繋・輪・輪</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Yukoku_Kiriko"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Irodoru_omoi">
+    <schema:name xml:lang="ja">彩る想ひ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">彩る想ひ</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Morino_Rinze"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Starley_Futures_Poplinks">
+    <schema:name xml:lang="ja">スターリー・フューチャーズ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スターリー・フューチャーズ</rdfs:label>
+    <schema:description xml:lang="ja">未来に向かって星のように輝き続けるアイドルたちの特別な衣装。さぁ笑って、「これからも、アイドル!!!!!」</rdfs:label>
+    <imas:Whose rdf:resource="Amami_Haruka"/>
+    <imas:Whose rdf:resource="Shimamura_Uzuki"/>
+    <imas:Whose rdf:resource="Kasuga_Mirai"/>
+    <imas:Whose rdf:resource="Tendo_Teru"/>
+    <imas:Whose rdf:resource="Sakuragi_Mano"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Bunny_pastel">
+    <schema:name xml:lang="ja">バニー・パステル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">バニー・パステル</rdfs:label>
+    <schema:description xml:lang="ja">うさちゃんがくれる幸せを、ファンの皆にプレゼント。可愛い仕草とイタズラな発想でエッグハントを盛り上げます。</rdfs:label>
+    <imas:Whose rdf:resource="Minase_Iori"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Poppin_pastel">
+    <schema:name xml:lang="ja">ポッピン・パステル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ポッピン・パステル</rdfs:label>
+    <schema:description xml:lang="ja">春めく季節にぴったりの、心が弾むような一着。躍動感のあるステップで、爽やかな春風をお届けします。</rdfs:label>
+    <imas:Whose rdf:resource="Akizuki_Ryo_315"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fluffy_pastel">
+    <schema:name xml:lang="ja">フラッフィ・パステル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フラッフィ・パステル</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Osaki_Amana"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Secret_maid">
+    <schema:name xml:lang="ja">ナイショノメイド</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ナイショノメイド</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Miyamoto_Frederica"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeyaka_kyushi">
+    <schema:name xml:lang="ja">秘めやか給仕</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">秘めやか給仕</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Emily_Stewart"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Marvelous_Batler">
+    <schema:name xml:lang="ja">マーベラスバトラー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">マーベラスバトラー</rdfs:label>
+    <schema:description xml:lang="ja">一癖も二癖もある使用人達をまとめ上げる、一流の使用人頭。数多ある仕事を完璧にこなす。最も得意な家事は掃除。</rdfs:label>
+    <imas:Whose rdf:resource="Kuzunoha_Amehiko"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Step_On_Beat">
+    <schema:name xml:lang="ja">ステップオンビート</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ステップオンビート</rdfs:label>
+    <schema:description xml:lang="ja">軽やかで動きやすい衣装。爽やかな初夏の風に乗って、走り出したら止まらない。さあ、一緒に駆け出そう！</rdfs:label>
+    <imas:Whose rdf:resource="Kikuchi_Makoto"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Top_speed">
+    <schema:name xml:lang="ja">トップスピード!</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">トップスピード!</rdfs:label>
+    <schema:description xml:lang="ja"></rdfs:label>
+    <imas:Whose rdf:resource="Amagase_Toma"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="shooting_star">
+    <schema:name xml:lang="ja">シューティングスター</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シューティングスター</rdfs:label>
+    <schema:description xml:lang="ja">アクティブな動きにぴったりな輝く素材の衣装。ステージの上を走る姿は煌めく流星のよう。あなたの願いを形にします！</rdfs:label>
+    <imas:Whose rdf:resource="Hachimiya_Meguru"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Purery_bride">
+    <schema:name xml:lang="ja">ピュアリーブライド</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピュアリーブライド</rdfs:label>
+    <schema:description xml:lang="ja">純粋な心を優しく彩るウェディングドレス風の衣装。小鳥のさえずりに乗せ、溢れそうな愛と幸運を届けたい。</rdfs:label>
+    <imas:Whose rdf:resource="Hoshii_Miki"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Brilliant_Bride">
+    <schema:name xml:lang="ja">ブリリアントブライド</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブリリアントブライド</rdfs:label>
+    <schema:description xml:lang="ja">煌めき続ける彼女にふさわしいウェディングドレス風の衣装。輝くガラスの靴を履いて、あなたと一緒に歩んでいきたい。</rdfs:label>
+    <imas:Whose rdf:resource="Jougasaki_Mika"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Floral_bride">
+    <schema:name xml:lang="ja">フローラルブライド</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローラルブライド</rdfs:label>
+    <schema:description xml:lang="ja">祝福の風に花の香りが満ちるウェディングドレス風の衣装。胸の奥にある言葉にできないこの想い、歌に乗せて伝えたい。</rdfs:label>
+    <imas:Whose rdf:resource="Shiraishi_Tsumugi"/>
+  </rdf:Description>
 </rdf:RDF>

--- a/RDFs/Clothes/PopLinks.rdf
+++ b/RDFs/Clothes/PopLinks.rdf
@@ -59,6 +59,9 @@
     <imas:Whose rdf:resource="Sakuma_Mayu"/>
     <imas:Whose rdf:resource="Shirasaka_Koume"/>
     <imas:Whose rdf:resource="Kobayakawa_Sae"/>
+    <imas:Whose rdf:resource="Abe_Nana"/>
+    <imas:Whose rdf:resource="Kanzaki_Ranko"/>
+    <imas:Whose rdf:resource="Ninomiya_Asuka"/>
     <imas:Whose rdf:resource="Kasuga_Mirai"/>
     <imas:Whose rdf:resource="Mogami_Shizuka"/>
     <imas:Whose rdf:resource="Ibuki_Tsubasa"/>
@@ -106,6 +109,8 @@
     <imas:Whose rdf:resource="Kurono_Genbu"/>
     <imas:Whose rdf:resource="Kizaki_Ren"/>
     <imas:Whose rdf:resource="Hanamura_Shoma"/>
+    <imas:Whose rdf:resource="Watanabe_Minori"/>
+    <imas:Whose rdf:resource="Asselin_BB_2"/>
     <imas:Whose rdf:resource="Sakuragi_Mano"/>
     <imas:Whose rdf:resource="Kazano_Hiori"/>
     <imas:Whose rdf:resource="Hachimiya_Meguru"/>
@@ -118,6 +123,7 @@
     <imas:Whose rdf:resource="Serizawa_Asahi"/>
     <imas:Whose rdf:resource="Yukoku_Kiriko"/>
     <imas:Whose rdf:resource="Morino_Rinze"/>
+    <imas:Whose rdf:resource="Mitsumine_Yuika"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Purely_pop">
@@ -456,6 +462,27 @@
     <imas:Whose rdf:resource="Kobayakawa_Sae"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Usamin_Frontier">
+    <schema:name xml:lang="ja">ウサミン☆フロンティア</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ウサミン☆フロンティア</rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
+    <imas:Whose rdf:resource="Abe_Nana"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Feast_Spinner">
+    <schema:name xml:lang="ja">饗宴の紡ぎ手</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">饗宴の紡ぎ手</rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
+    <imas:Whose rdf:resource="Kanzaki_Ranko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pulse_flying_in_the_dawn_sky">
+    <schema:name xml:lang="ja">暁天を翔るパルス</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">暁天を翔るパルス</rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
+    <imas:Whose rdf:resource="Ninomiya_Asuka"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
   <rdf:Description rdf:about="Step_future">
     <schema:name xml:lang="ja">ステップフューチャー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ステップフューチャー</rdfs:label>
@@ -578,7 +605,7 @@
   <rdf:Description rdf:about="Tokimeki_Flowers">
     <schema:name xml:lang="ja">トキメキフラワーズ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">トキメキフラワーズ</rdfs:label>
-    <schema:description xml:lang="ja"></schema:description>
+    <schema:description xml:lang="ja">乙女心をくすぐる花びらをあしらった衣装。可憐に咲いた好奇心は未知の世界を知り、光を浴びてより一層輝く。</schema:description>
     <imas:Whose rdf:resource="Hakozaki_Serika"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -785,6 +812,20 @@
     <imas:Whose rdf:resource="Hanamura_Shoma"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Eternity_Bloom">
+    <schema:name xml:lang="ja">エタニティブルーム</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エタニティブルーム</rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
+    <imas:Whose rdf:resource="Watanabe_Minori"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Twilight_aperitif">
+    <schema:name xml:lang="ja">黄昏のアペリティフ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">黄昏のアペリティフ</rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
+    <imas:Whose rdf:resource="Asselin_BB_2"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
   <rdf:Description rdf:about="Flappy_wing">
     <schema:name xml:lang="ja">フラッピーウィング</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フラッピーウィング</rdfs:label>
@@ -867,6 +908,13 @@
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">彩る想ひ</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Morino_Rinze"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="BE_D_REAMS">
+    <schema:name xml:lang="ja">Be_:D_reams</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Be_:D_reams</rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
+    <imas:Whose rdf:resource="Mitsumine_Yuika"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Starley_Futures_Poplinks">
@@ -962,6 +1010,27 @@
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローラルブライド</rdfs:label>
     <schema:description xml:lang="ja">祝福の風に花の香りが満ちるウェディングドレス風の衣装。胸の奥にある言葉にできないこの想い、歌に乗せて伝えたい。</schema:description>
     <imas:Whose rdf:resource="Shiraishi_Tsumugi"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yuunagi_no_myojo">
+    <schema:name xml:lang="ja">夕凪の明星</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">夕凪の明星</rdfs:label>
+    <schema:description xml:lang="ja">傾く陽、吹き止む風。仄かな夏が香る。だんだんと辺りは暗く、心は疾く……一番星、見つけた。</schema:description>
+    <imas:Whose rdf:resource="Anastasia"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mijikayo_no_suzukaze">
+    <schema:name xml:lang="ja">短夜の涼風</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">短夜の涼風</rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
+    <imas:Whose rdf:resource="Miyao_Miya"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hizakari_no_matsuribayashi">
+    <schema:name xml:lang="ja">日盛りの祭囃子</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">日盛りの祭囃子</rdfs:label>
+    <schema:description xml:lang="ja">軽快に下駄を鳴らす、向日葵のような笑顔に手を引かれて。耳を澄ませば、かすかに笛の音。今年もこの季節がやってきた。</schema:description>
+    <imas:Whose rdf:resource="Himeno_Kanon"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
 </rdf:RDF>

--- a/RDFs/Clothes/PopLinks.rdf
+++ b/RDFs/Clothes/PopLinks.rdf
@@ -155,7 +155,7 @@
     <schema:description xml:lang="ja">シャープなフォルムに、キュートなフリフリのクロス。カッコよくも、カワイくもなれる魅力的な衣装です。</schema:description>
     <imas:Whose rdf:resource="Kikuchi_Makoto"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Charming_check">
+  <rdf:Description rdf:about="Charming_checked">
     <schema:name xml:lang="ja">チャーミング・チェック</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">チャーミング・チェック</rdfs:label>
     <schema:description xml:lang="ja">大胆なチェックが特徴的な、着る人の内面の魅力まで引き出すチャーミングな衣装です。可愛いだけじゃないんだから♪</schema:description>
@@ -353,13 +353,13 @@
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Nanjo_Hikaru"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Locking_heartbeat">
+  <rdf:Description rdf:about="Rocking_heartbeat">
     <schema:name xml:lang="ja">ロッキングハートビート</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ロッキングハートビート</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Kimura_Natsuki"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Natural_locker">
+  <rdf:Description rdf:about="Natural_rocker">
     <schema:name xml:lang="ja">ナチュラルロッカー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ナチュラルロッカー</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
@@ -755,7 +755,7 @@
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Yukoku_Kiriko"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Irodoru_omoi">
+  <rdf:Description rdf:about="Irodoru_omohi">
     <schema:name xml:lang="ja">彩る想ひ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">彩る想ひ</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>

--- a/RDFs/Clothes/PopLinks.rdf
+++ b/RDFs/Clothes/PopLinks.rdf
@@ -10,7 +10,7 @@
   <rdf:Description rdf:about="Celestera_Unison">
     <schema:name xml:lang="ja">セレステラユニゾン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">セレステラユニゾン</rdfs:label>
-    <schema:description xml:lang="ja">色鮮やかな星々が、より一層輝いてお互いを照らし合う。つながりが奏でるハーモニーは新たな未来を祝福します。</rdfs:label>
+    <schema:description xml:lang="ja">色鮮やかな星々が、より一層輝いてお互いを照らし合う。つながりが奏でるハーモニーは新たな未来を祝福します。</schema:description>
     <imas:Whose rdf:resource="Amami_Haruka"/>
     <imas:Whose rdf:resource="Kisaragi_Chihaya"/>
     <imas:Whose rdf:resource="Hoshii_Miki"/>
@@ -122,649 +122,649 @@
   <rdf:Description rdf:about="Purely_pop">
     <schema:name xml:lang="ja">ピュアリーポップ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピュアリーポップ</rdfs:label>
-    <schema:description xml:lang="ja">ポップでカジュアルな見た目に、ひらひら揺れるリボンが特徴的。頭のコサージュのように、ステージで可愛く花開きます。</rdfs:label>
+    <schema:description xml:lang="ja">ポップでカジュアルな見た目に、ひらひら揺れるリボンが特徴的。頭のコサージュのように、ステージで可愛く花開きます。</schema:description>
     <imas:Whose rdf:resource="Amami_Haruka"/>
   </rdf:Description>
   <rdf:Description rdf:about="Cynthia_Mart">
     <schema:name xml:lang="ja">シンシアリアニマート</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シンシアリアニマート</rdfs:label>
-    <schema:description xml:lang="ja">夢見た場所へ、仲間と共に。新たな可能性を引き出す装い。昂ぶる想いを旋律にのせ、あなたに届くよう歌い上げます。</rdfs:label>
+    <schema:description xml:lang="ja">夢見た場所へ、仲間と共に。新たな可能性を引き出す装い。昂ぶる想いを旋律にのせ、あなたに届くよう歌い上げます。</schema:description>
     <imas:Whose rdf:resource="Kisaragi_Chihaya"/>
   </rdf:Description>
   <rdf:Description rdf:about="Sparkle_butterfly">
     <schema:name xml:lang="ja">スパークルバタフライ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スパークルバタフライ</rdfs:label>
-    <schema:description xml:lang="ja">優雅さと活発さをあわせ持つアトラクティブなドレス。これさえ着れば、みんなの視線はぜ～んぶキミのモノ！</rdfs:label>
+    <schema:description xml:lang="ja">優雅さと活発さをあわせ持つアトラクティブなドレス。これさえ着れば、みんなの視線はぜ～んぶキミのモノ！</schema:description>
     <imas:Whose rdf:resource="Hoshii_Miki"/>
   </rdf:Description>
   <rdf:Description rdf:about="Suite_chiffon">
     <schema:name xml:lang="ja">スイートシフォン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スイートシフォン</rdfs:label>
-    <schema:description xml:lang="ja">内気な心を柔らかく包み込み、一歩を踏み出す勇気をくれる、優しい素材の衣装。甘い気持ち、あなたにも届くかな？</rdfs:label>
+    <schema:description xml:lang="ja">内気な心を柔らかく包み込み、一歩を踏み出す勇気をくれる、優しい素材の衣装。甘い気持ち、あなたにも届くかな？</schema:description>
     <imas:Whose rdf:resource="Hagiwara_Yukiho"/>
   </rdf:Description>
   <rdf:Description rdf:about="Poppin_casual">
     <schema:name xml:lang="ja">ポッピンカジュアル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ポッピンカジュアル</rdfs:label>
-    <schema:description xml:lang="ja">明るくて元気いっぱいな子にぴったりの、爽やかな衣装。特売のお野菜を見つけた時のように、心がぴょんとはずみます。</rdfs:label>
+    <schema:description xml:lang="ja">明るくて元気いっぱいな子にぴったりの、爽やかな衣装。特売のお野菜を見つけた時のように、心がぴょんとはずみます。</schema:description>
     <imas:Whose rdf:resource="Takatsuki_Yayoi"/>
   </rdf:Description>
   <rdf:Description rdf:about="Brilliant_Bloom">
     <schema:name xml:lang="ja">ブリリアントブルーム</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブリリアントブルーム</rdfs:label>
-    <schema:description xml:lang="ja">シャープなフォルムに、キュートなフリフリのクロス。カッコよくも、カワイくもなれる魅力的な衣装です。</rdfs:label>
+    <schema:description xml:lang="ja">シャープなフォルムに、キュートなフリフリのクロス。カッコよくも、カワイくもなれる魅力的な衣装です。</schema:description>
     <imas:Whose rdf:resource="Kikuchi_Makoto"/>
   </rdf:Description>
   <rdf:Description rdf:about="Charming_check">
     <schema:name xml:lang="ja">チャーミング・チェック</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">チャーミング・チェック</rdfs:label>
-    <schema:description xml:lang="ja">大胆なチェックが特徴的な、着る人の内面の魅力まで引き出すチャーミングな衣装です。可愛いだけじゃないんだから♪</rdfs:label>
+    <schema:description xml:lang="ja">大胆なチェックが特徴的な、着る人の内面の魅力まで引き出すチャーミングな衣装です。可愛いだけじゃないんだから♪</schema:description>
     <imas:Whose rdf:resource="Minase_Iori"/>
   </rdf:Description>
   <rdf:Description rdf:about="Noble_Moonlight">
     <schema:name xml:lang="ja">ノーブルムーンライト</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ノーブルムーンライト</rdfs:label>
-    <schema:description xml:lang="ja">髪の揺れる音さえ聞こえそうな夜の帳。その雲間から射す、ただ一筋の月光のように幻想的で孤高の気高さを持つドレスです。</rdfs:label>
+    <schema:description xml:lang="ja">髪の揺れる音さえ聞こえそうな夜の帳。その雲間から射す、ただ一筋の月光のように幻想的で孤高の気高さを持つドレスです。</schema:description>
     <imas:Whose rdf:resource="Shijou_Takane"/>
   </rdf:Description>
   <rdf:Description rdf:about="Wisley_Wind">
     <schema:name xml:lang="ja">ワイズリー・ウィンド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ワイズリー・ウィンド</rdfs:label>
-    <schema:description xml:lang="ja">知的なイメージの中に、可愛らしさを漂わせる衣装です。風にはためく大きなスカートが人々の心を沸き立たせます。</rdfs:label>
+    <schema:description xml:lang="ja">知的なイメージの中に、可愛らしさを漂わせる衣装です。風にはためく大きなスカートが人々の心を沸き立たせます。</schema:description>
     <imas:Whose rdf:resource="Akizuki_Ritsuko"/>
   </rdf:Description>
   <rdf:Description rdf:about="Wonder_Venus">
     <schema:name xml:lang="ja">ワンダー・ヴィーナス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ワンダー・ヴィーナス</rdfs:label>
-    <schema:description xml:lang="ja">繊細かつ大胆なシルエットはまるで、うつし世に迷い降りた女神のよう。あなたの目に留まるのは、運命だったのかも……。</rdfs:label>
+    <schema:description xml:lang="ja">繊細かつ大胆なシルエットはまるで、うつし世に迷い降りた女神のよう。あなたの目に留まるのは、運命だったのかも……。</schema:description>
     <imas:Whose rdf:resource="Miura_Azusa"/>
   </rdf:Description>
   <rdf:Description rdf:about="Ukiuki_Passion">
     <schema:name xml:lang="ja">ウキウキ☆パッション</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ウキウキ☆パッション</rdfs:label>
-    <schema:description xml:lang="ja">サンサンと輝く太陽の下、元気ハツラツなステージをイメージして作られた衣装。ジョーネツ的に踊っちゃえ！</rdfs:label>
+    <schema:description xml:lang="ja">サンサンと輝く太陽の下、元気ハツラツなステージをイメージして作られた衣装。ジョーネツ的に踊っちゃえ！</schema:description>
     <imas:Whose rdf:resource="Futami_Ami"/>
   </rdf:Description>
   <rdf:Description rdf:about="Dokidoki_fine">
     <schema:name xml:lang="ja">ドキドキ☆ファイン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ドキドキ☆ファイン</rdfs:label>
-    <schema:description xml:lang="ja">心も身体も楽しくなっちゃう、メチャメチャキュートな衣装。これを着てステージに立てば、タイクツな日常にさようなら！</rdfs:label>
+    <schema:description xml:lang="ja">心も身体も楽しくなっちゃう、メチャメチャキュートな衣装。これを着てステージに立てば、タイクツな日常にさようなら！</schema:description>
     <imas:Whose rdf:resource="Futami_Mami"/>
   </rdf:Description>
   <rdf:Description rdf:about="High_tide_sunrise">
     <schema:name xml:lang="ja">ハイタイドサンライズ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ハイタイドサンライズ</rdfs:label>
-    <schema:description xml:lang="ja">おてんばな人魚をイメージしたトロピカルな衣装です。溢れ出る情熱で、見る人の心は満ち潮のように大フィーバー！</rdfs:label>
+    <schema:description xml:lang="ja">おてんばな人魚をイメージしたトロピカルな衣装です。溢れ出る情熱で、見る人の心は満ち潮のように大フィーバー！</schema:description>
     <imas:Whose rdf:resource="Ganaha_Hibiki"/>
   </rdf:Description>
   <rdf:Description rdf:about="Twinkle_smile">
     <schema:name xml:lang="ja">トゥインクルスマイル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">トゥインクルスマイル</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Shimamura_Uzuki"/>
   </rdf:Description>
   <rdf:Description rdf:about="Sing_to_Zenith">
     <schema:name xml:lang="ja">シング・トゥ・ゼニス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シング・トゥ・ゼニス</rdfs:label>
-    <schema:description xml:lang="ja">今よりもずっと、高い場所へ。妥協点なんてどこにもない。終わりの見えないこの道の上で、歌い続ける彼女のために。</rdfs:label>
+    <schema:description xml:lang="ja">今よりもずっと、高い場所へ。妥協点なんてどこにもない。終わりの見えないこの道の上で、歌い続ける彼女のために。</schema:description>
     <imas:Whose rdf:resource="Shibuya_Rin"/>
   </rdf:Description>
   <rdf:Description rdf:about="Illuminas_Active">
     <schema:name xml:lang="ja">イルミナスアクティブ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">イルミナスアクティブ</rdfs:label>
-    <schema:description xml:lang="ja">首元に巻いた動きのあるリボンとタイトなパンツが躍動的な元気いっぱいの衣装。動きの激しいダンスで、より輝きます。</rdfs:label>
+    <schema:description xml:lang="ja">首元に巻いた動きのあるリボンとタイトなパンツが躍動的な元気いっぱいの衣装。動きの激しいダンスで、より輝きます。</schema:description>
     <imas:Whose rdf:resource="Honda_Mio"/>
   </rdf:Description>
   <rdf:Description rdf:about="Tear_drop">
     <schema:name xml:lang="ja">ティアードロップ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ティアードロップ</rdfs:label>
-    <schema:description xml:lang="ja">感動で流れ落ちた一粒の涙のように、キラリと輝く衣装。涙の後には、満面の笑みが咲き誇ります。</rdfs:label>
+    <schema:description xml:lang="ja">感動で流れ落ちた一粒の涙のように、キラリと輝く衣装。涙の後には、満面の笑みが咲き誇ります。</schema:description>
     <imas:Whose rdf:resource="Ohnuma_Kurumi"/>
   </rdf:Description>
   <rdf:Description rdf:about="Chemical_perfume">
     <schema:name xml:lang="ja">ケミカルパフューム</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ケミカルパフューム</rdfs:label>
-    <schema:description xml:lang="ja">視覚も嗅覚も……五感すべてを支配し妄想心を呼び覚ます。気分はまるでトリッパー。踊ればたちまちケミカルな香りが漂う。</rdfs:label>
+    <schema:description xml:lang="ja">視覚も嗅覚も……五感すべてを支配し妄想心を呼び覚ます。気分はまるでトリッパー。踊ればたちまちケミカルな香りが漂う。</schema:description>
     <imas:Whose rdf:resource="Ichinose_Shiki"/>
   </rdf:Description>
   <rdf:Description rdf:about="Kimagure_Tutu">
     <schema:name xml:lang="ja">きまぐれチュチュ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">きまぐれチュチュ</rdfs:label>
-    <schema:description xml:lang="ja">辛めのライダースに甘めのスカートを組み合わせた気まぐれコーデが魅惑的。本当のアタシは、どっち？</rdfs:label>
+    <schema:description xml:lang="ja">辛めのライダースに甘めのスカートを組み合わせた気まぐれコーデが魅惑的。本当のアタシは、どっち？</schema:description>
     <imas:Whose rdf:resource="Miyamoto_Frederica"/>
   </rdf:Description>
   <rdf:Description rdf:about="Idling_idol">
     <schema:name xml:lang="ja">アイドリングアイドル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アイドリングアイドル</rdfs:label>
-    <schema:description xml:lang="ja">働くアイドルにオススメ。いっときの夢と希望を全世界の疲れた人たちへと。小柄な女の子にも重たくない、動きやすい衣装です。</rdfs:label>
+    <schema:description xml:lang="ja">働くアイドルにオススメ。いっときの夢と希望を全世界の疲れた人たちへと。小柄な女の子にも重たくない、動きやすい衣装です。</schema:description>
     <imas:Whose rdf:resource="Futaba_Anzu"/>
   </rdf:Description>
   <rdf:Description rdf:about="Smiley_Wave">
     <schema:name xml:lang="ja">スマイリーウェーブ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スマイリーウェーブ</rdfs:label>
-    <schema:description xml:lang="ja">みんなに元気とニコニコ笑顔を届ける、王道なアイドル衣装。大きく咲いたいくつものリボンがとってもかわいいでぇす♪</rdfs:label>
+    <schema:description xml:lang="ja">みんなに元気とニコニコ笑顔を届ける、王道なアイドル衣装。大きく咲いたいくつものリボンがとってもかわいいでぇす♪</schema:description>
     <imas:Whose rdf:resource="Muramatsu_Sakura"/>
   </rdf:Description>
   <rdf:Description rdf:about="Scratch_Devil">
     <schema:name xml:lang="ja">スクラッチデビル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スクラッチデビル</rdfs:label>
-    <schema:description xml:lang="ja">他人かどうか関係ない。自分が本当に好きなものを着たときにだけ、世界に爪痕を残すことができるのだから。</rdfs:label>
+    <schema:description xml:lang="ja">他人かどうか関係ない。自分が本当に好きなものを着たときにだけ、世界に爪痕を残すことができるのだから。</schema:description>
     <imas:Whose rdf:resource="Hayasaka_Mirei"/>
   </rdf:Description>
   <rdf:Description rdf:about="Genius_Court_No2">
     <schema:name xml:lang="ja">ジーニアスコート2号</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ジーニアスコート2号</rdfs:label>
-    <schema:description xml:lang="ja">日の目を見るまで、倉庫の奥深く厳重に保管されていた秘密兵器。改造は施されているのか、1号はどうなったのか、謎が尽きない。</rdfs:label>
+    <schema:description xml:lang="ja">日の目を見るまで、倉庫の奥深く厳重に保管されていた秘密兵器。改造は施されているのか、1号はどうなったのか、謎が尽きない。</schema:description>
     <imas:Whose rdf:resource="Ikebukuro_Akiha"/>
   </rdf:Description>
   <rdf:Description rdf:about="Mellow_Adagio">
     <schema:name xml:lang="ja">メロウ・アダージオ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">メロウ・アダージオ</rdfs:label>
-    <schema:description xml:lang="ja">見る人全てを惹き付ける、艶やかなシルエットのドレス。高鳴る鼓動の中で、私との時間をただゆっくりと楽しんで。</rdfs:label>
+    <schema:description xml:lang="ja">見る人全てを惹き付ける、艶やかなシルエットのドレス。高鳴る鼓動の中で、私との時間をただゆっくりと楽しんで。</schema:description>
     <imas:Whose rdf:resource="Mifune_Miyu"/>
   </rdf:Description>
   <rdf:Description rdf:about="Coral_splash">
     <schema:name xml:lang="ja">コーラルスプラッシュ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">コーラルスプラッシュ</rdfs:label>
-    <schema:description xml:lang="ja">サンゴ礁を優雅に泳ぐ熱帯魚のように、ひらひら揺らぐリボンが見る人の心を絡め取ります。お魚みたいに舞うのれす～。</rdfs:label>
+    <schema:description xml:lang="ja">サンゴ礁を優雅に泳ぐ熱帯魚のように、ひらひら揺らぐリボンが見る人の心を絡め取ります。お魚みたいに舞うのれす～。</schema:description>
     <imas:Whose rdf:resource="Asari_Nanami"/>
   </rdf:Description>
   <rdf:Description rdf:about="Grand_Super_Nova">
     <schema:name xml:lang="ja">グランスーパーノヴァ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">グランスーパーノヴァ</rdfs:label>
-    <schema:description xml:lang="ja">満天の片隅で輝く一つの光を、永遠の閃光へと昇華させるサイバーな衣装。一目見れば、瞼の裏に焼き付いて離れない。</rdfs:label>
+    <schema:description xml:lang="ja">満天の片隅で輝く一つの光を、永遠の閃光へと昇華させるサイバーな衣装。一目見れば、瞼の裏に焼き付いて離れない。</schema:description>
     <imas:Whose rdf:resource="Takamine_Noa"/>
   </rdf:Description>
   <rdf:Description rdf:about="Inspire_Wave">
     <schema:name xml:lang="ja">インスパイアウェーブ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">インスパイアウェーブ</rdfs:label>
-    <schema:description xml:lang="ja">バンダナリボンが大胆なドレス。アイドル×ロジック＝無限大。計算以上の反応が、少女を可愛くアップデートするでしょう。</rdfs:label>
+    <schema:description xml:lang="ja">バンダナリボンが大胆なドレス。アイドル×ロジック＝無限大。計算以上の反応が、少女を可愛くアップデートするでしょう。</schema:description>
     <imas:Whose rdf:resource="Ohishi_Izumi"/>
   </rdf:Description>
   <rdf:Description rdf:about="No_no_negative">
     <schema:name xml:lang="ja">ノーノー・ネガティブ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ノーノー・ネガティブ</rdfs:label>
-    <schema:description xml:lang="ja">クラシカルなチェックがキュートでファンシーな衣装。ちょっぴりいじらしい少女の、変わりたい気持ちを応援します。</rdfs:label>
+    <schema:description xml:lang="ja">クラシカルなチェックがキュートでファンシーな衣装。ちょっぴりいじらしい少女の、変わりたい気持ちを応援します。</schema:description>
     <imas:Whose rdf:resource="Morikubo_Nono"/>
   </rdf:Description>
   <rdf:Description rdf:about="Pure_snake">
     <schema:name xml:lang="ja">ピュア・スニェーク</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピュア・スニェーク</rdfs:label>
-    <schema:description xml:lang="ja">冬の夜。澄み切った空気。星の灯りに照らされ、ふわりと舞い降りた雪の結晶。純粋で、神秘的な衣装です。</rdfs:label>
+    <schema:description xml:lang="ja">冬の夜。澄み切った空気。星の灯りに照らされ、ふわりと舞い降りた雪の結晶。純粋で、神秘的な衣装です。</schema:description>
     <imas:Whose rdf:resource="Anastasia"/>
   </rdf:Description>
   <rdf:Description rdf:about="Dicotomy_Grown">
     <schema:name xml:lang="ja">ディコトミーグロウン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディコトミーグロウン</rdfs:label>
-    <schema:description xml:lang="ja">可愛さもカッコよさも引き立てる一着です。見た人の心は雷に打たれたキノコのように立ち上がること間違いなし！</rdfs:label>
+    <schema:description xml:lang="ja">可愛さもカッコよさも引き立てる一着です。見た人の心は雷に打たれたキノコのように立ち上がること間違いなし！</schema:description>
     <imas:Whose rdf:resource="Hoshi_Syoko"/>
   </rdf:Description>
   <rdf:Description rdf:about="Gloria_Squeen">
     <schema:name xml:lang="ja">グロリアスクイーン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">グロリアスクイーン</rdfs:label>
-    <schema:description xml:lang="ja">愚図な豚に言葉など不要。エックセレントな佇まいに無駄口をつぐみ、いやしく見惚れることこそが務めなのです。</rdfs:label>
+    <schema:description xml:lang="ja">愚図な豚に言葉など不要。エックセレントな佇まいに無駄口をつぐみ、いやしく見惚れることこそが務めなのです。</schema:description>
     <imas:Whose rdf:resource="Zaizen_Tokiko"/>
   </rdf:Description>
   <rdf:Description rdf:about="Cheerful_marching">
     <schema:name xml:lang="ja">チアフルマーチング</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">チアフルマーチング</rdfs:label>
-    <schema:description xml:lang="ja">頑張る全ての人へ、エールを！そんな気持ちがたっぷり詰まったマーチング風の衣装です。キープオンスマイル！</rdfs:label>
+    <schema:description xml:lang="ja">頑張る全ての人へ、エールを！そんな気持ちがたっぷり詰まったマーチング風の衣装です。キープオンスマイル！</schema:description>
     <imas:Whose rdf:resource="Wakabayashi_Tomoka"/>
   </rdf:Description>
   <rdf:Description rdf:about="Frontier_Mode">
     <schema:name xml:lang="ja">フロンティア★モード</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フロンティア★モード</rdfs:label>
-    <schema:description xml:lang="ja">歩き出したからには、一歩だって立ち止まれない。誰もが想像したことのない最先端を歩き続ける。妥協のない彼女のための一着</rdfs:label>
+    <schema:description xml:lang="ja">歩き出したからには、一歩だって立ち止まれない。誰もが想像したことのない最先端を歩き続ける。妥協のない彼女のための一着</schema:description>
     <imas:Whose rdf:resource="Jougasaki_Mika"/>
   </rdf:Description>
   <rdf:Description rdf:about="Poppin_Decorate">
     <schema:name xml:lang="ja">ポッピン☆デコレート</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ポッピン☆デコレート</rdfs:label>
-    <schema:description xml:lang="ja">元気と好奇心が弾け出しそうな、セクシーでポップな衣装。みんなと一緒に楽しくなれるエネルギッシュなライブに最適！</rdfs:label>
+    <schema:description xml:lang="ja">元気と好奇心が弾け出しそうな、セクシーでポップな衣装。みんなと一緒に楽しくなれるエネルギッシュなライブに最適！</schema:description>
     <imas:Whose rdf:resource="Jougasaki_Rika"/>
   </rdf:Description>
   <rdf:Description rdf:about="Hapy_Plincesse">
     <schema:name xml:lang="ja">ハピハピプリンセス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ハピハピプリンセス</rdfs:label>
-    <schema:description xml:lang="ja">大胆にデコレーションされた、元気いっぱいなハピハピドレス。きゃわいく散りばめられたアクセは自前で用意したらしい。</rdfs:label>
+    <schema:description xml:lang="ja">大胆にデコレーションされた、元気いっぱいなハピハピドレス。きゃわいく散りばめられたアクセは自前で用意したらしい。</schema:description>
     <imas:Whose rdf:resource="Moroboshi_Kirari"/>
   </rdf:Description>
   <rdf:Description rdf:about="Shining_wave">
     <schema:name xml:lang="ja">シャイニングウェーブ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シャイニングウェーブ</rdfs:label>
-    <schema:description xml:lang="ja">着た人と見た人にご利益があるという噂が、まことしやかに流れるエンターテイナーなドレス。儲かりまっか～！</rdfs:label>
+    <schema:description xml:lang="ja">着た人と見た人にご利益があるという噂が、まことしやかに流れるエンターテイナーなドレス。儲かりまっか～！</schema:description>
     <imas:Whose rdf:resource="Tsuchiya_Ako"/>
   </rdf:Description>
   <rdf:Description rdf:about="Angelic_Cute">
     <schema:name xml:lang="ja">エンジェリックキュート</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エンジェリックキュート</rdfs:label>
-    <schema:description xml:lang="ja">カワイイリボン、カワイイ靴、カワイイフリルにネックレス。カワイイをありったけ詰め込んだカワイイ彼女のための一着。</rdfs:label>
+    <schema:description xml:lang="ja">カワイイリボン、カワイイ靴、カワイイフリルにネックレス。カワイイをありったけ詰め込んだカワイイ彼女のための一着。</schema:description>
     <imas:Whose rdf:resource="Koshimizu_Sachiko"/>
   </rdf:Description>
   <rdf:Description rdf:about="Lollipop_Soleil">
     <schema:name xml:lang="ja">ロリポップソレイユ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ロリポップソレイユ</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Ohtsuki_Yui"/>
   </rdf:Description>
   <rdf:Description rdf:about="Heroes_Hope">
     <schema:name xml:lang="ja">ヒーローズホープ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ヒーローズホープ</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Nanjo_Hikaru"/>
   </rdf:Description>
   <rdf:Description rdf:about="Locking_heartbeat">
     <schema:name xml:lang="ja">ロッキングハートビート</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ロッキングハートビート</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Kimura_Natsuki"/>
   </rdf:Description>
   <rdf:Description rdf:about="Natural_locker">
     <schema:name xml:lang="ja">ナチュラルロッカー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ナチュラルロッカー</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Tada_Riina"/>
   </rdf:Description>
   <rdf:Description rdf:about="Fairytale_Dreamer">
     <schema:name xml:lang="ja">メルヒェンドリーマー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">メルヒェンドリーマー</rdfs:label>
-    <schema:description xml:lang="ja">無限大の妄想を形にした、キュートなプリンセス風ドレス。夢見る乙女は止まらない。待っててね、運命の王子様♪</rdfs:label>
+    <schema:description xml:lang="ja">無限大の妄想を形にした、キュートなプリンセス風ドレス。夢見る乙女は止まらない。待っててね、運命の王子様♪</schema:description>
     <imas:Whose rdf:resource="Kita_Hinako"/>
   </rdf:Description>
   <rdf:Description rdf:about="Eternal_Feather">
     <schema:name xml:lang="ja">エターナル・フェザー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エターナル・フェザー</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Takagaki_Kaede"/>
   </rdf:Description>
   <rdf:Description rdf:about="Smash_sparkle">
     <schema:name xml:lang="ja">スマッシュスパークル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スマッシュスパークル</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Mukai_Takumi"/>
   </rdf:Description>
   <rdf:Description rdf:about="Innocent_rose">
     <schema:name xml:lang="ja">イノセントローズ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">イノセントローズ</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Sakurai_Momoka"/>
   </rdf:Description>
   <rdf:Description rdf:about="Sweet_destiny">
     <schema:name xml:lang="ja">スイートデスティニー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スイートデスティニー</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Sakuma_Mayu"/>
   </rdf:Description>
   <rdf:Description rdf:about="Panic_Nightmare">
     <schema:name xml:lang="ja">パニックナイトメア</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">パニックナイトメア</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Shirasaka_Koume"/>
   </rdf:Description>
   <rdf:Description rdf:about="Maboroba_no_utahime">
     <schema:name xml:lang="ja">まぼろばの舞姫</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">まぼろばの舞姫</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Kobayakawa_Sae"/>
   </rdf:Description>
   <rdf:Description rdf:about="Step_future">
     <schema:name xml:lang="ja">ステップフューチャー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ステップフューチャー</rdfs:label>
-    <schema:description xml:lang="ja">チューブトップのスパンコールが笑顔と一緒に輝くコーデ。いつも未来を夢見る少女は新たな夢意を抱いて前進！</rdfs:label>
+    <schema:description xml:lang="ja">チューブトップのスパンコールが笑顔と一緒に輝くコーデ。いつも未来を夢見る少女は新たな夢意を抱いて前進！</schema:description>
     <imas:Whose rdf:resource="Kasuga_Mirai"/>
   </rdf:Description>
   <rdf:Description rdf:about="Ambitious_Tender">
     <schema:name xml:lang="ja">アンビシャステンダー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アンビシャステンダー</rdfs:label>
-    <schema:description xml:lang="ja">大きなリボンとファースカートで可愛くも優雅に仕立てた衣装。これからも仲間と手を取り合って優しい歌声を響かせます。</rdfs:label>
+    <schema:description xml:lang="ja">大きなリボンとファースカートで可愛くも優雅に仕立てた衣装。これからも仲間と手を取り合って優しい歌声を響かせます。</schema:description>
     <imas:Whose rdf:resource="Mogami_Shizuka"/>
   </rdf:Description>
   <rdf:Description rdf:about="Charming_flap">
     <schema:name xml:lang="ja">チャーミングフラップ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">チャーミングフラップ</rdfs:label>
-    <schema:description xml:lang="ja">持ち前の元気な明るさと、ちょっぴり小悪魔なセクシーさを引き出す衣装。イタズラな笑顔が見た人の心をくすぐります。</rdfs:label>
+    <schema:description xml:lang="ja">持ち前の元気な明るさと、ちょっぴり小悪魔なセクシーさを引き出す衣装。イタズラな笑顔が見た人の心をくすぐります。</schema:description>
     <imas:Whose rdf:resource="Ibuki_Tsubasa"/>
   </rdf:Description>
   <rdf:Description rdf:about="Sunlight_Moment">
     <schema:name xml:lang="ja">サンライトモーメント</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">サンライトモーメント</rdfs:label>
-    <schema:description xml:lang="ja">頭のひまわりがワンポイントの爽やかな衣装。輝く太陽のような笑顔で、みんな心はカーニバル！ワタシと一緒に踊ろうヨ♪</rdfs:label>
+    <schema:description xml:lang="ja">頭のひまわりがワンポイントの爽やかな衣装。輝く太陽のような笑顔で、みんな心はカーニバル！ワタシと一緒に踊ろうヨ♪</schema:description>
     <imas:Whose rdf:resource="Shimabara_Elena"/>
   </rdf:Description>
   <rdf:Description rdf:about="Parfe_Princess">
     <schema:name xml:lang="ja">パルフェ・プリンセス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">パルフェ・プリンセス</rdfs:label>
-    <schema:description xml:lang="ja">スイーツのように、甘く可愛くキラキラに飾り付けたお姫様のための衣装。ポイントはスカートに散りばめた、好物のマカロン。</rdfs:label>
+    <schema:description xml:lang="ja">スイーツのように、甘く可愛くキラキラに飾り付けたお姫様のための衣装。ポイントはスカートに散りばめた、好物のマカロン。</schema:description>
     <imas:Whose rdf:resource="Tokugawa_Matsuri"/>
   </rdf:Description>
   <rdf:Description rdf:about="Romance_dreamer">
     <schema:name xml:lang="ja">ロマンスドリーマー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ロマンスドリーマー</rdfs:label>
-    <schema:description xml:lang="ja">フリルをふんだんにあしらい上品で可憐に仕立てたドレス。舞台の上で踊る姿は、物語のヒロインのよう。</rdfs:label>
+    <schema:description xml:lang="ja">フリルをふんだんにあしらい上品で可憐に仕立てたドレス。舞台の上で踊る姿は、物語のヒロインのよう。</schema:description>
     <imas:Whose rdf:resource="Nanao_Yuriko"/>
   </rdf:Description>
   <rdf:Description rdf:about="Star_spirit">
     <schema:name xml:lang="ja">スター・スピリット</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スター・スピリット</rdfs:label>
-    <schema:description xml:lang="ja">アイドル研究の専門家も大満足の正統派アイドル衣装。この衣装をまとって輝く姿は誰よりもアイドル。</rdfs:label>
+    <schema:description xml:lang="ja">アイドル研究の専門家も大満足の正統派アイドル衣装。この衣装をまとって輝く姿は誰よりもアイドル。</schema:description>
     <imas:Whose rdf:resource="Matsuda_Arisa"/>
   </rdf:Description>
   <rdf:Description rdf:about="Pretty_essence">
     <schema:name xml:lang="ja">プリティエッセンス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プリティエッセンス</rdfs:label>
-    <schema:description xml:lang="ja">真っ直ぐで純真で、大人になりたいと背伸びする少女。その姿を、フリルとレースでキュートに包み込んだ一着。</rdfs:label>
+    <schema:description xml:lang="ja">真っ直ぐで純真で、大人になりたいと背伸びする少女。その姿を、フリルとレースでキュートに包み込んだ一着。</schema:description>
     <imas:Whose rdf:resource="Nakatani_Iku"/>
   </rdf:Description>
   <rdf:Description rdf:about="Irodori_komachi">
     <schema:name xml:lang="ja">彩り小町</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">彩り小町</rdfs:label>
-    <schema:description xml:lang="ja">奥ゆかしい大和撫子のために仕立て上げた彩り豊かな衣装。憧れへと歩き続ける少女の姿は、きっと誰かの憧れに。</rdfs:label>
+    <schema:description xml:lang="ja">奥ゆかしい大和撫子のために仕立て上げた彩り豊かな衣装。憧れへと歩き続ける少女の姿は、きっと誰かの憧れに。</schema:description>
     <imas:Whose rdf:resource="Emily_Stewart"/>
   </rdf:Description>
   <rdf:Description rdf:about="Secret_pride">
     <schema:name xml:lang="ja">シークレットプライド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シークレットプライド</rdfs:label>
-    <schema:description xml:lang="ja">静かに輝く月をデザインに加えた気品を感じる一着。夢に向かって弛まぬ努力を続ける誇り高い少女にぴったり。</rdfs:label>
+    <schema:description xml:lang="ja">静かに輝く月をデザインに加えた気品を感じる一着。夢に向かって弛まぬ努力を続ける誇り高い少女にぴったり。</schema:description>
     <imas:Whose rdf:resource="Kitazawa_Shiho"/>
   </rdf:Description>
   <rdf:Description rdf:about="Fluffy_Happiness">
     <schema:name xml:lang="ja">ふわもこハピネス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ふわもこハピネス</rdfs:label>
-    <schema:description xml:lang="ja">散りばめられた星がキラキラと瞬き、牧歌的で幻想的な空間を演出。幸せに満ちた笑顔が仲間もファンも癒します。</rdfs:label>
+    <schema:description xml:lang="ja">散りばめられた星がキラキラと瞬き、牧歌的で幻想的な空間を演出。幸せに満ちた笑顔が仲間もファンも癒します。</schema:description>
     <imas:Whose rdf:resource="Miyao_Miya"/>
   </rdf:Description>
   <rdf:Description rdf:about="Mystery_joker">
     <schema:name xml:lang="ja">ミステリージョーカー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ミステリージョーカー</rdfs:label>
-    <schema:description xml:lang="ja">見た目はミステリアス。でも、心の中はいつだって色彩豊か。秘められたその色が見えたとき、あなたの心は彼女の手中に……。</rdfs:label>
+    <schema:description xml:lang="ja">見た目はミステリアス。でも、心の中はいつだって色彩豊か。秘められたその色が見えたとき、あなたの心は彼女の手中に……。</schema:description>
     <imas:Whose rdf:resource="Makabe_Mizuki"/>
   </rdf:Description>
   <rdf:Description rdf:about="Platonic_Iris">
     <schema:name xml:lang="ja">プラトニックアイリス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プラトニックアイリス</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Shiraishi_Tsumugi"/>
   </rdf:Description>
   <rdf:Description rdf:about="Advanced_Garley">
     <schema:name xml:lang="ja">アドバンスドガーリー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アドバンスドガーリー</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Tokoro_Megumi"/>
   </rdf:Description>
   <rdf:Description rdf:about="Exciting_Explorer">
     <schema:name xml:lang="ja">わくわくエクスプローラ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">わくわくエクスプローラ</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Ogami_Tamaki"/>
   </rdf:Description>
   <rdf:Description rdf:about="Starlight_tune">
     <schema:name xml:lang="ja">スターライトチューン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スターライトチューン</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Julia"/>
   </rdf:Description>
   <rdf:Description rdf:about="Elegant_Fleur">
     <schema:name xml:lang="ja">エレガントフルール</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エレガントフルール</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Baba_Konomi"/>
   </rdf:Description>
   <rdf:Description rdf:about="Tokimeki_Flowers">
     <schema:name xml:lang="ja">トキメキフラワーズ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">トキメキフラワーズ</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Hakozaki_Serika"/>
   </rdf:Description>
   <rdf:Description rdf:about="Happy_surprise">
     <schema:name xml:lang="ja">ハッピーサプライズ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ハッピーサプライズ</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Maihama_Ayumu"/>
   </rdf:Description>
   <rdf:Description rdf:about="Majesty_Anima">
     <schema:name xml:lang="ja">マジェスティアニマ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">マジェスティアニマ</rdfs:label>
-    <schema:description xml:lang="ja">彩られたナポレオンジャケットが甘さと堅さを感じさせる正統派アイドル衣装。積み重ねた経験を糧にして、トップを目指す！</rdfs:label>
+    <schema:description xml:lang="ja">彩られたナポレオンジャケットが甘さと堅さを感じさせる正統派アイドル衣装。積み重ねた経験を糧にして、トップを目指す！</schema:description>
     <imas:Whose rdf:resource="Amagase_Toma"/>
   </rdf:Description>
   <rdf:Description rdf:about="Dolce_Amore">
     <schema:name xml:lang="ja">ドルチェ・アモーレ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ドルチェ・アモーレ</rdfs:label>
-    <schema:description xml:lang="ja">落ち着いたジャケットに合わせた遊び心のあるスカーフが、大人の余裕を感じさせます。甘い囁きを、天使の君に。</rdfs:label>
+    <schema:description xml:lang="ja">落ち着いたジャケットに合わせた遊び心のあるスカーフが、大人の余裕を感じさせます。甘い囁きを、天使の君に。</schema:description>
     <imas:Whose rdf:resource="Ijuin_Hokuto"/>
   </rdf:Description>
   <rdf:Description rdf:about="Shakit_off">
     <schema:name xml:lang="ja">シェイキットオフ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シェイキットオフ</rdfs:label>
-    <schema:description xml:lang="ja">素肌が眩しいノースリーブが、軽快で大胆なダンスを魅せる。つまんないことは忘れちゃって、みんなで楽しく踊ろうよ！</rdfs:label>
+    <schema:description xml:lang="ja">素肌が眩しいノースリーブが、軽快で大胆なダンスを魅せる。つまんないことは忘れちゃって、みんなで楽しく踊ろうよ！</schema:description>
     <imas:Whose rdf:resource="Mitarai_Shota"/>
   </rdf:Description>
   <rdf:Description rdf:about="Playful_shine">
     <schema:name xml:lang="ja">プレイフルシャイン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プレイフルシャイン</rdfs:label>
-    <schema:description xml:lang="ja">場所は変われど見上げたお天道様は変わらない。ステージ上で輝く笑顔が心を明るく照らします。この衣装、一生大事にするぜ！</rdfs:label>
+    <schema:description xml:lang="ja">場所は変われど見上げたお天道様は変わらない。ステージ上で輝く笑顔が心を明るく照らします。この衣装、一生大事にするぜ！</schema:description>
     <imas:Whose rdf:resource="Tendo_Teru"/>
   </rdf:Description>
   <rdf:Description rdf:about="Lancet_flash">
     <schema:name xml:lang="ja">ランセットフラッシュ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ランセットフラッシュ</rdfs:label>
-    <schema:description xml:lang="ja">品格と矜持を感じさせる絢爛な一着。鋭い輝きを放つその姿は心の壁をも切り拓き、見るもの全ての記憶に残る。</rdfs:label>
+    <schema:description xml:lang="ja">品格と矜持を感じさせる絢爛な一着。鋭い輝きを放つその姿は心の壁をも切り拓き、見るもの全ての記憶に残る。</schema:description>
     <imas:Whose rdf:resource="Sakuraba_Kaoru"/>
   </rdf:Description>
   <rdf:Description rdf:about="Eye_tail_wing">
     <schema:name xml:lang="ja">アイテールウイング</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アイテールウイング</rdfs:label>
-    <schema:description xml:lang="ja">風を背に受けステージへ！ジャケットをはためかせ舞台を走る姿、空を舞う鳥のよう。雲の上に、テイクオフ！</rdfs:label>
+    <schema:description xml:lang="ja">風を背に受けステージへ！ジャケットをはためかせ舞台を走る姿、空を舞う鳥のよう。雲の上に、テイクオフ！</schema:description>
     <imas:Whose rdf:resource="Kashiwagi_Tsubasa"/>
   </rdf:Description>
   <rdf:Description rdf:about="Seele_Spielen">
     <schema:name xml:lang="ja">ゼーレ・シュピーレン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ゼーレ・シュピーレン</rdfs:label>
-    <schema:description xml:lang="ja">クレッシェンド、君を想って奏でよう。ディミヌエンド、僕の想いを奏でよう。全てを込めた音を、君に。</rdfs:label>
+    <schema:description xml:lang="ja">クレッシェンド、君を想って奏でよう。ディミヌエンド、僕の想いを奏でよう。全てを込めた音を、君に。</schema:description>
     <imas:Whose rdf:resource="Tsuzuki_Kei"/>
   </rdf:Description>
   <rdf:Description rdf:about="Noble_Concerto">
     <schema:name xml:lang="ja">ノーブルコンチェルト</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ノーブルコンチェルト</rdfs:label>
-    <schema:description xml:lang="ja">ゆったりしたジャケットコートを羽織り、奏でる曲に合わせて、ふわりと袖を揺らす。音に揺れるは布か、心か。</rdfs:label>
+    <schema:description xml:lang="ja">ゆったりしたジャケットコートを羽織り、奏でる曲に合わせて、ふわりと袖を揺らす。音に揺れるは布か、心か。</schema:description>
     <imas:Whose rdf:resource="Kagura_Rei"/>
   </rdf:Description>
   <rdf:Description rdf:about="Brazing_hero">
     <schema:name xml:lang="ja">ブレイジングヒーロー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブレイジングヒーロー</rdfs:label>
-    <schema:description xml:lang="ja">いつもの鋭い眼光も、爽やかな着こなしで優しく見えるかも？みんなの笑顔を守るため、次のステージへ今日も出動！</rdfs:label>
+    <schema:description xml:lang="ja">いつもの鋭い眼光も、爽やかな着こなしで優しく見えるかも？みんなの笑顔を守るため、次のステージへ今日も出動！</schema:description>
     <imas:Whose rdf:resource="Akuno_Hideo"/>
   </rdf:Description>
   <rdf:Description rdf:about="Peaceful_rack">
     <schema:name xml:lang="ja">ピースフルラック</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピースフルラック</rdfs:label>
-    <schema:description xml:lang="ja">何があっても前へ進む、不撓不屈の精神がモチーフ。夢へ向かって燃え上がれ！※火の取り扱いにはご用心。</rdfs:label>
+    <schema:description xml:lang="ja">何があっても前へ進む、不撓不屈の精神がモチーフ。夢へ向かって燃え上がれ！※火の取り扱いにはご用心。</schema:description>
     <imas:Whose rdf:resource="Kimura_Ryu"/>
   </rdf:Description>
   <rdf:Description rdf:about="Smile_Commander">
     <schema:name xml:lang="ja">スマイル・コマンダー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スマイル・コマンダー</rdfs:label>
-    <schema:description xml:lang="ja">ノースリーブのトップスがワイルドさを感じさせる一着。鍛えた肉体を存分に活かしてあなたの笑顔を守ります。</rdfs:label>
+    <schema:description xml:lang="ja">ノースリーブのトップスがワイルドさを感じさせる一着。鍛えた肉体を存分に活かしてあなたの笑顔を守ります。</schema:description>
     <imas:Whose rdf:resource="Shingen_Seiji"/>
   </rdf:Description>
   <rdf:Description rdf:about="Pure_flavor">
     <schema:name xml:lang="ja">ピュアフレーバー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピュアフレーバー</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Okamura_Nao"/>
   </rdf:Description>
   <rdf:Description rdf:about="Minimom_Bigster">
     <schema:name xml:lang="ja">ミニマムビッグスター</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ミニマムビッグスター</rdfs:label>
-    <schema:description xml:lang="ja">小さな体につまった、だれにも負けないビッグな目標。最強にカッコいいアイドルを目指す姿が光ります。</rdfs:label>
+    <schema:description xml:lang="ja">小さな体につまった、だれにも負けないビッグな目標。最強にカッコいいアイドルを目指す姿が光ります。</schema:description>
     <imas:Whose rdf:resource="Tachibana_Shiro"/>
   </rdf:Description>
   <rdf:Description rdf:about="Yumekawa_Angel">
     <schema:name xml:lang="ja">ゆめかわエンジェル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ゆめかわエンジェル</rdfs:label>
-    <schema:description xml:lang="ja">「だーいすき」なかわいいが詰め込まれた一着。甘くてやわらかい衣装をまとう天使の笑顔に、みんなの心も夢の中。</rdfs:label>
+    <schema:description xml:lang="ja">「だーいすき」なかわいいが詰め込まれた一着。甘くてやわらかい衣装をまとう天使の笑顔に、みんなの心も夢の中。</schema:description>
     <imas:Whose rdf:resource="Himeno_Kanon"/>
   </rdf:Description>
   <rdf:Description rdf:about="Wave_the_flag">
     <schema:name xml:lang="ja">ウェイブザフラッグ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ウェイブザフラッグ</rdfs:label>
-    <schema:description xml:lang="ja">大きなシルエットを背負うのはこれまで仲間たちと紡いできたたくさんの物語があるから。夢に向かって、これからも。</rdfs:label>
+    <schema:description xml:lang="ja">大きなシルエットを背負うのはこれまで仲間たちと紡いできたたくさんの物語があるから。夢に向かって、これからも。</schema:description>
     <imas:Whose rdf:resource="Akizuki_Ryo_315"/>
   </rdf:Description>
   <rdf:Description rdf:about="Blooming_smile">
     <schema:name xml:lang="ja">ブルーミングスマイル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブルーミングスマイル</rdfs:label>
-    <schema:description xml:lang="ja">足回りを警戒にまとめたコーデ。躍動感にあふれるパフォーマンスで、みんなの顔をはなまる笑顔にしてみせるけぇのぉ！</rdfs:label>
+    <schema:description xml:lang="ja">足回りを警戒にまとめたコーデ。躍動感にあふれるパフォーマンスで、みんなの顔をはなまる笑顔にしてみせるけぇのぉ！</schema:description>
     <imas:Whose rdf:resource="Kabuto_Daigo"/>
   </rdf:Description>
   <rdf:Description rdf:about="Primal_sail">
     <schema:name xml:lang="ja">プライマルセイル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プライマルセイル</rdfs:label>
-    <schema:description xml:lang="ja">色鮮やかなロングストールが、動きに大胆な印象をプラス。新たな舞台で紡がれる物語を、どうぞご期待ください。</rdfs:label>
+    <schema:description xml:lang="ja">色鮮やかなロングストールが、動きに大胆な印象をプラス。新たな舞台で紡がれる物語を、どうぞご期待ください。</schema:description>
     <imas:Whose rdf:resource="Tsukumo_Kazuki"/>
   </rdf:Description>
   <rdf:Description rdf:about="Stoic_sweeper">
     <schema:name xml:lang="ja">ストイックスイーパー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ストイックスイーパー</rdfs:label>
-    <schema:description xml:lang="ja">飄々とした態度の裏にある、他人を想う優しさを織り込んだ一着。磨き上げた歌と踊りで、見るものの心を浄化します。</rdfs:label>
+    <schema:description xml:lang="ja">飄々とした態度の裏にある、他人を想う優しさを織り込んだ一着。磨き上げた歌と踊りで、見るものの心を浄化します。</schema:description>
     <imas:Whose rdf:resource="Kuzunoha_Amehiko"/>
   </rdf:Description>
   <rdf:Description rdf:about="Swinging_Bird">
     <schema:name xml:lang="ja">スインギング・バード</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スインギング・バード</rdfs:label>
-    <schema:description xml:lang="ja">自然体な立ち居振る舞いの中にキラリと光る魅力を際立たせる遊び心のある衣装。ありのまま夢の舞台にいざ立たん。</rdfs:label>
+    <schema:description xml:lang="ja">自然体な立ち居振る舞いの中にキラリと光る魅力を際立たせる遊び心のある衣装。ありのまま夢の舞台にいざ立たん。</schema:description>
     <imas:Whose rdf:resource="Kitamura_Sora"/>
   </rdf:Description>
   <rdf:Description rdf:about="Wonderful_Marine">
     <schema:name xml:lang="ja">ワンダフルマリン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ワンダフルマリン</rdfs:label>
-    <schema:description xml:lang="ja">未知なるフロンティアを求める探検家をイメージした一着。新たなステージと言う名の大海原へ、いざ漕ぎ出そう！</rdfs:label>
+    <schema:description xml:lang="ja">未知なるフロンティアを求める探検家をイメージした一着。新たなステージと言う名の大海原へ、いざ漕ぎ出そう！</schema:description>
     <imas:Whose rdf:resource="Koron_Chris"/>
   </rdf:Description>
   <rdf:Description rdf:about="My_Favorite">
     <schema:name xml:lang="ja">マイ・フェイバリット</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">マイ・フェイバリット</rdfs:label>
-    <schema:description xml:lang="ja">「大好き」が詰まった衣装でパピッとカワイくドレスアップ！まるで魔法をかけたみたいに、自分らしい自分でいられます。</rdfs:label>
+    <schema:description xml:lang="ja">「大好き」が詰まった衣装でパピッとカワイくドレスアップ！まるで魔法をかけたみたいに、自分らしい自分でいられます。</schema:description>
     <imas:Whose rdf:resource="Mizushima_Saki"/>
   </rdf:Description>
   <rdf:Description rdf:about="Majimega_Emotion">
     <schema:name xml:lang="ja">マジメガエモーション</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">マジメガエモーション</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Iseya_Shiki"/>
   </rdf:Description>
   <rdf:Description rdf:about="Shiawase_Magic">
     <schema:name xml:lang="ja">シアワセ・マジック</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シアワセ・マジック</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Pierre"/>
   </rdf:Description>
   <rdf:Description rdf:about="Conversion_Heart">
     <schema:name xml:lang="ja">コンバウンド・ハート</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">コンバウンド・ハート</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Yamashita_Jiro"/>
   </rdf:Description>
   <rdf:Description rdf:about="Blaze_soul">
     <schema:name xml:lang="ja">ブレイズソウル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブレイズソウル</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Akai_Suzaku"/>
   </rdf:Description>
   <rdf:Description rdf:about="Ice_due_diligence">
     <schema:name xml:lang="ja">アイスディリジェンス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アイスディリジェンス</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Kurono_Genbu"/>
   </rdf:Description>
   <rdf:Description rdf:about="Snap_fang">
     <schema:name xml:lang="ja">スナップファング</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スナップファング</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Kizaki_Ren"/>
   </rdf:Description>
   <rdf:Description rdf:about="Kabuku_honryu_no_shirabe">
     <schema:name xml:lang="ja">傾く奔流の調べ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">傾く奔流の調べ</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Hanamura_Shoma"/>
   </rdf:Description>
   <rdf:Description rdf:about="Flappy_wing">
     <schema:name xml:lang="ja">フラッピーウィング</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フラッピーウィング</rdfs:label>
-    <schema:description xml:lang="ja">テーラードジャネットに合わせたふわふわのスカートがキュートなコーデ。新たな空への期待を胸に少女はステージへと羽ばたく。</rdfs:label>
+    <schema:description xml:lang="ja">テーラードジャネットに合わせたふわふわのスカートがキュートなコーデ。新たな空への期待を胸に少女はステージへと羽ばたく。</schema:description>
     <imas:Whose rdf:resource="Sakuragi_Mano"/>
   </rdf:Description>
   <rdf:Description rdf:about="Brink_wish">
     <schema:name xml:lang="ja">ブリンクウィッシュ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブリンクウィッシュ</rdfs:label>
-    <schema:description xml:lang="ja">会場の視線を独り占めしてしまうこと間違い無しの豪華な一着。期待も不安もドレスが包む、お守りが入る隠しポケット付き。</rdfs:label>
+    <schema:description xml:lang="ja">会場の視線を独り占めしてしまうこと間違い無しの豪華な一着。期待も不安もドレスが包む、お守りが入る隠しポケット付き。</schema:description>
     <imas:Whose rdf:resource="Kazano_Hiori"/>
   </rdf:Description>
   <rdf:Description rdf:about="Sprinkles_smile">
     <schema:name xml:lang="ja">スプリンクルスマイル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スプリンクルスマイル</rdfs:label>
-    <schema:description xml:lang="ja">太陽のような明るい笑顔が輝けば誰もが心の中まで晴れ渡る。元気いっぱいな少女のための、動きやすさを重視した衣装。</rdfs:label>
+    <schema:description xml:lang="ja">太陽のような明るい笑顔が輝けば誰もが心の中まで晴れ渡る。元気いっぱいな少女のための、動きやすさを重視した衣装。</schema:description>
     <imas:Whose rdf:resource="Hachimiya_Meguru"/>
   </rdf:Description>
   <rdf:Description rdf:about="Urban_Blossom">
     <schema:name xml:lang="ja">アーバンブロッサム</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アーバンブロッサム</rdfs:label>
-    <schema:description xml:lang="ja">ガーリッシュなコーデはいつだってティーンの憧れ。可愛く着こなす姿を見せてみんなのことを魅了しちゃうよ☆</rdfs:label>
+    <schema:description xml:lang="ja">ガーリッシュなコーデはいつだってティーンの憧れ。可愛く着こなす姿を見せてみんなのことを魅了しちゃうよ☆</schema:description>
     <imas:Whose rdf:resource="Osaki_Amana"/>
   </rdf:Description>
   <rdf:Description rdf:about="Lovely_Bloom">
     <schema:name xml:lang="ja">ラブリーブルーム</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ラブリーブルーム</rdfs:label>
-    <schema:description xml:lang="ja">にげたくなっても勇気を出して、へやの外に飛び出せばスターに大へんしん！自信を引き出し、先へと進む勇気をくれる一着です。</rdfs:label>
+    <schema:description xml:lang="ja">にげたくなっても勇気を出して、へやの外に飛び出せばスターに大へんしん！自信を引き出し、先へと進む勇気をくれる一着です。</schema:description>
     <imas:Whose rdf:resource="Osaki_Tenka"/>
   </rdf:Description>
   <rdf:Description rdf:about="Graceful_Lillian">
     <schema:name xml:lang="ja">グレイスフルリリアン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">グレイスフルリリアン</rdfs:label>
-    <schema:description xml:lang="ja">ゆったりとしたストールが大人のエレガントさを演出。ステージに立てば大輪の花が咲き誇り、夢のような世界が広がる。</rdfs:label>
+    <schema:description xml:lang="ja">ゆったりとしたストールが大人のエレガントさを演出。ステージに立てば大輪の花が咲き誇り、夢のような世界が広がる。</schema:description>
     <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
   </rdf:Description>
   <rdf:Description rdf:about="Reversed_cute">
     <schema:name xml:lang="ja">リバースド♡キュート</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">リバースド♡キュート</rdfs:label>
-    <schema:description xml:lang="ja">ふんわりフォルムのトップスとタイトスカートのメリハリが素敵な衣装。可愛い表情を、バッチリ際立たせます。</rdfs:label>
+    <schema:description xml:lang="ja">ふんわりフォルムのトップスとタイトスカートのメリハリが素敵な衣装。可愛い表情を、バッチリ際立たせます。</schema:description>
     <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
   </rdf:Description>
   <rdf:Description rdf:about="Hokago_checked">
     <schema:name xml:lang="ja">ホーカゴチェック!</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ホーカゴチェック!</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Komiya_Kaho"/>
   </rdf:Description>
   <rdf:Description rdf:about="Afascinale_of_fleeting_moment">
     <schema:name xml:lang="ja">玉響のアファシナーレ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">玉響のアファシナーレ</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Shirase_Sakuya"/>
   </rdf:Description>
   <rdf:Description rdf:about="Unknown_Eyes">
     <schema:name xml:lang="ja">アンノウンアイズ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アンノウンアイズ</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Serizawa_Asahi"/>
   </rdf:Description>
   <rdf:Description rdf:about="Onnkeirinnrinn">
     <schema:name xml:lang="ja">音・繋・輪・輪</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">音・繋・輪・輪</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Yukoku_Kiriko"/>
   </rdf:Description>
   <rdf:Description rdf:about="Irodoru_omoi">
     <schema:name xml:lang="ja">彩る想ひ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">彩る想ひ</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Morino_Rinze"/>
   </rdf:Description>
   <rdf:Description rdf:about="Starley_Futures_Poplinks">
     <schema:name xml:lang="ja">スターリー・フューチャーズ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スターリー・フューチャーズ</rdfs:label>
-    <schema:description xml:lang="ja">未来に向かって星のように輝き続けるアイドルたちの特別な衣装。さぁ笑って、「これからも、アイドル!!!!!」</rdfs:label>
+    <schema:description xml:lang="ja">未来に向かって星のように輝き続けるアイドルたちの特別な衣装。さぁ笑って、「これからも、アイドル!!!!!」</schema:description>
     <imas:Whose rdf:resource="Amami_Haruka"/>
     <imas:Whose rdf:resource="Shimamura_Uzuki"/>
     <imas:Whose rdf:resource="Kasuga_Mirai"/>
@@ -774,73 +774,73 @@
   <rdf:Description rdf:about="Bunny_pastel">
     <schema:name xml:lang="ja">バニー・パステル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">バニー・パステル</rdfs:label>
-    <schema:description xml:lang="ja">うさちゃんがくれる幸せを、ファンの皆にプレゼント。可愛い仕草とイタズラな発想でエッグハントを盛り上げます。</rdfs:label>
+    <schema:description xml:lang="ja">うさちゃんがくれる幸せを、ファンの皆にプレゼント。可愛い仕草とイタズラな発想でエッグハントを盛り上げます。</schema:description>
     <imas:Whose rdf:resource="Minase_Iori"/>
   </rdf:Description>
   <rdf:Description rdf:about="Poppin_pastel">
     <schema:name xml:lang="ja">ポッピン・パステル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ポッピン・パステル</rdfs:label>
-    <schema:description xml:lang="ja">春めく季節にぴったりの、心が弾むような一着。躍動感のあるステップで、爽やかな春風をお届けします。</rdfs:label>
+    <schema:description xml:lang="ja">春めく季節にぴったりの、心が弾むような一着。躍動感のあるステップで、爽やかな春風をお届けします。</schema:description>
     <imas:Whose rdf:resource="Akizuki_Ryo_315"/>
   </rdf:Description>
   <rdf:Description rdf:about="Fluffy_pastel">
     <schema:name xml:lang="ja">フラッフィ・パステル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フラッフィ・パステル</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Osaki_Amana"/>
   </rdf:Description>
   <rdf:Description rdf:about="Secret_maid">
     <schema:name xml:lang="ja">ナイショノメイド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ナイショノメイド</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Miyamoto_Frederica"/>
   </rdf:Description>
   <rdf:Description rdf:about="Himeyaka_kyushi">
     <schema:name xml:lang="ja">秘めやか給仕</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">秘めやか給仕</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Emily_Stewart"/>
   </rdf:Description>
   <rdf:Description rdf:about="Marvelous_Batler">
     <schema:name xml:lang="ja">マーベラスバトラー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">マーベラスバトラー</rdfs:label>
-    <schema:description xml:lang="ja">一癖も二癖もある使用人達をまとめ上げる、一流の使用人頭。数多ある仕事を完璧にこなす。最も得意な家事は掃除。</rdfs:label>
+    <schema:description xml:lang="ja">一癖も二癖もある使用人達をまとめ上げる、一流の使用人頭。数多ある仕事を完璧にこなす。最も得意な家事は掃除。</schema:description>
     <imas:Whose rdf:resource="Kuzunoha_Amehiko"/>
   </rdf:Description>
   <rdf:Description rdf:about="Step_On_Beat">
     <schema:name xml:lang="ja">ステップオンビート</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ステップオンビート</rdfs:label>
-    <schema:description xml:lang="ja">軽やかで動きやすい衣装。爽やかな初夏の風に乗って、走り出したら止まらない。さあ、一緒に駆け出そう！</rdfs:label>
+    <schema:description xml:lang="ja">軽やかで動きやすい衣装。爽やかな初夏の風に乗って、走り出したら止まらない。さあ、一緒に駆け出そう！</schema:description>
     <imas:Whose rdf:resource="Kikuchi_Makoto"/>
   </rdf:Description>
   <rdf:Description rdf:about="Top_speed">
     <schema:name xml:lang="ja">トップスピード!</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">トップスピード!</rdfs:label>
-    <schema:description xml:lang="ja"></rdfs:label>
+    <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Amagase_Toma"/>
   </rdf:Description>
   <rdf:Description rdf:about="shooting_star">
     <schema:name xml:lang="ja">シューティングスター</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シューティングスター</rdfs:label>
-    <schema:description xml:lang="ja">アクティブな動きにぴったりな輝く素材の衣装。ステージの上を走る姿は煌めく流星のよう。あなたの願いを形にします！</rdfs:label>
+    <schema:description xml:lang="ja">アクティブな動きにぴったりな輝く素材の衣装。ステージの上を走る姿は煌めく流星のよう。あなたの願いを形にします！</schema:description>
     <imas:Whose rdf:resource="Hachimiya_Meguru"/>
   </rdf:Description>
   <rdf:Description rdf:about="Purery_bride">
     <schema:name xml:lang="ja">ピュアリーブライド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピュアリーブライド</rdfs:label>
-    <schema:description xml:lang="ja">純粋な心を優しく彩るウェディングドレス風の衣装。小鳥のさえずりに乗せ、溢れそうな愛と幸運を届けたい。</rdfs:label>
+    <schema:description xml:lang="ja">純粋な心を優しく彩るウェディングドレス風の衣装。小鳥のさえずりに乗せ、溢れそうな愛と幸運を届けたい。</schema:description>
     <imas:Whose rdf:resource="Hoshii_Miki"/>
   </rdf:Description>
   <rdf:Description rdf:about="Brilliant_Bride">
     <schema:name xml:lang="ja">ブリリアントブライド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブリリアントブライド</rdfs:label>
-    <schema:description xml:lang="ja">煌めき続ける彼女にふさわしいウェディングドレス風の衣装。輝くガラスの靴を履いて、あなたと一緒に歩んでいきたい。</rdfs:label>
+    <schema:description xml:lang="ja">煌めき続ける彼女にふさわしいウェディングドレス風の衣装。輝くガラスの靴を履いて、あなたと一緒に歩んでいきたい。</schema:description>
     <imas:Whose rdf:resource="Jougasaki_Mika"/>
   </rdf:Description>
   <rdf:Description rdf:about="Floral_bride">
     <schema:name xml:lang="ja">フローラルブライド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローラルブライド</rdfs:label>
-    <schema:description xml:lang="ja">祝福の風に花の香りが満ちるウェディングドレス風の衣装。胸の奥にある言葉にできないこの想い、歌に乗せて伝えたい。</rdfs:label>
+    <schema:description xml:lang="ja">祝福の風に花の香りが満ちるウェディングドレス風の衣装。胸の奥にある言葉にできないこの想い、歌に乗せて伝えたい。</schema:description>
     <imas:Whose rdf:resource="Shiraishi_Tsumugi"/>
   </rdf:Description>
 </rdf:RDF>

--- a/RDFs/Clothes/PopLinks.rdf
+++ b/RDFs/Clothes/PopLinks.rdf
@@ -325,14 +325,14 @@
     <imas:Whose rdf:resource="Morikubo_Nono"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Pure_Snake">
+  <rdf:Description rdf:about="Pure_Sneg">
     <schema:name xml:lang="ja">ピュア・スニェーク</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピュア・スニェーク</rdfs:label>
     <schema:description xml:lang="ja">冬の夜。澄み切った空気。星の灯りに照らされ、ふわりと舞い降りた雪の結晶。純粋で、神秘的な衣装です。</schema:description>
     <imas:Whose rdf:resource="Anastasia"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Dicotomy_Grown">
+  <rdf:Description rdf:about="Dichotomy_Groan">
     <schema:name xml:lang="ja">ディコトミーグロウン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディコトミーグロウン</rdfs:label>
     <schema:description xml:lang="ja">可愛さもカッコよさも引き立てる一着です。見た人の心は雷に打たれたキノコのように立ち上がること間違いなし！</schema:description>
@@ -556,7 +556,7 @@
     <imas:Whose rdf:resource="Kitazawa_Shiho"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Fluffy_Happiness">
+  <rdf:Description rdf:about="Fuwamoko_Happiness">
     <schema:name xml:lang="ja">ふわもこハピネス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ふわもこハピネス</rdfs:label>
     <schema:description xml:lang="ja">散りばめられた星がキラキラと瞬き、牧歌的で幻想的な空間を演出。幸せに満ちた笑顔が仲間もファンも癒します。</schema:description>
@@ -584,7 +584,7 @@
     <imas:Whose rdf:resource="Tokoro_Megumi"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Exciting_Explorer">
+  <rdf:Description rdf:about="Wakuwaku_Explorer">
     <schema:name xml:lang="ja">わくわくエクスプローラ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">わくわくエクスプローラ</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
@@ -633,7 +633,7 @@
     <imas:Whose rdf:resource="Ijuin_Hokuto"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Shakit_Off">
+  <rdf:Description rdf:about="Shake_It_Off">
     <schema:name xml:lang="ja">シェイキットオフ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シェイキットオフ</rdfs:label>
     <schema:description xml:lang="ja">素肌が眩しいノースリーブが、軽快で大胆なダンスを魅せる。つまんないことは忘れちゃって、みんなで楽しく踊ろうよ！</schema:description>
@@ -654,7 +654,7 @@
     <imas:Whose rdf:resource="Sakuraba_Kaoru"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Eye_Tail_Wing">
+  <rdf:Description rdf:about="Aether_Wing">
     <schema:name xml:lang="ja">アイテールウイング</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アイテールウイング</rdfs:label>
     <schema:description xml:lang="ja">風を背に受けステージへ！ジャケットをはためかせ舞台を走る姿、空を舞う鳥のよう。雲の上に、テイクオフ！</schema:description>
@@ -699,11 +699,11 @@
   <rdf:Description rdf:about="Pure_Flavor">
     <schema:name xml:lang="ja">ピュアフレーバー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピュアフレーバー</rdfs:label>
-    <schema:description xml:lang="ja"></schema:description>
+    <schema:description xml:lang="ja">普段は弱気な自分でも、衣装を着れば立派なアイドル！純粋で真っ直ぐな思いを届けて、みんなを笑顔に変えてみせます！</schema:description>
     <imas:Whose rdf:resource="Okamura_Nao"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Minimom_Bigster">
+  <rdf:Description rdf:about="Minimum_Bigster">
     <schema:name xml:lang="ja">ミニマムビッグスター</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ミニマムビッグスター</rdfs:label>
     <schema:description xml:lang="ja">小さな体につまった、だれにも負けないビッグな目標。最強にカッコいいアイドルを目指す姿が光ります。</schema:description>
@@ -727,7 +727,7 @@
   <rdf:Description rdf:about="Blooming_Smile">
     <schema:name xml:lang="ja">ブルーミングスマイル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブルーミングスマイル</rdfs:label>
-    <schema:description xml:lang="ja">足回りを警戒にまとめたコーデ。躍動感にあふれるパフォーマンスで、みんなの顔をはなまる笑顔にしてみせるけぇのぉ！</schema:description>
+    <schema:description xml:lang="ja">足回りを軽快にまとめたコーデ。躍動感にあふれるパフォーマンスで、みんなの顔をはなまる笑顔にしてみせるけぇのぉ！</schema:description>
     <imas:Whose rdf:resource="Kabuto_Daigo"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -769,20 +769,20 @@
   <rdf:Description rdf:about="Majimega_Emotion">
     <schema:name xml:lang="ja">マジメガエモーション</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">マジメガエモーション</rdfs:label>
-    <schema:description xml:lang="ja"></schema:description>
+    <schema:description xml:lang="ja">アツい心で歌声を届ける彼にぴったりの、メガMAXカッコイイ衣装。心揺さぶるステージから、煌めくミライへ、ハイジャンプ！</schema:description>
     <imas:Whose rdf:resource="Iseya_Shiki"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Shiawase_Magic">
     <schema:name xml:lang="ja">シアワセ・マジック</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シアワセ・マジック</rdfs:label>
-    <schema:description xml:lang="ja"></schema:description>
+    <schema:description xml:lang="ja">お菓子を大胆にあしらった一着。みんなが笑顔になれるように、シアワセな夢をお届けします。もちろん、カエールもいっしょ！</schema:description>
     <imas:Whose rdf:resource="Pierre"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Conversion_Heart">
-    <schema:name xml:lang="ja">コンバウンド・ハート</schema:name>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">コンバウンド・ハート</rdfs:label>
+  <rdf:Description rdf:about="Compound_Heart">
+    <schema:name xml:lang="ja">コンパウンド・ハート</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">コンパウンド・ハート</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Yamashita_Jiro"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
@@ -790,21 +790,21 @@
   <rdf:Description rdf:about="Blaze_Soul">
     <schema:name xml:lang="ja">ブレイズソウル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブレイズソウル</rdfs:label>
-    <schema:description xml:lang="ja"></schema:description>
+    <schema:description xml:lang="ja">悪を許さない燃える魂をより輝かせる衣装。全身全霊を捧げる覚悟を胸に、メンチ切って走り抜ける！</schema:description>
     <imas:Whose rdf:resource="Akai_Suzaku"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Ice_Due_Diligence">
+  <rdf:Description rdf:about="Ice_Diligence">
     <schema:name xml:lang="ja">アイスディリジェンス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アイスディリジェンス</rdfs:label>
-    <schema:description xml:lang="ja"></schema:description>
+    <schema:description xml:lang="ja">悪に容赦しないクールな魂の持ち主にふさわしい一着。百錬成鋼、日々精進あるのみ。真っ向勝負の行く末を見届けろ。</schema:description>
     <imas:Whose rdf:resource="Kurono_Genbu"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Snap_Fang">
     <schema:name xml:lang="ja">スナップファング</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スナップファング</rdfs:label>
-    <schema:description xml:lang="ja"></schema:description>
+    <schema:description xml:lang="ja">「最強」を体現し次々と繰り出す素早い動きを際立たせる一着。鋭い騎馬のように洗練された踊りはあなたの心を仕留めるでしょう。</schema:description>
     <imas:Whose rdf:resource="Kizaki_Ren"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -822,7 +822,7 @@
     <imas:Whose rdf:resource="Watanabe_Minori"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Twilight_Aperitif">
+  <rdf:Description rdf:about="Tasogare_No_Aperitif">
     <schema:name xml:lang="ja">黄昏のアペリティフ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">黄昏のアペリティフ</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
@@ -843,7 +843,7 @@
     <imas:Whose rdf:resource="Kazano_Hiori"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Sprinkles_Smile">
+  <rdf:Description rdf:about="Sprinkle_Smile">
     <schema:name xml:lang="ja">スプリンクルスマイル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スプリンクルスマイル</rdfs:label>
     <schema:description xml:lang="ja">太陽のような明るい笑顔が輝けば誰もが心の中まで晴れ渡る。元気いっぱいな少女のための、動きやすさを重視した衣装。</schema:description>
@@ -885,7 +885,7 @@
     <imas:Whose rdf:resource="Komiya_Kaho"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Afascinale_Of_Fleeting_Moment">
+  <rdf:Description rdf:about="Tamayura_No_Affascinare">
     <schema:name xml:lang="ja">玉響のアファシナーレ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">玉響のアファシナーレ</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
@@ -920,10 +920,10 @@
     <imas:Whose rdf:resource="Mitsumine_Yuika"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Starley_Futures_Poplinks">
+  <rdf:Description rdf:about="Starry_Futures_Poplinks">
     <schema:name xml:lang="ja">スターリー・フューチャーズ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スターリー・フューチャーズ</rdfs:label>
-    <schema:description xml:lang="ja">未来に向かって星のように輝き続けるアイドルたちの特別な衣装。さぁ笑って、「これからも、アイドル!!!!!」</schema:description>
+    <!-- <schema:description xml:lang="ja">未来に向かって星のように輝き続けるアイドルたちの特別な衣装。さぁ笑って、「これからも、アイドル!!!!!」</schema:description> -->
     <imas:Whose rdf:resource="Amami_Haruka"/>
     <imas:Whose rdf:resource="Shimamura_Uzuki"/>
     <imas:Whose rdf:resource="Kasuga_Mirai"/>
@@ -952,7 +952,7 @@
     <imas:Whose rdf:resource="Osaki_Amana"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Secret_Maid">
+  <rdf:Description rdf:about="Naisho_No_Maid">
     <schema:name xml:lang="ja">ナイショノメイド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ナイショノメイド</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
@@ -962,11 +962,11 @@
   <rdf:Description rdf:about="Himeyaka_Kyushi">
     <schema:name xml:lang="ja">秘めやか給仕</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">秘めやか給仕</rdfs:label>
-    <schema:description xml:lang="ja"></schema:description>
+    <schema:description xml:lang="ja">料理に彩りを添える彼女の完璧な給仕は、主人に好評。日に日に腕を上げる彼女のお目当ては、ご褒美の上品な甘味らしい。</schema:description>
     <imas:Whose rdf:resource="Emily_Stewart"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Marvelous_Batler">
+  <rdf:Description rdf:about="Marvelous_Butler">
     <schema:name xml:lang="ja">マーベラスバトラー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">マーベラスバトラー</rdfs:label>
     <schema:description xml:lang="ja">一癖も二癖もある使用人達をまとめ上げる、一流の使用人頭。数多ある仕事を完璧にこなす。最も得意な家事は掃除。</schema:description>
@@ -994,7 +994,7 @@
     <imas:Whose rdf:resource="Hachimiya_Meguru"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Purery_Bride">
+  <rdf:Description rdf:about="Purely_Bride">
     <schema:name xml:lang="ja">ピュアリーブライド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピュアリーブライド</rdfs:label>
     <schema:description xml:lang="ja">純粋な心を優しく彩るウェディングドレス風の衣装。小鳥のさえずりに乗せ、溢れそうな愛と幸運を届けたい。</schema:description>

--- a/RDFs/Clothes/PopLinks.rdf
+++ b/RDFs/Clothes/PopLinks.rdf
@@ -474,14 +474,14 @@
     <imas:Whose rdf:resource="Abe_Nana"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Feast_Spinner">
+  <rdf:Description rdf:about="Kyoen_No_Tsumugite">
     <schema:name xml:lang="ja">饗宴の紡ぎ手</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">饗宴の紡ぎ手</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
     <imas:Whose rdf:resource="Kanzaki_Ranko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Pulse_Flying_In_The_Dawn_Sky">
+  <rdf:Description rdf:about="Gyoten_Wo_Kakeru_Pulse">
     <schema:name xml:lang="ja">暁天を翔るパルス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">暁天を翔るパルス</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
@@ -580,7 +580,7 @@
     <imas:Whose rdf:resource="Shiraishi_Tsumugi"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Advanced_Garley">
+  <rdf:Description rdf:about="Advanced_Girly">
     <schema:name xml:lang="ja">アドバンスドガーリー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アドバンスドガーリー</rdfs:label>
     <schema:description xml:lang="ja"></schema:description>
@@ -707,7 +707,7 @@
     <imas:Whose rdf:resource="Okamura_Nao"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Minimum_Bigster">
+  <rdf:Description rdf:about="Minimum_Big_Star">
     <schema:name xml:lang="ja">ミニマムビッグスター</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ミニマムビッグスター</rdfs:label>
     <schema:description xml:lang="ja">小さな体につまった、だれにも負けないビッグな目標。最強にカッコいいアイドルを目指す姿が光ります。</schema:description>

--- a/RDFs/Clothes/PopLinks.rdf
+++ b/RDFs/Clothes/PopLinks.rdf
@@ -456,7 +456,7 @@
   <rdf:Description rdf:about="Panic_Nightmare">
     <schema:name xml:lang="ja">パニックナイトメア</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">パニックナイトメア</rdfs:label>
-    <schema:description xml:lang="ja"></schema:description>
+    <schema:description xml:lang="ja">つぎはぎ布とホラーなモチーフのかざり付きの衣装。絶叫と興奮がまじわる魅惑のステージで相まみえた、あなたは一体だあれ……？</schema:description>
     <imas:Whose rdf:resource="Shirasaka_Koume"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>


### PR DESCRIPTION
#390
ポプマス衣装のデータを追加します。
一部説明文章が未記載の物がありますが、まずはデータ自体の登録が先ということで一度プルリクします。
データの出どころ：
 - Pixiv百科事典 ポップリンクス衣装https://dic.pixiv.net/a/%E3%83%9D%E3%83%83%E3%83%97%E3%83%AA%E3%83%B3%E3%82%AF%E3%82%B9%E8%A1%A3%E8%A3%85
 - 謎の猫 Wiki* 衣装一覧
https://wikiwiki.jp/popumas_cat/%E8%A1%A3%E8%A3%85%E4%B8%80%E8%A6%A7