### PR TITLE
sideMとシャイニーカラーズの呼称データ追加

### DIFF
--- a/RDFs/CallTable.rdf
+++ b/RDFs/CallTable.rdf
@@ -7,6 +7,7 @@
     xml:base="https://sparql.crssnky.xyz/imasrdf/RDFs/detail/"
     >
 
+<!-- CinderellaGirls -->
   <rdf:Description rdf:about="Shimamura_Uzuki_Shimamura_Uzuki">
     <imas:Source rdf:resource="Shimamura_Uzuki"/>
     <imas:Destination rdf:resource="Shimamura_Uzuki"/>
@@ -20665,6 +20666,7 @@
     <imas:Called xml:lang="ja">紗南</imas:Called>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
   </rdf:Description>
+<!-- MillionLive -->
   <rdf:Description rdf:about="Amami_Haruka_Amami_Haruka">
     <imas:Source rdf:resource="Amami_Haruka"/>
     <imas:Destination rdf:resource="Amami_Haruka"/>
@@ -35847,6 +35849,2017 @@
     <imas:Source rdf:resource="Producer"/>
     <imas:Destination rdf:resource="Shika"/>
     <imas:Called xml:lang="ja">詩花</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+<!-- ShinyColors -->
+  <rdf:Description rdf:about="Sakuragi_Mano_Kazano_Hiori">
+    <imas:Source rdf:resource="Sakuragi_Mano"/>
+    <imas:Destination rdf:resource="Kazano_Hiori"/>
+    <imas:Called xml:lang="ja">灯織ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuragi_Mano_Hachimiya_Meguru">
+    <imas:Source rdf:resource="Sakuragi_Mano"/>
+    <imas:Destination rdf:resource="Hachimiya_Meguru"/>
+    <imas:Called xml:lang="ja">めぐるちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuragi_Mano_Tsukioka_Kogane">
+    <imas:Source rdf:resource="Sakuragi_Mano"/>
+    <imas:Destination rdf:resource="Tsukioka_Kogane"/>
+    <imas:Called xml:lang="ja">恋鐘ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuragi_Mano_Tanaka_Mamimi">
+    <imas:Source rdf:resource="Sakuragi_Mano"/>
+    <imas:Destination rdf:resource="Tanaka_Mamimi"/>
+    <imas:Called xml:lang="ja">摩美々ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuragi_Mano_Shirase_Sakuya">
+    <imas:Source rdf:resource="Sakuragi_Mano"/>
+    <imas:Destination rdf:resource="Shirase_Sakuya"/>
+    <imas:Called xml:lang="ja">咲耶さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuragi_Mano_Mitsumine_Yuika">
+    <imas:Source rdf:resource="Sakuragi_Mano"/>
+    <imas:Destination rdf:resource="Mitsumine_Yuika"/>
+    <imas:Called xml:lang="ja">結華ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuragi_Mano_Yukoku_Kiriko">
+    <imas:Source rdf:resource="Sakuragi_Mano"/>
+    <imas:Destination rdf:resource="Yukoku_Kiriko"/>
+    <imas:Called xml:lang="ja">霧子ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuragi_Mano_Osaki_Amana">
+    <imas:Source rdf:resource="Sakuragi_Mano"/>
+    <imas:Destination rdf:resource="Osaki_Amana"/>
+    <imas:Called xml:lang="ja">甘奈ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuragi_Mano_Osaki_Tenka">
+    <imas:Source rdf:resource="Sakuragi_Mano"/>
+    <imas:Destination rdf:resource="Osaki_Tenka"/>
+    <imas:Called xml:lang="ja">甜花ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuragi_Mano_Kuwayama_Chiyuki">
+    <imas:Source rdf:resource="Sakuragi_Mano"/>
+    <imas:Destination rdf:resource="Kuwayama_Chiyuki"/>
+    <imas:Called xml:lang="ja">千雪さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuragi_Mano_Komiya_Kaho">
+    <imas:Source rdf:resource="Sakuragi_Mano"/>
+    <imas:Destination rdf:resource="Komiya_Kaho"/>
+    <imas:Called xml:lang="ja">果穂ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuragi_Mano_Sonoda_Chiyoko">
+    <imas:Source rdf:resource="Sakuragi_Mano"/>
+    <imas:Destination rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Called xml:lang="ja">智代子ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuragi_Mano_Saijo_Juri">
+    <imas:Source rdf:resource="Sakuragi_Mano"/>
+    <imas:Destination rdf:resource="Saijo_Juri"/>
+    <imas:Called xml:lang="ja">樹里ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuragi_Mano_Arisugawa_Natsuha">
+    <imas:Source rdf:resource="Sakuragi_Mano"/>
+    <imas:Destination rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Called xml:lang="ja">夏葉さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuragi_Mano_Serizawa_Asahi">
+    <imas:Source rdf:resource="Sakuragi_Mano"/>
+    <imas:Destination rdf:resource="Serizawa_Asahi"/>
+    <imas:Called xml:lang="ja">あさひちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuragi_Mano_Mayuzumi_Fuyuko">
+    <imas:Source rdf:resource="Sakuragi_Mano"/>
+    <imas:Destination rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Called xml:lang="ja">ふゆちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuragi_Mano_Izumi_Mei">
+    <imas:Source rdf:resource="Sakuragi_Mano"/>
+    <imas:Destination rdf:resource="Izumi_Mei"/>
+    <imas:Called xml:lang="ja">愛依ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuragi_Mano_Asakura_Toru">
+    <imas:Source rdf:resource="Sakuragi_Mano"/>
+    <imas:Destination rdf:resource="Asakura_Toru"/>
+    <imas:Called xml:lang="ja">透ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuragi_Mano_Higuchi_Madoka">
+    <imas:Source rdf:resource="Sakuragi_Mano"/>
+    <imas:Destination rdf:resource="Higuchi_Madoka"/>
+    <imas:Called xml:lang="ja">円香ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuragi_Mano_Fukumaru_Koito">
+    <imas:Source rdf:resource="Sakuragi_Mano"/>
+    <imas:Destination rdf:resource="Fukumaru_Koito"/>
+    <imas:Called xml:lang="ja">小糸ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuragi_Mano_Ichikawa_Hinana">
+    <imas:Source rdf:resource="Sakuragi_Mano"/>
+    <imas:Destination rdf:resource="Ichikawa_Hinana"/>
+    <imas:Called xml:lang="ja">雛菜ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuragi_Mano_Nanakusa_Hazuki">
+    <imas:Source rdf:resource="Sakuragi_Mano"/>
+    <imas:Destination rdf:resource="Nanakusa_Hazuki"/>
+    <imas:Called xml:lang="ja">はづきさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kazano_Hiori_Sakuragi_Mano">
+    <imas:Source rdf:resource="Kazano_Hiori"/>
+    <imas:Destination rdf:resource="Sakuragi_Mano"/>
+    <imas:Called xml:lang="ja">真乃</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kazano_Hiori_Hachimiya_Meguru">
+    <imas:Source rdf:resource="Kazano_Hiori"/>
+    <imas:Destination rdf:resource="Hachimiya_Meguru"/>
+    <imas:Called xml:lang="ja">めぐる</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kazano_Hiori_Tsukioka_Kogane">
+    <imas:Source rdf:resource="Kazano_Hiori"/>
+    <imas:Destination rdf:resource="Tsukioka_Kogane"/>
+    <imas:Called xml:lang="ja">恋鐘さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kazano_Hiori_Tanaka_Mamimi">
+    <imas:Source rdf:resource="Kazano_Hiori"/>
+    <imas:Destination rdf:resource="Tanaka_Mamimi"/>
+    <imas:Called xml:lang="ja">摩美々さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kazano_Hiori_Shirase_Sakuya">
+    <imas:Source rdf:resource="Kazano_Hiori"/>
+    <imas:Destination rdf:resource="Shirase_Sakuya"/>
+    <imas:Called xml:lang="ja">咲耶さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kazano_Hiori_Mitsumine_Yuika">
+    <imas:Source rdf:resource="Kazano_Hiori"/>
+    <imas:Destination rdf:resource="Mitsumine_Yuika"/>
+    <imas:Called xml:lang="ja">結華さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kazano_Hiori_Yukoku_Kiriko">
+    <imas:Source rdf:resource="Kazano_Hiori"/>
+    <imas:Destination rdf:resource="Yukoku_Kiriko"/>
+    <imas:Called xml:lang="ja">霧子さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kazano_Hiori_Osaki_Amana">
+    <imas:Source rdf:resource="Kazano_Hiori"/>
+    <imas:Destination rdf:resource="Osaki_Amana"/>
+    <imas:Called xml:lang="ja">甘奈</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kazano_Hiori_Osaki_Tenka">
+    <imas:Source rdf:resource="Kazano_Hiori"/>
+    <imas:Destination rdf:resource="Osaki_Tenka"/>
+    <imas:Called xml:lang="ja">甜花さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kazano_Hiori_Kuwayama_Chiyuki">
+    <imas:Source rdf:resource="Kazano_Hiori"/>
+    <imas:Destination rdf:resource="Kuwayama_Chiyuki"/>
+    <imas:Called xml:lang="ja">千雪さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kazano_Hiori_Komiya_Kaho">
+    <imas:Source rdf:resource="Kazano_Hiori"/>
+    <imas:Destination rdf:resource="Komiya_Kaho"/>
+    <imas:Called xml:lang="ja">果穂</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kazano_Hiori_Saijo_Juri">
+    <imas:Source rdf:resource="Kazano_Hiori"/>
+    <imas:Destination rdf:resource="Saijo_Juri"/>
+    <imas:Called xml:lang="ja">樹里</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kazano_Hiori_Morino_Rinze">
+    <imas:Source rdf:resource="Kazano_Hiori"/>
+    <imas:Destination rdf:resource="Morino_Rinze"/>
+    <imas:Called xml:lang="ja">凛世</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kazano_Hiori_Arisugawa_Natsuha">
+    <imas:Source rdf:resource="Kazano_Hiori"/>
+    <imas:Destination rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Called xml:lang="ja">夏葉さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kazano_Hiori_Serizawa_Asahi">
+    <imas:Source rdf:resource="Kazano_Hiori"/>
+    <imas:Destination rdf:resource="Serizawa_Asahi"/>
+    <imas:Called xml:lang="ja">あさひ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kazano_Hiori_Mayuzumi_Fuyuko">
+    <imas:Source rdf:resource="Kazano_Hiori"/>
+    <imas:Destination rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Called xml:lang="ja">冬優子さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kazano_Hiori_Izumi_Mei">
+    <imas:Source rdf:resource="Kazano_Hiori"/>
+    <imas:Destination rdf:resource="Izumi_Mei"/>
+    <imas:Called xml:lang="ja">愛依さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kazano_Hiori_Ichikawa_Hinana">
+    <imas:Source rdf:resource="Kazano_Hiori"/>
+    <imas:Destination rdf:resource="Ichikawa_Hinana"/>
+    <imas:Called xml:lang="ja">市川さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kazano_Hiori_Nanakusa_Hazuki">
+    <imas:Source rdf:resource="Kazano_Hiori"/>
+    <imas:Destination rdf:resource="Nanakusa_Hazuki"/>
+    <imas:Called xml:lang="ja">はづきさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hachimiya_Meguru_Sakuragi_Mano">
+    <imas:Source rdf:resource="Hachimiya_Meguru"/>
+    <imas:Destination rdf:resource="Sakuragi_Mano"/>
+    <imas:Called xml:lang="ja">真乃</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hachimiya_Meguru_Kazano_Hiori">
+    <imas:Source rdf:resource="Hachimiya_Meguru"/>
+    <imas:Destination rdf:resource="Kazano_Hiori"/>
+    <imas:Called xml:lang="ja">灯織</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hachimiya_Meguru_Tsukioka_Kogane">
+    <imas:Source rdf:resource="Hachimiya_Meguru"/>
+    <imas:Destination rdf:resource="Tsukioka_Kogane"/>
+    <imas:Called xml:lang="ja">恋鐘ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hachimiya_Meguru_Tanaka_Mamimi">
+    <imas:Source rdf:resource="Hachimiya_Meguru"/>
+    <imas:Destination rdf:resource="Tanaka_Mamimi"/>
+    <imas:Called xml:lang="ja">摩美々ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hachimiya_Meguru_Shirase_Sakuya">
+    <imas:Source rdf:resource="Hachimiya_Meguru"/>
+    <imas:Destination rdf:resource="Shirase_Sakuya"/>
+    <imas:Called xml:lang="ja">咲耶</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hachimiya_Meguru_Mitsumine_Yuika">
+    <imas:Source rdf:resource="Hachimiya_Meguru"/>
+    <imas:Destination rdf:resource="Mitsumine_Yuika"/>
+    <imas:Called xml:lang="ja">結華ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hachimiya_Meguru_Yukoku_Kiriko">
+    <imas:Source rdf:resource="Hachimiya_Meguru"/>
+    <imas:Destination rdf:resource="Yukoku_Kiriko"/>
+    <imas:Called xml:lang="ja">霧子ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hachimiya_Meguru_Komiya_Kaho">
+    <imas:Source rdf:resource="Hachimiya_Meguru"/>
+    <imas:Destination rdf:resource="Komiya_Kaho"/>
+    <imas:Called xml:lang="ja">果穂</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hachimiya_Meguru_Sonoda_Chiyoko">
+    <imas:Source rdf:resource="Hachimiya_Meguru"/>
+    <imas:Destination rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Called xml:lang="ja">チョコ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hachimiya_Meguru_Saijo_Juri">
+    <imas:Source rdf:resource="Hachimiya_Meguru"/>
+    <imas:Destination rdf:resource="Saijo_Juri"/>
+    <imas:Called xml:lang="ja">樹里</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hachimiya_Meguru_Arisugawa_Natsuha">
+    <imas:Source rdf:resource="Hachimiya_Meguru"/>
+    <imas:Destination rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Called xml:lang="ja">夏葉さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hachimiya_Meguru_Serizawa_Asahi">
+    <imas:Source rdf:resource="Hachimiya_Meguru"/>
+    <imas:Destination rdf:resource="Serizawa_Asahi"/>
+    <imas:Called xml:lang="ja">あさひ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hachimiya_Meguru_Mayuzumi_Fuyuko">
+    <imas:Source rdf:resource="Hachimiya_Meguru"/>
+    <imas:Destination rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Called xml:lang="ja">ふゆちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hachimiya_Meguru_Izumi_Mei">
+    <imas:Source rdf:resource="Hachimiya_Meguru"/>
+    <imas:Destination rdf:resource="Izumi_Mei"/>
+    <imas:Called xml:lang="ja">愛依</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hachimiya_Meguru_Ichikawa_Hinana">
+    <imas:Source rdf:resource="Hachimiya_Meguru"/>
+    <imas:Destination rdf:resource="Ichikawa_Hinana"/>
+    <imas:Called xml:lang="ja">雛菜</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hachimiya_Meguru_Nanakusa_Hazuki">
+    <imas:Source rdf:resource="Hachimiya_Meguru"/>
+    <imas:Destination rdf:resource="Nanakusa_Hazuki"/>
+    <imas:Called xml:lang="ja">はづきさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukioka_Kogane_Sakuragi_Mano">
+    <imas:Source rdf:resource="Tsukioka_Kogane"/>
+    <imas:Destination rdf:resource="Sakuragi_Mano"/>
+    <imas:Called xml:lang="ja">真乃</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukioka_Kogane_Kazano_Hiori">
+    <imas:Source rdf:resource="Tsukioka_Kogane"/>
+    <imas:Destination rdf:resource="Kazano_Hiori"/>
+    <imas:Called xml:lang="ja">灯織</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukioka_Kogane_Hachimiya_Meguru">
+    <imas:Source rdf:resource="Tsukioka_Kogane"/>
+    <imas:Destination rdf:resource="Hachimiya_Meguru"/>
+    <imas:Called xml:lang="ja">めぐる</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukioka_Kogane_Tanaka_Mamimi">
+    <imas:Source rdf:resource="Tsukioka_Kogane"/>
+    <imas:Destination rdf:resource="Tanaka_Mamimi"/>
+    <imas:Called xml:lang="ja">摩美々</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukioka_Kogane_Shirase_Sakuya">
+    <imas:Source rdf:resource="Tsukioka_Kogane"/>
+    <imas:Destination rdf:resource="Shirase_Sakuya"/>
+    <imas:Called xml:lang="ja">咲耶</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukioka_Kogane_Mitsumine_Yuika">
+    <imas:Source rdf:resource="Tsukioka_Kogane"/>
+    <imas:Destination rdf:resource="Mitsumine_Yuika"/>
+    <imas:Called xml:lang="ja">結華</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukioka_Kogane_Yukoku_Kiriko">
+    <imas:Source rdf:resource="Tsukioka_Kogane"/>
+    <imas:Destination rdf:resource="Yukoku_Kiriko"/>
+    <imas:Called xml:lang="ja">霧子</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukioka_Kogane_Osaki_Amana">
+    <imas:Source rdf:resource="Tsukioka_Kogane"/>
+    <imas:Destination rdf:resource="Osaki_Amana"/>
+    <imas:Called xml:lang="ja">甘奈</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukioka_Kogane_Osaki_Tenka">
+    <imas:Source rdf:resource="Tsukioka_Kogane"/>
+    <imas:Destination rdf:resource="Osaki_Tenka"/>
+    <imas:Called xml:lang="ja">甜花</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukioka_Kogane_Kuwayama_Chiyuki">
+    <imas:Source rdf:resource="Tsukioka_Kogane"/>
+    <imas:Destination rdf:resource="Kuwayama_Chiyuki"/>
+    <imas:Called xml:lang="ja">千雪</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukioka_Kogane_Komiya_Kaho">
+    <imas:Source rdf:resource="Tsukioka_Kogane"/>
+    <imas:Destination rdf:resource="Komiya_Kaho"/>
+    <imas:Called xml:lang="ja">果穂</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukioka_Kogane_Sonoda_Chiyoko">
+    <imas:Source rdf:resource="Tsukioka_Kogane"/>
+    <imas:Destination rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Called xml:lang="ja">智代子</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukioka_Kogane_Saijo_Juri">
+    <imas:Source rdf:resource="Tsukioka_Kogane"/>
+    <imas:Destination rdf:resource="Saijo_Juri"/>
+    <imas:Called xml:lang="ja">樹里</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukioka_Kogane_Morino_Rinze">
+    <imas:Source rdf:resource="Tsukioka_Kogane"/>
+    <imas:Destination rdf:resource="Morino_Rinze"/>
+    <imas:Called xml:lang="ja">凛世</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukioka_Kogane_Arisugawa_Natsuha">
+    <imas:Source rdf:resource="Tsukioka_Kogane"/>
+    <imas:Destination rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Called xml:lang="ja">夏葉</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukioka_Kogane_Serizawa_Asahi">
+    <imas:Source rdf:resource="Tsukioka_Kogane"/>
+    <imas:Destination rdf:resource="Serizawa_Asahi"/>
+    <imas:Called xml:lang="ja">あさひ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukioka_Kogane_Mayuzumi_Fuyuko">
+    <imas:Source rdf:resource="Tsukioka_Kogane"/>
+    <imas:Destination rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Called xml:lang="ja">冬優子</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukioka_Kogane_Izumi_Mei">
+    <imas:Source rdf:resource="Tsukioka_Kogane"/>
+    <imas:Destination rdf:resource="Izumi_Mei"/>
+    <imas:Called xml:lang="ja">愛依</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukioka_Kogane_Nanakusa_Hazuki">
+    <imas:Source rdf:resource="Tsukioka_Kogane"/>
+    <imas:Destination rdf:resource="Nanakusa_Hazuki"/>
+    <imas:Called xml:lang="ja">はづき</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukioka_Kogane_Sakuragi_Mano">
+    <imas:Source rdf:resource="Tsukioka_Kogane"/>
+    <imas:Destination rdf:resource="Sakuragi_Mano"/>
+    <imas:Called xml:lang="ja">真乃</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tanaka_Mamimi_Kazano_Hiori">
+    <imas:Source rdf:resource="Tanaka_Mamimi"/>
+    <imas:Destination rdf:resource="Kazano_Hiori"/>
+    <imas:Called xml:lang="ja">灯織</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tanaka_Mamimi_Hachimiya_Meguru">
+    <imas:Source rdf:resource="Tanaka_Mamimi"/>
+    <imas:Destination rdf:resource="Hachimiya_Meguru"/>
+    <imas:Called xml:lang="ja">めぐる</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tanaka_Mamimi_Tsukioka_Kogane">
+    <imas:Source rdf:resource="Tanaka_Mamimi"/>
+    <imas:Destination rdf:resource="Tsukioka_Kogane"/>
+    <imas:Called xml:lang="ja">恋鐘</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tanaka_Mamimi_Shirase_Sakuya">
+    <imas:Source rdf:resource="Tanaka_Mamimi"/>
+    <imas:Destination rdf:resource="Shirase_Sakuya"/>
+    <imas:Called xml:lang="ja">咲耶</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tanaka_Mamimi_Mitsumine_Yuika">
+    <imas:Source rdf:resource="Tanaka_Mamimi"/>
+    <imas:Destination rdf:resource="Mitsumine_Yuika"/>
+    <imas:Called xml:lang="ja">三峰</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tanaka_Mamimi_Yukoku_Kiriko">
+    <imas:Source rdf:resource="Tanaka_Mamimi"/>
+    <imas:Destination rdf:resource="Yukoku_Kiriko"/>
+    <imas:Called xml:lang="ja">霧子</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tanaka_Mamimi_Osaki_Tenka">
+    <imas:Source rdf:resource="Tanaka_Mamimi"/>
+    <imas:Destination rdf:resource="Osaki_Tenka"/>
+    <imas:Called xml:lang="ja">甜花</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tanaka_Mamimi_Saijo_Juri">
+    <imas:Source rdf:resource="Tanaka_Mamimi"/>
+    <imas:Destination rdf:resource="Saijo_Juri"/>
+    <imas:Called xml:lang="ja">樹里</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tanaka_Mamimi_Morino_Rinze">
+    <imas:Source rdf:resource="Tanaka_Mamimi"/>
+    <imas:Destination rdf:resource="Morino_Rinze"/>
+    <imas:Called xml:lang="ja">凛世</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tanaka_Mamimi_Arisugawa_Natsuha">
+    <imas:Source rdf:resource="Tanaka_Mamimi"/>
+    <imas:Destination rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Called xml:lang="ja">夏葉</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tanaka_Mamimi_Mayuzumi_Fuyuko">
+    <imas:Source rdf:resource="Tanaka_Mamimi"/>
+    <imas:Destination rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Called xml:lang="ja">冬優子</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tanaka_Mamimi_Izumi_Mei">
+    <imas:Source rdf:resource="Tanaka_Mamimi"/>
+    <imas:Destination rdf:resource="Izumi_Mei"/>
+    <imas:Called xml:lang="ja">愛依</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tanaka_Mamimi_Sakuragi_Mano">
+    <imas:Source rdf:resource="Tanaka_Mamimi"/>
+    <imas:Destination rdf:resource="Sakuragi_Mano"/>
+    <imas:Called xml:lang="ja">真乃</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shirase_Sakuya_Kazano_Hiori">
+    <imas:Source rdf:resource="Shirase_Sakuya"/>
+    <imas:Destination rdf:resource="Kazano_Hiori"/>
+    <imas:Called xml:lang="ja">灯織</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shirase_Sakuya_Hachimiya_Meguru">
+    <imas:Source rdf:resource="Shirase_Sakuya"/>
+    <imas:Destination rdf:resource="Hachimiya_Meguru"/>
+    <imas:Called xml:lang="ja">めぐる</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shirase_Sakuya_Tsukioka_Kogane">
+    <imas:Source rdf:resource="Shirase_Sakuya"/>
+    <imas:Destination rdf:resource="Tsukioka_Kogane"/>
+    <imas:Called xml:lang="ja">恋鐘</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shirase_Sakuya_Tanaka_Mamimi">
+    <imas:Source rdf:resource="Shirase_Sakuya"/>
+    <imas:Destination rdf:resource="Tanaka_Mamimi"/>
+    <imas:Called xml:lang="ja">摩美々</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shirase_Sakuya_Mitsumine_Yuika">
+    <imas:Source rdf:resource="Shirase_Sakuya"/>
+    <imas:Destination rdf:resource="Mitsumine_Yuika"/>
+    <imas:Called xml:lang="ja">結華</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shirase_Sakuya_Yukoku_Kiriko">
+    <imas:Source rdf:resource="Shirase_Sakuya"/>
+    <imas:Destination rdf:resource="Yukoku_Kiriko"/>
+    <imas:Called xml:lang="ja">霧子</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shirase_Sakuya_Osaki_Amana">
+    <imas:Source rdf:resource="Shirase_Sakuya"/>
+    <imas:Destination rdf:resource="Osaki_Amana"/>
+    <imas:Called xml:lang="ja">甘奈</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shirase_Sakuya_Komiya_Kaho">
+    <imas:Source rdf:resource="Shirase_Sakuya"/>
+    <imas:Destination rdf:resource="Komiya_Kaho"/>
+    <imas:Called xml:lang="ja">果穂</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shirase_Sakuya_Sonoda_Chiyoko">
+    <imas:Source rdf:resource="Shirase_Sakuya"/>
+    <imas:Destination rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Called xml:lang="ja">智代子</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shirase_Sakuya_Saijo_Juri">
+    <imas:Source rdf:resource="Shirase_Sakuya"/>
+    <imas:Destination rdf:resource="Saijo_Juri"/>
+    <imas:Called xml:lang="ja">樹里</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shirase_Sakuya_Morino_Rinze">
+    <imas:Source rdf:resource="Shirase_Sakuya"/>
+    <imas:Destination rdf:resource="Morino_Rinze"/>
+    <imas:Called xml:lang="ja">凛世</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shirase_Sakuya_Arisugawa_Natsuha">
+    <imas:Source rdf:resource="Shirase_Sakuya"/>
+    <imas:Destination rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Called xml:lang="ja">夏葉</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shirase_Sakuya_Serizawa_Asahi">
+    <imas:Source rdf:resource="Shirase_Sakuya"/>
+    <imas:Destination rdf:resource="Serizawa_Asahi"/>
+    <imas:Called xml:lang="ja">あさひ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shirase_Sakuya_Izumi_Mei">
+    <imas:Source rdf:resource="Shirase_Sakuya"/>
+    <imas:Destination rdf:resource="Izumi_Mei"/>
+    <imas:Called xml:lang="ja">愛依</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shirase_Sakuya_Asakura_Toru">
+    <imas:Source rdf:resource="Shirase_Sakuya"/>
+    <imas:Destination rdf:resource="Asakura_Toru"/>
+    <imas:Called xml:lang="ja">透</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shirase_Sakuya_Higuchi_Madoka">
+    <imas:Source rdf:resource="Shirase_Sakuya"/>
+    <imas:Destination rdf:resource="Higuchi_Madoka"/>
+    <imas:Called xml:lang="ja">円香</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shirase_Sakuya_Fukumaru_Koito">
+    <imas:Source rdf:resource="Shirase_Sakuya"/>
+    <imas:Destination rdf:resource="Fukumaru_Koito"/>
+    <imas:Called xml:lang="ja">小糸</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shirase_Sakuya_Ichikawa_Hinana">
+    <imas:Source rdf:resource="Shirase_Sakuya"/>
+    <imas:Destination rdf:resource="Ichikawa_Hinana"/>
+    <imas:Called xml:lang="ja">雛菜</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shirase_Sakuya_Sakuragi_Mano">
+    <imas:Source rdf:resource="Shirase_Sakuya"/>
+    <imas:Destination rdf:resource="Sakuragi_Mano"/>
+    <imas:Called xml:lang="ja">まののん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitsumine_Yuika_Kazano_Hiori">
+    <imas:Source rdf:resource="Mitsumine_Yuika"/>
+    <imas:Destination rdf:resource="Kazano_Hiori"/>
+    <imas:Called xml:lang="ja">ひおりん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitsumine_Yuika_Hachimiya_Meguru">
+    <imas:Source rdf:resource="Mitsumine_Yuika"/>
+    <imas:Destination rdf:resource="Hachimiya_Meguru"/>
+    <imas:Called xml:lang="ja">めぐるん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitsumine_Yuika_Tsukioka_Kogane">
+    <imas:Source rdf:resource="Mitsumine_Yuika"/>
+    <imas:Destination rdf:resource="Tsukioka_Kogane"/>
+    <imas:Called xml:lang="ja">こがたん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitsumine_Yuika_Tanaka_Mamimi">
+    <imas:Source rdf:resource="Mitsumine_Yuika"/>
+    <imas:Destination rdf:resource="Tanaka_Mamimi"/>
+    <imas:Called xml:lang="ja">まみみん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitsumine_Yuika_Shirase_Sakuya">
+    <imas:Source rdf:resource="Mitsumine_Yuika"/>
+    <imas:Destination rdf:resource="Shirase_Sakuya"/>
+    <imas:Called xml:lang="ja">さくやん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitsumine_Yuika_Yukoku_Kiriko">
+    <imas:Source rdf:resource="Mitsumine_Yuika"/>
+    <imas:Destination rdf:resource="Yukoku_Kiriko"/>
+    <imas:Called xml:lang="ja">きりりん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitsumine_Yuika_Osaki_Amana">
+    <imas:Source rdf:resource="Mitsumine_Yuika"/>
+    <imas:Destination rdf:resource="Osaki_Amana"/>
+    <imas:Called xml:lang="ja">なーちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitsumine_Yuika_Osaki_Tenka">
+    <imas:Source rdf:resource="Mitsumine_Yuika"/>
+    <imas:Destination rdf:resource="Osaki_Tenka"/>
+    <imas:Called xml:lang="ja">てんちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitsumine_Yuika_Kuwayama_Chiyuki">
+    <imas:Source rdf:resource="Mitsumine_Yuika"/>
+    <imas:Destination rdf:resource="Kuwayama_Chiyuki"/>
+    <imas:Called xml:lang="ja">千雪さん</imas:Called>
+    <imas:Called xml:lang="ja">千雪姉さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitsumine_Yuika_Komiya_Kaho">
+    <imas:Source rdf:resource="Mitsumine_Yuika"/>
+    <imas:Destination rdf:resource="Komiya_Kaho"/>
+    <imas:Called xml:lang="ja">果穂ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitsumine_Yuika_Sonoda_Chiyoko">
+    <imas:Source rdf:resource="Mitsumine_Yuika"/>
+    <imas:Destination rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Called xml:lang="ja">チョコ</imas:Called>
+    <imas:Called xml:lang="ja">チョコちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitsumine_Yuika_Saijo_Juri">
+    <imas:Source rdf:resource="Mitsumine_Yuika"/>
+    <imas:Destination rdf:resource="Saijo_Juri"/>
+    <imas:Called xml:lang="ja">じゅりちー</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitsumine_Yuika_Morino_Rinze">
+    <imas:Source rdf:resource="Mitsumine_Yuika"/>
+    <imas:Destination rdf:resource="Morino_Rinze"/>
+    <imas:Called xml:lang="ja">りんりん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitsumine_Yuika_Arisugawa_Natsuha">
+    <imas:Source rdf:resource="Mitsumine_Yuika"/>
+    <imas:Destination rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Called xml:lang="ja">なっちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitsumine_Yuika_Serizawa_Asahi">
+    <imas:Source rdf:resource="Mitsumine_Yuika"/>
+    <imas:Destination rdf:resource="Serizawa_Asahi"/>
+    <imas:Called xml:lang="ja">あさたん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitsumine_Yuika_Mayuzumi_Fuyuko">
+    <imas:Source rdf:resource="Mitsumine_Yuika"/>
+    <imas:Destination rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Called xml:lang="ja">ふゆゆ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitsumine_Yuika_Izumi_Mei">
+    <imas:Source rdf:resource="Mitsumine_Yuika"/>
+    <imas:Destination rdf:resource="Izumi_Mei"/>
+    <imas:Called xml:lang="ja">めいめい</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitsumine_Yuika_Asakura_Toru">
+    <imas:Source rdf:resource="Mitsumine_Yuika"/>
+    <imas:Destination rdf:resource="Asakura_Toru"/>
+    <imas:Called xml:lang="ja">とおるん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitsumine_Yuika_Higuchi_Madoka">
+    <imas:Source rdf:resource="Mitsumine_Yuika"/>
+    <imas:Destination rdf:resource="Higuchi_Madoka"/>
+    <imas:Called xml:lang="ja">まどちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitsumine_Yuika_Fukumaru_Koito">
+    <imas:Source rdf:resource="Mitsumine_Yuika"/>
+    <imas:Destination rdf:resource="Fukumaru_Koito"/>
+    <imas:Called xml:lang="ja">こいちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitsumine_Yuika_Ichikawa_Hinana">
+    <imas:Source rdf:resource="Mitsumine_Yuika"/>
+    <imas:Destination rdf:resource="Ichikawa_Hinana"/>
+    <imas:Called xml:lang="ja">ひななん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitsumine_Yuika_Nanakusa_Hazuki">
+    <imas:Source rdf:resource="Mitsumine_Yuika"/>
+    <imas:Destination rdf:resource="Nanakusa_Hazuki"/>
+    <imas:Called xml:lang="ja">はづきさん</imas:Called>
+    <imas:Called xml:lang="ja">はづきちさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yukoku_Kiriko_Tsukioka_Kogane">
+    <imas:Source rdf:resource="Yukoku_Kiriko"/>
+    <imas:Destination rdf:resource="Tsukioka_Kogane"/>
+    <imas:Called xml:lang="ja">恋鐘ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yukoku_Kiriko_Tanaka_Mamimi">
+    <imas:Source rdf:resource="Yukoku_Kiriko"/>
+    <imas:Destination rdf:resource="Tanaka_Mamimi"/>
+    <imas:Called xml:lang="ja">摩美々ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yukoku_Kiriko_Shirase_Sakuya">
+    <imas:Source rdf:resource="Yukoku_Kiriko"/>
+    <imas:Destination rdf:resource="Shirase_Sakuya"/>
+    <imas:Called xml:lang="ja">咲耶ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yukoku_Kiriko_Mitsumine_Yuika">
+    <imas:Source rdf:resource="Yukoku_Kiriko"/>
+    <imas:Destination rdf:resource="Mitsumine_Yuika"/>
+    <imas:Called xml:lang="ja">結華ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yukoku_Kiriko_Osaki_Amana">
+    <imas:Source rdf:resource="Yukoku_Kiriko"/>
+    <imas:Destination rdf:resource="Osaki_Amana"/>
+    <imas:Called xml:lang="ja">甘奈さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yukoku_Kiriko_Osaki_Tenka">
+    <imas:Source rdf:resource="Yukoku_Kiriko"/>
+    <imas:Destination rdf:resource="Osaki_Tenka"/>
+    <imas:Called xml:lang="ja">甜花ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yukoku_Kiriko_Arisugawa_Natsuha">
+    <imas:Source rdf:resource="Yukoku_Kiriko"/>
+    <imas:Destination rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Called xml:lang="ja">夏葉さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yukoku_Kiriko_Serizawa_Asahi">
+    <imas:Source rdf:resource="Yukoku_Kiriko"/>
+    <imas:Destination rdf:resource="Serizawa_Asahi"/>
+    <imas:Called xml:lang="ja">あさひちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yukoku_Kiriko_Fukumaru_Koito">
+    <imas:Source rdf:resource="Yukoku_Kiriko"/>
+    <imas:Destination rdf:resource="Fukumaru_Koito"/>
+    <imas:Called xml:lang="ja">小糸ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Amana_Kazano_Hiori">
+    <imas:Source rdf:resource="Osaki_Amana"/>
+    <imas:Destination rdf:resource="Kazano_Hiori"/>
+    <imas:Called xml:lang="ja">灯織ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Amana_Tsukioka_Kogane">
+    <imas:Source rdf:resource="Osaki_Amana"/>
+    <imas:Destination rdf:resource="Tsukioka_Kogane"/>
+    <imas:Called xml:lang="ja">恋鐘ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Amana_Tanaka_Mamimi">
+    <imas:Source rdf:resource="Osaki_Amana"/>
+    <imas:Destination rdf:resource="Tanaka_Mamimi"/>
+    <imas:Called xml:lang="ja">摩美々ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Amana_Shirase_Sakuya">
+    <imas:Source rdf:resource="Osaki_Amana"/>
+    <imas:Destination rdf:resource="Shirase_Sakuya"/>
+    <imas:Called xml:lang="ja">咲耶さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Amana_Osaki_Tenka">
+    <imas:Source rdf:resource="Osaki_Amana"/>
+    <imas:Destination rdf:resource="Osaki_Tenka"/>
+    <imas:Called xml:lang="ja">甜花ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Amana_Kuwayama_Chiyuki">
+    <imas:Source rdf:resource="Osaki_Amana"/>
+    <imas:Destination rdf:resource="Kuwayama_Chiyuki"/>
+    <imas:Called xml:lang="ja">千雪さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Amana_Komiya_Kaho">
+    <imas:Source rdf:resource="Osaki_Amana"/>
+    <imas:Destination rdf:resource="Komiya_Kaho"/>
+    <imas:Called xml:lang="ja">果穂ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Amana_Sonoda_Chiyoko">
+    <imas:Source rdf:resource="Osaki_Amana"/>
+    <imas:Destination rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Called xml:lang="ja">チョコちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Amana_Serizawa_Asahi">
+    <imas:Source rdf:resource="Osaki_Amana"/>
+    <imas:Destination rdf:resource="Serizawa_Asahi"/>
+    <imas:Called xml:lang="ja">あさひちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Amana_Mayuzumi_Fuyuko">
+    <imas:Source rdf:resource="Osaki_Amana"/>
+    <imas:Destination rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Called xml:lang="ja">ふゆちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Amana_Izumi_Mei">
+    <imas:Source rdf:resource="Osaki_Amana"/>
+    <imas:Destination rdf:resource="Izumi_Mei"/>
+    <imas:Called xml:lang="ja">愛依ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Amana_Asakura_Toru">
+    <imas:Source rdf:resource="Osaki_Amana"/>
+    <imas:Destination rdf:resource="Asakura_Toru"/>
+    <imas:Called xml:lang="ja">透ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Amana_Higuchi_Madoka">
+    <imas:Source rdf:resource="Osaki_Amana"/>
+    <imas:Destination rdf:resource="Higuchi_Madoka"/>
+    <imas:Called xml:lang="ja">円香ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Amana_Fukumaru_Koito">
+    <imas:Source rdf:resource="Osaki_Amana"/>
+    <imas:Destination rdf:resource="Fukumaru_Koito"/>
+    <imas:Called xml:lang="ja">小糸ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Amana_Sakuragi_Mano">
+    <imas:Source rdf:resource="Osaki_Amana"/>
+    <imas:Destination rdf:resource="Sakuragi_Mano"/>
+    <imas:Called xml:lang="ja">真乃ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Tenka_Kazano_Hiori">
+    <imas:Source rdf:resource="Osaki_Tenka"/>
+    <imas:Destination rdf:resource="Kazano_Hiori"/>
+    <imas:Called xml:lang="ja">風野さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Tenka_Hachimiya_Meguru">
+    <imas:Source rdf:resource="Osaki_Tenka"/>
+    <imas:Destination rdf:resource="Hachimiya_Meguru"/>
+    <imas:Called xml:lang="ja">八宮さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Tenka_Tsukioka_Kogane">
+    <imas:Source rdf:resource="Osaki_Tenka"/>
+    <imas:Destination rdf:resource="Tsukioka_Kogane"/>
+    <imas:Called xml:lang="ja">月岡さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Tenka_Tanaka_Mamimi">
+    <imas:Source rdf:resource="Osaki_Tenka"/>
+    <imas:Destination rdf:resource="Tanaka_Mamimi"/>
+    <imas:Called xml:lang="ja">田中さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Tenka_Shirase_Sakuya">
+    <imas:Source rdf:resource="Osaki_Tenka"/>
+    <imas:Destination rdf:resource="Shirase_Sakuya"/>
+    <imas:Called xml:lang="ja">白瀬さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Tenka_Yukoku_Kiriko">
+    <imas:Source rdf:resource="Osaki_Tenka"/>
+    <imas:Destination rdf:resource="Yukoku_Kiriko"/>
+    <imas:Called xml:lang="ja">幽谷さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Tenka_Osaki_Amana">
+    <imas:Source rdf:resource="Osaki_Tenka"/>
+    <imas:Destination rdf:resource="Osaki_Amana"/>
+    <imas:Called xml:lang="ja">なーちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Tenka_Kuwayama_Chiyuki">
+    <imas:Source rdf:resource="Osaki_Tenka"/>
+    <imas:Destination rdf:resource="Kuwayama_Chiyuki"/>
+    <imas:Called xml:lang="ja">千雪さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Tenka_Komiya_Kaho">
+    <imas:Source rdf:resource="Osaki_Tenka"/>
+    <imas:Destination rdf:resource="Komiya_Kaho"/>
+    <imas:Called xml:lang="ja">果穂ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Tenka_Saijo_Juri">
+    <imas:Source rdf:resource="Osaki_Tenka"/>
+    <imas:Destination rdf:resource="Saijo_Juri"/>
+    <imas:Called xml:lang="ja">西城さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Tenka_Morino_Rinze">
+    <imas:Source rdf:resource="Osaki_Tenka"/>
+    <imas:Destination rdf:resource="Morino_Rinze"/>
+    <imas:Called xml:lang="ja">杜野さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Tenka_Arisugawa_Natsuha">
+    <imas:Source rdf:resource="Osaki_Tenka"/>
+    <imas:Destination rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Called xml:lang="ja">有栖川さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Tenka_Serizawa_Asahi">
+    <imas:Source rdf:resource="Osaki_Tenka"/>
+    <imas:Destination rdf:resource="Serizawa_Asahi"/>
+    <imas:Called xml:lang="ja">芹沢さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Tenka_Mayuzumi_Fuyuko">
+    <imas:Source rdf:resource="Osaki_Tenka"/>
+    <imas:Destination rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Called xml:lang="ja">黛さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Tenka_Izumi_Mei">
+    <imas:Source rdf:resource="Osaki_Tenka"/>
+    <imas:Destination rdf:resource="Izumi_Mei"/>
+    <imas:Called xml:lang="ja">和泉さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Osaki_Tenka_Sakuragi_Mano">
+    <imas:Source rdf:resource="Osaki_Tenka"/>
+    <imas:Destination rdf:resource="Sakuragi_Mano"/>
+    <imas:Called xml:lang="ja">真乃ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuwayama_Chiyuki_Shirase_Sakuya">
+    <imas:Source rdf:resource="Kuwayama_Chiyuki"/>
+    <imas:Destination rdf:resource="Shirase_Sakuya"/>
+    <imas:Called xml:lang="ja">咲耶ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuwayama_Chiyuki_Osaki_Amana">
+    <imas:Source rdf:resource="Kuwayama_Chiyuki"/>
+    <imas:Destination rdf:resource="Osaki_Amana"/>
+    <imas:Called xml:lang="ja">甘奈ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuwayama_Chiyuki_Osaki_Tenka">
+    <imas:Source rdf:resource="Kuwayama_Chiyuki"/>
+    <imas:Destination rdf:resource="Osaki_Tenka"/>
+    <imas:Called xml:lang="ja">甜花ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuwayama_Chiyuki_Arisugawa_Natsuha">
+    <imas:Source rdf:resource="Kuwayama_Chiyuki"/>
+    <imas:Destination rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Called xml:lang="ja">夏葉ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuwayama_Chiyuki_Serizawa_Asahi">
+    <imas:Source rdf:resource="Kuwayama_Chiyuki"/>
+    <imas:Destination rdf:resource="Serizawa_Asahi"/>
+    <imas:Called xml:lang="ja">あさひちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuwayama_Chiyuki_Izumi_Mei">
+    <imas:Source rdf:resource="Kuwayama_Chiyuki"/>
+    <imas:Destination rdf:resource="Izumi_Mei"/>
+    <imas:Called xml:lang="ja">愛依ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuwayama_Chiyuki_Nanakusa_Hazuki">
+    <imas:Source rdf:resource="Kuwayama_Chiyuki"/>
+    <imas:Destination rdf:resource="Nanakusa_Hazuki"/>
+    <imas:Called xml:lang="ja">はづきさん</imas:Called>
+    <imas:Called xml:lang="ja">はづき</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Komiya_Kaho_Sakuragi_Mano">
+    <imas:Source rdf:resource="Komiya_Kaho"/>
+    <imas:Destination rdf:resource="Sakuragi_Mano"/>
+    <imas:Called xml:lang="ja">真乃さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Komiya_Kaho_Kazano_Hiori">
+    <imas:Source rdf:resource="Komiya_Kaho"/>
+    <imas:Destination rdf:resource="Kazano_Hiori"/>
+    <imas:Called xml:lang="ja">灯織さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Komiya_Kaho_Hachimiya_Meguru">
+    <imas:Source rdf:resource="Komiya_Kaho"/>
+    <imas:Destination rdf:resource="Hachimiya_Meguru"/>
+    <imas:Called xml:lang="ja">めぐるさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Komiya_Kaho_Tsukioka_Kogane">
+    <imas:Source rdf:resource="Komiya_Kaho"/>
+    <imas:Destination rdf:resource="Tsukioka_Kogane"/>
+    <imas:Called xml:lang="ja">恋鐘さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Komiya_Kaho_Tanaka_Mamimi">
+    <imas:Source rdf:resource="Komiya_Kaho"/>
+    <imas:Destination rdf:resource="Tanaka_Mamimi"/>
+    <imas:Called xml:lang="ja">摩美々さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Komiya_Kaho_Shirase_Sakuya">
+    <imas:Source rdf:resource="Komiya_Kaho"/>
+    <imas:Destination rdf:resource="Shirase_Sakuya"/>
+    <imas:Called xml:lang="ja">咲耶さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Komiya_Kaho_Mitsumine_Yuika">
+    <imas:Source rdf:resource="Komiya_Kaho"/>
+    <imas:Destination rdf:resource="Mitsumine_Yuika"/>
+    <imas:Called xml:lang="ja">結華さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Komiya_Kaho_Yukoku_Kiriko">
+    <imas:Source rdf:resource="Komiya_Kaho"/>
+    <imas:Destination rdf:resource="Yukoku_Kiriko"/>
+    <imas:Called xml:lang="ja">霧子さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Komiya_Kaho_Osaki_Amana">
+    <imas:Source rdf:resource="Komiya_Kaho"/>
+    <imas:Destination rdf:resource="Osaki_Amana"/>
+    <imas:Called xml:lang="ja">甘奈さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Komiya_Kaho_Osaki_Tenka">
+    <imas:Source rdf:resource="Komiya_Kaho"/>
+    <imas:Destination rdf:resource="Osaki_Tenka"/>
+    <imas:Called xml:lang="ja">甜花さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Komiya_Kaho_Kuwayama_Chiyuki">
+    <imas:Source rdf:resource="Komiya_Kaho"/>
+    <imas:Destination rdf:resource="Kuwayama_Chiyuki"/>
+    <imas:Called xml:lang="ja">千雪さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Komiya_Kaho_Sonoda_Chiyoko">
+    <imas:Source rdf:resource="Komiya_Kaho"/>
+    <imas:Destination rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Called xml:lang="ja">ちょこ先輩</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Komiya_Kaho_Saijo_Juri">
+    <imas:Source rdf:resource="Komiya_Kaho"/>
+    <imas:Destination rdf:resource="Saijo_Juri"/>
+    <imas:Called xml:lang="ja">樹里ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Komiya_Kaho_Morino_Rinze">
+    <imas:Source rdf:resource="Komiya_Kaho"/>
+    <imas:Destination rdf:resource="Morino_Rinze"/>
+    <imas:Called xml:lang="ja">凛世さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Komiya_Kaho_Arisugawa_Natsuha">
+    <imas:Source rdf:resource="Komiya_Kaho"/>
+    <imas:Destination rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Called xml:lang="ja">夏葉さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Komiya_Kaho_Serizawa_Asahi">
+    <imas:Source rdf:resource="Komiya_Kaho"/>
+    <imas:Destination rdf:resource="Serizawa_Asahi"/>
+    <imas:Called xml:lang="ja">あさひさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Komiya_Kaho_Mayuzumi_Fuyuko">
+    <imas:Source rdf:resource="Komiya_Kaho"/>
+    <imas:Destination rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Called xml:lang="ja">ふゆさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Komiya_Kaho_Izumi_Mei">
+    <imas:Source rdf:resource="Komiya_Kaho"/>
+    <imas:Destination rdf:resource="Izumi_Mei"/>
+    <imas:Called xml:lang="ja">愛依さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Komiya_Kaho_Asakura_Toru">
+    <imas:Source rdf:resource="Komiya_Kaho"/>
+    <imas:Destination rdf:resource="Asakura_Toru"/>
+    <imas:Called xml:lang="ja">透さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Komiya_Kaho_Higuchi_Madoka">
+    <imas:Source rdf:resource="Komiya_Kaho"/>
+    <imas:Destination rdf:resource="Higuchi_Madoka"/>
+    <imas:Called xml:lang="ja">円香さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Komiya_Kaho_Fukumaru_Koito">
+    <imas:Source rdf:resource="Komiya_Kaho"/>
+    <imas:Destination rdf:resource="Fukumaru_Koito"/>
+    <imas:Called xml:lang="ja">小糸さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Komiya_Kaho_Ichikawa_Hinana">
+    <imas:Source rdf:resource="Komiya_Kaho"/>
+    <imas:Destination rdf:resource="Ichikawa_Hinana"/>
+    <imas:Called xml:lang="ja">雛菜さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Komiya_Kaho_Nanakusa_Hazuki">
+    <imas:Source rdf:resource="Komiya_Kaho"/>
+    <imas:Destination rdf:resource="Nanakusa_Hazuki"/>
+    <imas:Called xml:lang="ja">はづきさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Komiya_Kaho_Sakuragi_Mano">
+    <imas:Source rdf:resource="Komiya_Kaho"/>
+    <imas:Destination rdf:resource="Sakuragi_Mano"/>
+    <imas:Called xml:lang="ja">真乃ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sonoda_Chiyoko_Hachimiya_Meguru">
+    <imas:Source rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Destination rdf:resource="Hachimiya_Meguru"/>
+    <imas:Called xml:lang="ja">めぐるちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sonoda_Chiyoko_Tsukioka_Kogane">
+    <imas:Source rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Destination rdf:resource="Tsukioka_Kogane"/>
+    <imas:Called xml:lang="ja">恋鐘ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sonoda_Chiyoko_Tanaka_Mamimi">
+    <imas:Source rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Destination rdf:resource="Tanaka_Mamimi"/>
+    <imas:Called xml:lang="ja">摩美々ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sonoda_Chiyoko_Shirase_Sakuya">
+    <imas:Source rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Destination rdf:resource="Shirase_Sakuya"/>
+    <imas:Called xml:lang="ja">咲耶ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sonoda_Chiyoko_Mitsumine_Yuika">
+    <imas:Source rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Destination rdf:resource="Mitsumine_Yuika"/>
+    <imas:Called xml:lang="ja">結華ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sonoda_Chiyoko_Yukoku_Kiriko">
+    <imas:Source rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Destination rdf:resource="Yukoku_Kiriko"/>
+    <imas:Called xml:lang="ja">霧子ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sonoda_Chiyoko_Osaki_Amana">
+    <imas:Source rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Destination rdf:resource="Osaki_Amana"/>
+    <imas:Called xml:lang="ja">甘奈ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sonoda_Chiyoko_Osaki_Tenka">
+    <imas:Source rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Destination rdf:resource="Osaki_Tenka"/>
+    <imas:Called xml:lang="ja">甜花ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sonoda_Chiyoko_Komiya_Kaho">
+    <imas:Source rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Destination rdf:resource="Komiya_Kaho"/>
+    <imas:Called xml:lang="ja">果穂</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sonoda_Chiyoko_Saijo_Juri">
+    <imas:Source rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Destination rdf:resource="Saijo_Juri"/>
+    <imas:Called xml:lang="ja">樹里ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sonoda_Chiyoko_Morino_Rinze">
+    <imas:Source rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Destination rdf:resource="Morino_Rinze"/>
+    <imas:Called xml:lang="ja">凛世ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sonoda_Chiyoko_Arisugawa_Natsuha">
+    <imas:Source rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Destination rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Called xml:lang="ja">夏葉ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sonoda_Chiyoko_Serizawa_Asahi">
+    <imas:Source rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Destination rdf:resource="Serizawa_Asahi"/>
+    <imas:Called xml:lang="ja">あさひちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sonoda_Chiyoko_Mayuzumi_Fuyuko">
+    <imas:Source rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Destination rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Called xml:lang="ja">ふゆちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sonoda_Chiyoko_Izumi_Mei">
+    <imas:Source rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Destination rdf:resource="Izumi_Mei"/>
+    <imas:Called xml:lang="ja">愛依ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sonoda_Chiyoko_Asakura_Toru">
+    <imas:Source rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Destination rdf:resource="Asakura_Toru"/>
+    <imas:Called xml:lang="ja">透ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sonoda_Chiyoko_Higuchi_Madoka">
+    <imas:Source rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Destination rdf:resource="Higuchi_Madoka"/>
+    <imas:Called xml:lang="ja">円香ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sonoda_Chiyoko_Fukumaru_Koito">
+    <imas:Source rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Destination rdf:resource="Fukumaru_Koito"/>
+    <imas:Called xml:lang="ja">小糸ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sonoda_Chiyoko_Ichikawa_Hinana">
+    <imas:Source rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Destination rdf:resource="Ichikawa_Hinana"/>
+    <imas:Called xml:lang="ja">雛菜ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sonoda_Chiyoko_Sakuragi_Mano">
+    <imas:Source rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Destination rdf:resource="Sakuragi_Mano"/>
+    <imas:Called xml:lang="ja">真乃</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Saijo_Juri_Kazano_Hiori">
+    <imas:Source rdf:resource="Saijo_Juri"/>
+    <imas:Destination rdf:resource="Kazano_Hiori"/>
+    <imas:Called xml:lang="ja">灯織</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Saijo_Juri_Tsukioka_Kogane">
+    <imas:Source rdf:resource="Saijo_Juri"/>
+    <imas:Destination rdf:resource="Tsukioka_Kogane"/>
+    <imas:Called xml:lang="ja">恋鐘</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Saijo_Juri_Shirase_Sakuya">
+    <imas:Source rdf:resource="Saijo_Juri"/>
+    <imas:Destination rdf:resource="Shirase_Sakuya"/>
+    <imas:Called xml:lang="ja">咲耶</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Saijo_Juri_Yukoku_Kiriko">
+    <imas:Source rdf:resource="Saijo_Juri"/>
+    <imas:Destination rdf:resource="Yukoku_Kiriko"/>
+    <imas:Called xml:lang="ja">霧子</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Saijo_Juri_Osaki_Amana">
+    <imas:Source rdf:resource="Saijo_Juri"/>
+    <imas:Destination rdf:resource="Osaki_Amana"/>
+    <imas:Called xml:lang="ja">甘奈</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Saijo_Juri_Osaki_Tenka">
+    <imas:Source rdf:resource="Saijo_Juri"/>
+    <imas:Destination rdf:resource="Osaki_Tenka"/>
+    <imas:Called xml:lang="ja">甜花</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Saijo_Juri_Kuwayama_Chiyuki">
+    <imas:Source rdf:resource="Saijo_Juri"/>
+    <imas:Destination rdf:resource="Kuwayama_Chiyuki"/>
+    <imas:Called xml:lang="ja">千雪さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Saijo_Juri_Komiya_Kaho">
+    <imas:Source rdf:resource="Saijo_Juri"/>
+    <imas:Destination rdf:resource="Komiya_Kaho"/>
+    <imas:Called xml:lang="ja">果穂</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Saijo_Juri_Sonoda_Chiyoko">
+    <imas:Source rdf:resource="Saijo_Juri"/>
+    <imas:Destination rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Called xml:lang="ja">チョコ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Saijo_Juri_Morino_Rinze">
+    <imas:Source rdf:resource="Saijo_Juri"/>
+    <imas:Destination rdf:resource="Morino_Rinze"/>
+    <imas:Called xml:lang="ja">凛世</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Saijo_Juri_Arisugawa_Natsuha">
+    <imas:Source rdf:resource="Saijo_Juri"/>
+    <imas:Destination rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Called xml:lang="ja">夏葉</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Saijo_Juri_Serizawa_Asahi">
+    <imas:Source rdf:resource="Saijo_Juri"/>
+    <imas:Destination rdf:resource="Serizawa_Asahi"/>
+    <imas:Called xml:lang="ja">あさひ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Saijo_Juri_Mayuzumi_Fuyuko">
+    <imas:Source rdf:resource="Saijo_Juri"/>
+    <imas:Destination rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Called xml:lang="ja">冬優子</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Saijo_Juri_Ichikawa_Hinana">
+    <imas:Source rdf:resource="Saijo_Juri"/>
+    <imas:Destination rdf:resource="Ichikawa_Hinana"/>
+    <imas:Called xml:lang="ja">雛菜</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Saijo_Juri_Nanakusa_Hazuki">
+    <imas:Source rdf:resource="Saijo_Juri"/>
+    <imas:Destination rdf:resource="Nanakusa_Hazuki"/>
+    <imas:Called xml:lang="ja">はづきさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Morino_Rinze_Kazano_Hiori">
+    <imas:Source rdf:resource="Morino_Rinze"/>
+    <imas:Destination rdf:resource="Kazano_Hiori"/>
+    <imas:Called xml:lang="ja">灯織さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Morino_Rinze_Hachimiya_Meguru">
+    <imas:Source rdf:resource="Morino_Rinze"/>
+    <imas:Destination rdf:resource="Hachimiya_Meguru"/>
+    <imas:Called xml:lang="ja">めぐるさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Morino_Rinze_Tsukioka_Kogane">
+    <imas:Source rdf:resource="Morino_Rinze"/>
+    <imas:Destination rdf:resource="Tsukioka_Kogane"/>
+    <imas:Called xml:lang="ja">恋鐘さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Morino_Rinze_Shirase_Sakuya">
+    <imas:Source rdf:resource="Morino_Rinze"/>
+    <imas:Destination rdf:resource="Shirase_Sakuya"/>
+    <imas:Called xml:lang="ja">咲耶さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Morino_Rinze_Komiya_Kaho">
+    <imas:Source rdf:resource="Morino_Rinze"/>
+    <imas:Destination rdf:resource="Komiya_Kaho"/>
+    <imas:Called xml:lang="ja">果穂さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Morino_Rinze_Sonoda_Chiyoko">
+    <imas:Source rdf:resource="Morino_Rinze"/>
+    <imas:Destination rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Called xml:lang="ja">智代子さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Morino_Rinze_Saijo_Juri">
+    <imas:Source rdf:resource="Morino_Rinze"/>
+    <imas:Destination rdf:resource="Saijo_Juri"/>
+    <imas:Called xml:lang="ja">樹里さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Morino_Rinze_Arisugawa_Natsuha">
+    <imas:Source rdf:resource="Morino_Rinze"/>
+    <imas:Destination rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Called xml:lang="ja">夏葉さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Morino_Rinze_Serizawa_Asahi">
+    <imas:Source rdf:resource="Morino_Rinze"/>
+    <imas:Destination rdf:resource="Serizawa_Asahi"/>
+    <imas:Called xml:lang="ja">あさひさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Morino_Rinze_Izumi_Mei">
+    <imas:Source rdf:resource="Morino_Rinze"/>
+    <imas:Destination rdf:resource="Izumi_Mei"/>
+    <imas:Called xml:lang="ja">愛依さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Morino_Rinze_Nanakusa_Hazuki">
+    <imas:Source rdf:resource="Morino_Rinze"/>
+    <imas:Destination rdf:resource="Nanakusa_Hazuki"/>
+    <imas:Called xml:lang="ja">はづきさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Morino_Rinze_Sakuragi_Mano">
+    <imas:Source rdf:resource="Morino_Rinze"/>
+    <imas:Destination rdf:resource="Sakuragi_Mano"/>
+    <imas:Called xml:lang="ja">真乃</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Arisugawa_Natsuha_Kazano_Hiori">
+    <imas:Source rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Destination rdf:resource="Kazano_Hiori"/>
+    <imas:Called xml:lang="ja">凛世</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Arisugawa_Natsuha_Hachimiya_Meguru">
+    <imas:Source rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Destination rdf:resource="Hachimiya_Meguru"/>
+    <imas:Called xml:lang="ja">めぐる</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Arisugawa_Natsuha_Tsukioka_Kogane">
+    <imas:Source rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Destination rdf:resource="Tsukioka_Kogane"/>
+    <imas:Called xml:lang="ja">恋鐘</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Arisugawa_Natsuha_Tanaka_Mamimi">
+    <imas:Source rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Destination rdf:resource="Tanaka_Mamimi"/>
+    <imas:Called xml:lang="ja">摩美々</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Arisugawa_Natsuha_Mitsumine_Yuika">
+    <imas:Source rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Destination rdf:resource="Mitsumine_Yuika"/>
+    <imas:Called xml:lang="ja">結華</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Arisugawa_Natsuha_Yukoku_Kiriko">
+    <imas:Source rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Destination rdf:resource="Yukoku_Kiriko"/>
+    <imas:Called xml:lang="ja">霧子</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Arisugawa_Natsuha_Komiya_Kaho">
+    <imas:Source rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Destination rdf:resource="Komiya_Kaho"/>
+    <imas:Called xml:lang="ja">果穂</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Arisugawa_Natsuha_Sonoda_Chiyoko">
+    <imas:Source rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Destination rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Called xml:lang="ja">智代子</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Arisugawa_Natsuha_Saijo_Juri">
+    <imas:Source rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Destination rdf:resource="Saijo_Juri"/>
+    <imas:Called xml:lang="ja">樹里</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Arisugawa_Natsuha_Morino_Rinze">
+    <imas:Source rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Destination rdf:resource="Morino_Rinze"/>
+    <imas:Called xml:lang="ja">凛世</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Arisugawa_Natsuha_Serizawa_Asahi">
+    <imas:Source rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Destination rdf:resource="Serizawa_Asahi"/>
+    <imas:Called xml:lang="ja">あさひ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Arisugawa_Natsuha_Mayuzumi_Fuyuko">
+    <imas:Source rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Destination rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Called xml:lang="ja">冬優子</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Arisugawa_Natsuha_Nanakusa_Hazuki">
+    <imas:Source rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Destination rdf:resource="Nanakusa_Hazuki"/>
+    <imas:Called xml:lang="ja">はづき</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Serizawa_Asahi_Sakuragi_Mano">
+    <imas:Source rdf:resource="Serizawa_Asahi"/>
+    <imas:Destination rdf:resource="Sakuragi_Mano"/>
+    <imas:Called xml:lang="ja">真乃ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Serizawa_Asahi_Kazano_Hiori">
+    <imas:Source rdf:resource="Serizawa_Asahi"/>
+    <imas:Destination rdf:resource="Kazano_Hiori"/>
+    <imas:Called xml:lang="ja">灯織ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Serizawa_Asahi_Tsukioka_Kogane">
+    <imas:Source rdf:resource="Serizawa_Asahi"/>
+    <imas:Destination rdf:resource="Tsukioka_Kogane"/>
+    <imas:Called xml:lang="ja">恋鐘ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Serizawa_Asahi_Tanaka_Mamimi">
+    <imas:Source rdf:resource="Serizawa_Asahi"/>
+    <imas:Destination rdf:resource="Tanaka_Mamimi"/>
+    <imas:Called xml:lang="ja">摩美々ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Serizawa_Asahi_Shirase_Sakuya">
+    <imas:Source rdf:resource="Serizawa_Asahi"/>
+    <imas:Destination rdf:resource="Shirase_Sakuya"/>
+    <imas:Called xml:lang="ja">咲耶さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Serizawa_Asahi_Yukoku_Kiriko">
+    <imas:Source rdf:resource="Serizawa_Asahi"/>
+    <imas:Destination rdf:resource="Yukoku_Kiriko"/>
+    <imas:Called xml:lang="ja">霧子ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Serizawa_Asahi_Komiya_Kaho">
+    <imas:Source rdf:resource="Serizawa_Asahi"/>
+    <imas:Destination rdf:resource="Komiya_Kaho"/>
+    <imas:Called xml:lang="ja">果穂ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Serizawa_Asahi_Saijo_Juri">
+    <imas:Source rdf:resource="Serizawa_Asahi"/>
+    <imas:Destination rdf:resource="Saijo_Juri"/>
+    <imas:Called xml:lang="ja">樹里ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Serizawa_Asahi_Morino_Rinze">
+    <imas:Source rdf:resource="Serizawa_Asahi"/>
+    <imas:Destination rdf:resource="Morino_Rinze"/>
+    <imas:Called xml:lang="ja">凛世ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Serizawa_Asahi_Arisugawa_Natsuha">
+    <imas:Source rdf:resource="Serizawa_Asahi"/>
+    <imas:Destination rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Called xml:lang="ja">夏葉さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Serizawa_Asahi_Mayuzumi_Fuyuko">
+    <imas:Source rdf:resource="Serizawa_Asahi"/>
+    <imas:Destination rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Called xml:lang="ja">冬優子ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Serizawa_Asahi_Izumi_Mei">
+    <imas:Source rdf:resource="Serizawa_Asahi"/>
+    <imas:Destination rdf:resource="Izumi_Mei"/>
+    <imas:Called xml:lang="ja">愛依ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Serizawa_Asahi_Asakura_Toru">
+    <imas:Source rdf:resource="Serizawa_Asahi"/>
+    <imas:Destination rdf:resource="Asakura_Toru"/>
+    <imas:Called xml:lang="ja">透ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Serizawa_Asahi_Fukumaru_Koito">
+    <imas:Source rdf:resource="Serizawa_Asahi"/>
+    <imas:Destination rdf:resource="Fukumaru_Koito"/>
+    <imas:Called xml:lang="ja">小糸ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Serizawa_Asahi_Sakuragi_Mano">
+    <imas:Source rdf:resource="Serizawa_Asahi"/>
+    <imas:Destination rdf:resource="Sakuragi_Mano"/>
+    <imas:Called xml:lang="ja">真乃ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mayuzumi_Fuyuko_Kazano_Hiori">
+    <imas:Source rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Destination rdf:resource="Kazano_Hiori"/>
+    <imas:Called xml:lang="ja">灯織ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mayuzumi_Fuyuko_Hachimiya_Meguru">
+    <imas:Source rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Destination rdf:resource="Hachimiya_Meguru"/>
+    <imas:Called xml:lang="ja">めぐるちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mayuzumi_Fuyuko_Tsukioka_Kogane">
+    <imas:Source rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Destination rdf:resource="Tsukioka_Kogane"/>
+    <imas:Called xml:lang="ja">恋鐘ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mayuzumi_Fuyuko_Tanaka_Mamimi">
+    <imas:Source rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Destination rdf:resource="Tanaka_Mamimi"/>
+    <imas:Called xml:lang="ja">摩美々ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mayuzumi_Fuyuko_Shirase_Sakuya">
+    <imas:Source rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Destination rdf:resource="Shirase_Sakuya"/>
+    <imas:Called xml:lang="ja">咲耶ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mayuzumi_Fuyuko_Mitsumine_Yuika">
+    <imas:Source rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Destination rdf:resource="Mitsumine_Yuika"/>
+    <imas:Called xml:lang="ja">ゆいにゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mayuzumi_Fuyuko_Osaki_Amana">
+    <imas:Source rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Destination rdf:resource="Osaki_Amana"/>
+    <imas:Called xml:lang="ja">甘奈ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mayuzumi_Fuyuko_Osaki_Tenka">
+    <imas:Source rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Destination rdf:resource="Osaki_Tenka"/>
+    <imas:Called xml:lang="ja">甜花ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mayuzumi_Fuyuko_Kuwayama_Chiyuki">
+    <imas:Source rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Destination rdf:resource="Kuwayama_Chiyuki"/>
+    <imas:Called xml:lang="ja">千雪さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mayuzumi_Fuyuko_Komiya_Kaho">
+    <imas:Source rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Destination rdf:resource="Komiya_Kaho"/>
+    <imas:Called xml:lang="ja">果穂ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mayuzumi_Fuyuko_Sonoda_Chiyoko">
+    <imas:Source rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Destination rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Called xml:lang="ja">智代子ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mayuzumi_Fuyuko_Saijo_Juri">
+    <imas:Source rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Destination rdf:resource="Saijo_Juri"/>
+    <imas:Called xml:lang="ja">樹里ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mayuzumi_Fuyuko_Morino_Rinze">
+    <imas:Source rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Destination rdf:resource="Morino_Rinze"/>
+    <imas:Called xml:lang="ja">凛世ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mayuzumi_Fuyuko_Arisugawa_Natsuha">
+    <imas:Source rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Destination rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Called xml:lang="ja">夏葉さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mayuzumi_Fuyuko_Serizawa_Asahi">
+    <imas:Source rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Destination rdf:resource="Serizawa_Asahi"/>
+    <imas:Called xml:lang="ja">あさひちゃん</imas:Called>
+    <imas:Called xml:lang="ja">あさひ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mayuzumi_Fuyuko_Izumi_Mei">
+    <imas:Source rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Destination rdf:resource="Izumi_Mei"/>
+    <imas:Called xml:lang="ja">愛依ちゃん</imas:Called>
+    <imas:Called xml:lang="ja">愛依</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mayuzumi_Fuyuko_Asakura_Toru">
+    <imas:Source rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Destination rdf:resource="Asakura_Toru"/>
+    <imas:Called xml:lang="ja">透ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mayuzumi_Fuyuko_Higuchi_Madoka">
+    <imas:Source rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Destination rdf:resource="Higuchi_Madoka"/>
+    <imas:Called xml:lang="ja">円香ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mayuzumi_Fuyuko_Fukumaru_Koito">
+    <imas:Source rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Destination rdf:resource="Fukumaru_Koito"/>
+    <imas:Called xml:lang="ja">小糸ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mayuzumi_Fuyuko_Ichikawa_Hinana">
+    <imas:Source rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Destination rdf:resource="Ichikawa_Hinana"/>
+    <imas:Called xml:lang="ja">雛菜ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mayuzumi_Fuyuko_Sakuragi_Mano">
+    <imas:Source rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Destination rdf:resource="Sakuragi_Mano"/>
+    <imas:Called xml:lang="ja">真乃ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Izumi_Mei_Kazano_Hiori">
+    <imas:Source rdf:resource="Izumi_Mei"/>
+    <imas:Destination rdf:resource="Kazano_Hiori"/>
+    <imas:Called xml:lang="ja">灯織ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Izumi_Mei_Hachimiya_Meguru">
+    <imas:Source rdf:resource="Izumi_Mei"/>
+    <imas:Destination rdf:resource="Hachimiya_Meguru"/>
+    <imas:Called xml:lang="ja">めぐるちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Izumi_Mei_Tsukioka_Kogane">
+    <imas:Source rdf:resource="Izumi_Mei"/>
+    <imas:Destination rdf:resource="Tsukioka_Kogane"/>
+    <imas:Called xml:lang="ja">恋鐘ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Izumi_Mei_Tanaka_Mamimi">
+    <imas:Source rdf:resource="Izumi_Mei"/>
+    <imas:Destination rdf:resource="Tanaka_Mamimi"/>
+    <imas:Called xml:lang="ja">摩美々ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Izumi_Mei_Shirase_Sakuya">
+    <imas:Source rdf:resource="Izumi_Mei"/>
+    <imas:Destination rdf:resource="Shirase_Sakuya"/>
+    <imas:Called xml:lang="ja">咲耶ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Izumi_Mei_Mitsumine_Yuika">
+    <imas:Source rdf:resource="Izumi_Mei"/>
+    <imas:Destination rdf:resource="Mitsumine_Yuika"/>
+    <imas:Called xml:lang="ja">結華ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Izumi_Mei_Yukoku_Kiriko">
+    <imas:Source rdf:resource="Izumi_Mei"/>
+    <imas:Destination rdf:resource="Yukoku_Kiriko"/>
+    <imas:Called xml:lang="ja">霧子ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Izumi_Mei_Osaki_Amana">
+    <imas:Source rdf:resource="Izumi_Mei"/>
+    <imas:Destination rdf:resource="Osaki_Amana"/>
+    <imas:Called xml:lang="ja">甘奈ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Izumi_Mei_Osaki_Tenka">
+    <imas:Source rdf:resource="Izumi_Mei"/>
+    <imas:Destination rdf:resource="Osaki_Tenka"/>
+    <imas:Called xml:lang="ja">甜花ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Izumi_Mei_Kuwayama_Chiyuki">
+    <imas:Source rdf:resource="Izumi_Mei"/>
+    <imas:Destination rdf:resource="Kuwayama_Chiyuki"/>
+    <imas:Called xml:lang="ja">千雪さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Izumi_Mei_Komiya_Kaho">
+    <imas:Source rdf:resource="Izumi_Mei"/>
+    <imas:Destination rdf:resource="Komiya_Kaho"/>
+    <imas:Called xml:lang="ja">果穂ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Izumi_Mei_Sonoda_Chiyoko">
+    <imas:Source rdf:resource="Izumi_Mei"/>
+    <imas:Destination rdf:resource="Sonoda_Chiyoko"/>
+    <imas:Called xml:lang="ja">智代子ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Izumi_Mei_Morino_Rinze">
+    <imas:Source rdf:resource="Izumi_Mei"/>
+    <imas:Destination rdf:resource="Morino_Rinze"/>
+    <imas:Called xml:lang="ja">凛世ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Izumi_Mei_Arisugawa_Natsuha">
+    <imas:Source rdf:resource="Izumi_Mei"/>
+    <imas:Destination rdf:resource="Arisugawa_Natsuha"/>
+    <imas:Called xml:lang="ja">夏葉ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Izumi_Mei_Serizawa_Asahi">
+    <imas:Source rdf:resource="Izumi_Mei"/>
+    <imas:Destination rdf:resource="Serizawa_Asahi"/>
+    <imas:Called xml:lang="ja">あさひちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Izumi_Mei_Mayuzumi_Fuyuko">
+    <imas:Source rdf:resource="Izumi_Mei"/>
+    <imas:Destination rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Called xml:lang="ja">冬優子ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Izumi_Mei_Asakura_Toru">
+    <imas:Source rdf:resource="Izumi_Mei"/>
+    <imas:Destination rdf:resource="Asakura_Toru"/>
+    <imas:Called xml:lang="ja">透ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Izumi_Mei_Fukumaru_Koito">
+    <imas:Source rdf:resource="Izumi_Mei"/>
+    <imas:Destination rdf:resource="Fukumaru_Koito"/>
+    <imas:Called xml:lang="ja">小糸ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Izumi_Mei_Nanakusa_Hazuki">
+    <imas:Source rdf:resource="Izumi_Mei"/>
+    <imas:Destination rdf:resource="Nanakusa_Hazuki"/>
+    <imas:Called xml:lang="ja">はづきさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asakura_Toru_Sakuragi_Mano">
+    <imas:Source rdf:resource="Asakura_Toru"/>
+    <imas:Destination rdf:resource="Sakuragi_Mano"/>
+    <imas:Called xml:lang="ja">真乃ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asakura_Toru_Higuchi_Madoka">
+    <imas:Source rdf:resource="Asakura_Toru"/>
+    <imas:Destination rdf:resource="Higuchi_Madoka"/>
+    <imas:Called xml:lang="ja">樋口</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asakura_Toru_Fukumaru_Koito">
+    <imas:Source rdf:resource="Asakura_Toru"/>
+    <imas:Destination rdf:resource="Fukumaru_Koito"/>
+    <imas:Called xml:lang="ja">小糸ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asakura_Toru_Ichikawa_Hinana">
+    <imas:Source rdf:resource="Asakura_Toru"/>
+    <imas:Destination rdf:resource="Ichikawa_Hinana"/>
+    <imas:Called xml:lang="ja">雛菜</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Higuchi_Madoka_Mayuzumi_Fuyuko">
+    <imas:Source rdf:resource="Higuchi_Madoka"/>
+    <imas:Destination rdf:resource="Mayuzumi_Fuyuko"/>
+    <imas:Called xml:lang="ja">冬優子さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Higuchi_Madoka_Asakura_Toru">
+    <imas:Source rdf:resource="Higuchi_Madoka"/>
+    <imas:Destination rdf:resource="Asakura_Toru"/>
+    <imas:Called xml:lang="ja">浅倉</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Higuchi_Madoka_Fukumaru_Koito">
+    <imas:Source rdf:resource="Higuchi_Madoka"/>
+    <imas:Destination rdf:resource="Fukumaru_Koito"/>
+    <imas:Called xml:lang="ja">小糸</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Higuchi_Madoka_Ichikawa_Hinana">
+    <imas:Source rdf:resource="Higuchi_Madoka"/>
+    <imas:Destination rdf:resource="Ichikawa_Hinana"/>
+    <imas:Called xml:lang="ja">雛菜</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fukumaru_Koito_Asakura_Toru">
+    <imas:Source rdf:resource="Fukumaru_Koito"/>
+    <imas:Destination rdf:resource="Asakura_Toru"/>
+    <imas:Called xml:lang="ja">透ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fukumaru_Koito_Higuchi_Madoka">
+    <imas:Source rdf:resource="Fukumaru_Koito"/>
+    <imas:Destination rdf:resource="Higuchi_Madoka"/>
+    <imas:Called xml:lang="ja">円香ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fukumaru_Koito_Ichikawa_Hinana">
+    <imas:Source rdf:resource="Fukumaru_Koito"/>
+    <imas:Destination rdf:resource="Ichikawa_Hinana"/>
+    <imas:Called xml:lang="ja">雛菜ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ichikawa_Hinana_Asakura_Toru">
+    <imas:Source rdf:resource="Ichikawa_Hinana"/>
+    <imas:Destination rdf:resource="Asakura_Toru"/>
+    <imas:Called xml:lang="ja">透先輩</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ichikawa_Hinana_Higuchi_Madoka">
+    <imas:Source rdf:resource="Ichikawa_Hinana"/>
+    <imas:Destination rdf:resource="Higuchi_Madoka"/>
+    <imas:Called xml:lang="ja">円香先輩</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ichikawa_Hinana_Fukumaru_Koito">
+    <imas:Source rdf:resource="Ichikawa_Hinana"/>
+    <imas:Destination rdf:resource="Fukumaru_Koito"/>
+    <imas:Called xml:lang="ja">小糸ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nanakusa_Nichika_Aketa_Mikoto">
+    <imas:Source rdf:resource="Nanakusa_Nichika"/>
+    <imas:Destination rdf:resource="Aketa_Mikoto"/>
+    <imas:Called xml:lang="ja">美琴さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nanakusa_Nichika_Nanakusa_Hazuki">
+    <imas:Source rdf:resource="Nanakusa_Nichika"/>
+    <imas:Destination rdf:resource="Nanakusa_Hazuki"/>
+    <imas:Called xml:lang="ja">お姉ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ikaruga_Luca_Aketa_Mikoto">
+    <imas:Source rdf:resource="Ikaruga_Luca"/>
+    <imas:Destination rdf:resource="Aketa_Mikoto"/>
+    <imas:Called xml:lang="ja">美琴</imas:Called>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
   </rdf:Description>
 </rdf:RDF>

--- a/RDFs/CallTable.rdf
+++ b/RDFs/CallTable.rdf
@@ -35851,6 +35851,14003 @@
     <imas:Called xml:lang="ja">詩花</imas:Called>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
   </rdf:Description>
+<!-- sideM -->
+  <rdf:Description rdf:about="Amagase_Toma_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Mitarai_Shota">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Tendo_Teru">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">天道さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">桜庭さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">柏木さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">都築さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Kagura_Rei">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">麗</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Takajo_Kyoji">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">鷹城さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Pierre">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエール</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Watanabe_Minori">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">渡辺さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Aoi_Yusuke">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Akuno_Hideo">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">握野さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Kimura_Ryu">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">木村さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Shingen_Seiji">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">信玄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">猫柳さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Hanamura_Shoma">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">華村さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">清澄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Akiyama_Hayato">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">隼人</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Fuyumi_Jun">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">旬</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">夏来</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Wakazato_Haruna">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">若里さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Iseya_Shiki">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Akai_Suzaku">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">朱雀</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Kurono_Genbu">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">神谷さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">東雲さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Asselin_BB_2">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスランさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Uzuki_Makio">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">卯月さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Mizushima_Saki">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">水嶋さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">桜庭</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">翼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Amagase_Toma">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Mitarai_Shota">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">都築さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Kagura_Rei">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">麗</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Takajo_Kyoji">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭二</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Pierre">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエール</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Watanabe_Minori">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Aoi_Yusuke">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Akuno_Hideo">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Kimura_Ryu">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">龍</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Shingen_Seiji">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">にゃんす</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Hanamura_Shoma">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">あねご</imas:Called>
+    <imas:Called xml:lang="ja">姐御</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Akiyama_Hayato">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">隼人</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Fuyumi_Jun">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">旬</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">夏来</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Wakazato_Haruna">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">春名</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Iseya_Shiki">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Akai_Suzaku">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">朱雀</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Kurono_Genbu">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Takajo_Kyoji">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭二</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Pierre">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエール</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Amagase_Toma">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Mitarai_Shota">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Tendo_Teru">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">輝</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">薫</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">翼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">圭さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Kagura_Rei">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">麗くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Aoi_Yusuke">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Akuno_Hideo">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Kimura_Ryu">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">龍</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Shingen_Seiji">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Hanamura_Shoma">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Akiyama_Hayato">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">隼人くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Fuyumi_Jun">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">旬くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">夏来くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Wakazato_Haruna">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">春名くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Iseya_Shiki">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Akai_Suzaku">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">朱雀くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Kurono_Genbu">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Akuno_Hideo">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Shingen_Seiji">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Amagase_Toma">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Mitarai_Shota">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Tendo_Teru">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">輝さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">薫さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">翼さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">都築さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Kagura_Rei">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">神楽</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Takajo_Kyoji">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">鷹城</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Pierre">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエール</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Watanabe_Minori">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Aoi_Yusuke">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">猫柳</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Hanamura_Shoma">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">清澄</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Akiyama_Hayato">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">秋山</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Fuyumi_Jun">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">冬美</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">榊</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Wakazato_Haruna">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">若里</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Iseya_Shiki">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">伊瀬谷</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Akai_Suzaku">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">紅井</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Kurono_Genbu">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">黒野</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Akiyama_Hayato">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">ハヤトっち</imas:Called>
+    <imas:Called xml:lang="ja">ハヤト先輩</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Fuyumi_Jun">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">ジュンっち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">ナツキっち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Wakazato_Haruna">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">ハルナっち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Amagase_Toma">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Mitarai_Shota">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Tendo_Teru">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">輝っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">薫っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">翼っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">圭っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Kagura_Rei">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">麗っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Takajo_Kyoji">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭二っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Pierre">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエールっち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Watanabe_Minori">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりっち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Aoi_Yusuke">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Akuno_Hideo">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Kimura_Ryu">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">龍っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Shingen_Seiji">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオっち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Hanamura_Shoma">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Akai_Suzaku">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">朱雀っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Kurono_Genbu">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Fuyumi_Jun">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">ジュン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">ナツキ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Wakazato_Haruna">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">ハルナ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Iseya_Shiki">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">シキ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Amagase_Toma">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬さん</imas:Called>
+    <imas:Called xml:lang="ja">冬馬</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Mitarai_Shota">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Tendo_Teru">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">輝さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">薫さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">翼さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">圭さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Kagura_Rei">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">麗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Takajo_Kyoji">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭二さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Pierre">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエール</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Watanabe_Minori">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Aoi_Yusuke">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Akuno_Hideo">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Kimura_Ryu">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">龍さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Shingen_Seiji">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Hanamura_Shoma">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Akai_Suzaku">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">朱雀</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Kurono_Genbu">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Kurono_Genbu">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Amagase_Toma">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Mitarai_Shota">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Tendo_Teru">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">輝さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">薫さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">翼さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">圭さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Kagura_Rei">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">麗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Takajo_Kyoji">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭二さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Pierre">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエール</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Watanabe_Minori">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Aoi_Yusuke">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Akuno_Hideo">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Kimura_Ryu">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">龍さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Shingen_Seiji">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Hanamura_Shoma">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Akiyama_Hayato">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">隼人さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Fuyumi_Jun">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">旬さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">夏来さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Wakazato_Haruna">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">春名さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Iseya_Shiki">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">カミヤ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">ソーイチロー</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Uzuki_Makio">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">マキオ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Mizushima_Saki">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">サキ</imas:Called>
+    <imas:Called xml:lang="ja">パピ族</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Amagase_Toma">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">トーマ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">暗黒貴公子ホクト</imas:Called>
+    <imas:Called xml:lang="ja">ホクト</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Mitarai_Shota">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">ショータ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Tendo_Teru">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">テル</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">カオル</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">ツバサ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">ケイ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Kagura_Rei">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">レイ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Takajo_Kyoji">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">キョウジ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Pierre">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエール</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Watanabe_Minori">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">ミノリ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Aoi_Yusuke">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">ユースケ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">キョースケ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Akuno_Hideo">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">ヒデオ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Kimura_Ryu">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">リュウ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Shingen_Seiji">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">セイジ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Hanamura_Shoma">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">ショーマ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">クロウ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Akiyama_Hayato">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">ハヤト</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Fuyumi_Jun">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">ジュン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">ナツキ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Wakazato_Haruna">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">ハルナ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Iseya_Shiki">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">シキ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">かみや</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">そういちろう</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Asselin_BB_2">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスラン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Uzuki_Makio">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">ロール</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Amagase_Toma">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">とうま</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">ほくと</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Mitarai_Shota">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">しょうた</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Tendo_Teru">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">てる</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">かおる</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">つばさ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">けい</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Kagura_Rei">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">れい</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Takajo_Kyoji">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">きょうじ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Pierre">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ぴえーる</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Watanabe_Minori">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのり</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Aoi_Yusuke">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">ゆうすけ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Akuno_Hideo">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">ひでお</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Kimura_Ryu">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">りゅう</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Shingen_Seiji">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">せいじ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Hanamura_Shoma">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">しょうま</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">くろう</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Akiyama_Hayato">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">はやと</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Fuyumi_Jun">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">じゅん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">なつき</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Wakazato_Haruna">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">はるな</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Iseya_Shiki">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">しき</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Okamura_Nao">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">なお</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Himeno_Kanon">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Amagase_Toma">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">とうま</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">ほくと</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Mitarai_Shota">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">しょうた</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Tendo_Teru">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">てる</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">かおる</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">つばさ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">けい</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Kagura_Rei">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">れい</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Takajo_Kyoji">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">きょうじ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Pierre">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエール</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Watanabe_Minori">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのり</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Aoi_Yusuke">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">ゆうすけ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">きょうすけ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Akuno_Hideo">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">ひでお</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Kimura_Ryu">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">せいじ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Shingen_Seiji">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">りゅう</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">きりお</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Hanamura_Shoma">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">しょうま</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">くろう</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Akiyama_Hayato">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">はやと</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Fuyumi_Jun">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">じゅん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">なつき</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Wakazato_Haruna">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">はるな</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Iseya_Shiki">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">しき</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Kizaki_Ren">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">オマエ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Enjoji_Michiru">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">円城寺さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Amagase_Toma">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Mitarai_Shota">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Tendo_Teru">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">輝さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">薫さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">翼さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">圭さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Kagura_Rei">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">麗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Takajo_Kyoji">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭二さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Pierre">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエールさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Watanabe_Minori">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Aoi_Yusuke">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Akuno_Hideo">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Kimura_Ryu">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">龍さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Shingen_Seiji">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Hanamura_Shoma">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Akiyama_Hayato">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">隼人さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Fuyumi_Jun">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">旬さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">夏来さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Wakazato_Haruna">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">春名さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Iseya_Shiki">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Taiga_Takeru">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">チビ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Enjoji_Michiru">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">らーめん屋</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Amagase_Toma">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Mitarai_Shota">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Tendo_Teru">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">輝</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">薫</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">でけーの</imas:Called>
+    <imas:Called xml:lang="ja">翼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">圭</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Kagura_Rei">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">オカッパ</imas:Called>
+    <imas:Called xml:lang="ja">麗</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Takajo_Kyoji">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭二</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Pierre">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエール</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Watanabe_Minori">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのり</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Aoi_Yusuke">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Akuno_Hideo">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Kimura_Ryu">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">龍</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Shingen_Seiji">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Hanamura_Shoma">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Akiyama_Hayato">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">隼人</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Fuyumi_Jun">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">旬</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">夏来</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Wakazato_Haruna">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">春名</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Iseya_Shiki">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">バンドメガネ野郎</imas:Called>
+    <imas:Called xml:lang="ja">四季</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Taiga_Takeru">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケル</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Kizaki_Ren">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">漣</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Amagase_Toma">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Mitarai_Shota">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Tendo_Teru">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">輝</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">薫</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">翼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">圭</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Kagura_Rei">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">麗</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Takajo_Kyoji">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭二</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Pierre">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエール</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Watanabe_Minori">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのり</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Aoi_Yusuke">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Akuno_Hideo">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Kimura_Ryu">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">龍</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Shingen_Seiji">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Hanamura_Shoma">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Akiyama_Hayato">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">隼人</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Fuyumi_Jun">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">旬</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">夏来</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Wakazato_Haruna">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">春名</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Iseya_Shiki">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Amagase_Toma">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Mitarai_Shota">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Tendo_Teru">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">輝</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">薫センセ</imas:Called>
+    <imas:Called xml:lang="ja">薫先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">翼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">圭</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Kagura_Rei">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">麗</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Takajo_Kyoji">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭二</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Pierre">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエール</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Watanabe_Minori">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのり</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Aoi_Yusuke">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Akuno_Hideo">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Kimura_Ryu">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">龍</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Shingen_Seiji">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Hanamura_Shoma">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Akiyama_Hayato">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">隼人</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Fuyumi_Jun">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">旬</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">夏来</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Wakazato_Haruna">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">春名</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Iseya_Shiki">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Amagase_Toma">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Mitarai_Shota">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Tendo_Teru">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">天道さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">桜庭さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">柏木さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">都築さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Kagura_Rei">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">神楽君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Takajo_Kyoji">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">鷹城君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Pierre">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエール君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Watanabe_Minori">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">渡辺さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Aoi_Yusuke">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Akuno_Hideo">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">握野さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Kimura_Ryu">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">木村君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Shingen_Seiji">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">信玄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">猫柳君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Hanamura_Shoma">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">華村さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">清澄君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Akiyama_Hayato">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">秋山君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Fuyumi_Jun">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">冬美君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">榊君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Wakazato_Haruna">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">若里君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Iseya_Shiki">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">伊瀬谷君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Akai_Suzaku">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">紅井君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Kurono_Genbu">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">黒野君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">神谷さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">東雲さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Asselin_BB_2">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスランさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Uzuki_Makio">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">卯月君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Mizushima_Saki">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">水嶋君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Tendo_Teru">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">天道</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">柏木</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Amagase_Toma">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">天ヶ瀬君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">伊集院君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Mitarai_Shota">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">御手洗君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">音楽家</imas:Called>
+    <imas:Called xml:lang="ja">都築さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Kagura_Rei">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">神楽君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Takajo_Kyoji">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">鷹城君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Pierre">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエール</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Watanabe_Minori">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">渡辺さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Aoi_Yusuke">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">双子兄</imas:Called>
+    <imas:Called xml:lang="ja">悠介君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Akuno_Hideo">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">握野君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Kimura_Ryu">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">木村君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Shingen_Seiji">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">信玄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">猫柳君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Hanamura_Shoma">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">華村さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">茶道家</imas:Called>
+    <imas:Called xml:lang="ja">清澄君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Akiyama_Hayato">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">学生</imas:Called>
+    <imas:Called xml:lang="ja">秋山君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Fuyumi_Jun">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">学生</imas:Called>
+    <imas:Called xml:lang="ja">冬美君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">ベーシスト</imas:Called>
+    <imas:Called xml:lang="ja">榊君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Wakazato_Haruna">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">若里君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Iseya_Shiki">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季君</imas:Called>
+    <imas:Called xml:lang="ja">伊瀬谷君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Akai_Suzaku">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">ヤンキーA</imas:Called>
+    <imas:Called xml:lang="ja">紅井君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Kurono_Genbu">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">ヤンキーB</imas:Called>
+    <imas:Called xml:lang="ja">黒野君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">都築さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Amagase_Toma">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">天ヶ瀬さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">伊集院さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Mitarai_Shota">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">御手洗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Tendo_Teru">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">天道さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">桜庭さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">柏木さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Takajo_Kyoji">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">鷹城さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Pierre">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエール</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Watanabe_Minori">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Aoi_Yusuke">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">蒼井さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">蒼井さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Akuno_Hideo">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">握野さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Kimura_Ryu">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">木村さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Shingen_Seiji">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">信玄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">猫柳さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Hanamura_Shoma">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">華村さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">清澄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Akiyama_Hayato">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">秋山さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Fuyumi_Jun">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">冬美さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">榊さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Wakazato_Haruna">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">若里さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Iseya_Shiki">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">伊瀬谷</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Akai_Suzaku">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">紅井</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Kurono_Genbu">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">黒野さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Pierre">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエール</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Watanabe_Minori">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Amagase_Toma">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">天ヶ瀬さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">伊集院さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Mitarai_Shota">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">御手洗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Tendo_Teru">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">天道さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">桜庭さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">柏木さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">都築さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Kagura_Rei">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">神楽</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Aoi_Yusuke">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Akuno_Hideo">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">握野さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Kimura_Ryu">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">木村</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Shingen_Seiji">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">信玄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">猫柳</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Hanamura_Shoma">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">華村さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">清澄</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Akiyama_Hayato">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">秋山</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Fuyumi_Jun">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">冬美</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">榊</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Wakazato_Haruna">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">若里</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Iseya_Shiki">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">伊瀬谷</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Akai_Suzaku">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">紅井</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Kurono_Genbu">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">黒野</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Aoi_Yusuke">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Amagase_Toma">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">とーまくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">ほくとくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Mitarai_Shota">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">しょーたくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Tendo_Teru">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">てるさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">かおるさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">つばささん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">けいさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Kagura_Rei">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">れいさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Takajo_Kyoji">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">きょーじくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Pierre">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ぴえーる</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Watanabe_Minori">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Akuno_Hideo">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">ひでおくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Kimura_Ryu">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">りゅーくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Shingen_Seiji">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">せーじさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">きりお</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Hanamura_Shoma">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">しょーまさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">くろーくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Akiyama_Hayato">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">はやと</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Fuyumi_Jun">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">じゅん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">なつき</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Wakazato_Haruna">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">はるな</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Iseya_Shiki">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">しき</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Akai_Suzaku">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">すざく</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Kurono_Genbu">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">げんぶ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Kimura_Ryu">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">龍</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Shingen_Seiji">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">信玄</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Amagase_Toma">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">翔太さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Mitarai_Shota">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">北斗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Tendo_Teru">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">輝</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">薫</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">翼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">圭</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Kagura_Rei">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">麗</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Takajo_Kyoji">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭二</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Pierre">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエール</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Watanabe_Minori">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのり</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Aoi_Yusuke">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Hanamura_Shoma">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Akiyama_Hayato">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">隼人</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Fuyumi_Jun">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">旬</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">夏来</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Wakazato_Haruna">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">春名</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Iseya_Shiki">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Akai_Suzaku">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">朱雀</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Kurono_Genbu">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Hanamura_Shoma">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">ちょうちょサン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">くろークン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Amagase_Toma">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">とーまクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">ほくとクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Mitarai_Shota">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">しょーたクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Tendo_Teru">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">てるクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">かおるクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">つばさクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">けいクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Kagura_Rei">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">れいクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Takajo_Kyoji">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">きょーじクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Pierre">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">かえるクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Watanabe_Minori">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Aoi_Yusuke">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">お兄ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">おとーとクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Akuno_Hideo">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄クン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Kimura_Ryu">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">りゅークン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Shingen_Seiji">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司クン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Akiyama_Hayato">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">隼人クン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Fuyumi_Jun">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">旬クン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">夏来クン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Wakazato_Haruna">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">春名クン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Iseya_Shiki">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季クン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Akai_Suzaku">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">とさかクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Kurono_Genbu">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武クン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Akiyama_Hayato">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">ハヤト</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Fuyumi_Jun">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">ジュン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Wakazato_Haruna">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">ハルナ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Iseya_Shiki">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">シキ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Amagase_Toma">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Mitarai_Shota">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Tendo_Teru">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">輝さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">薫さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">翼さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">圭さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Kagura_Rei">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">麗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Takajo_Kyoji">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭二さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Pierre">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエール</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Watanabe_Minori">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Aoi_Yusuke">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Akuno_Hideo">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Kimura_Ryu">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">龍さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Shingen_Seiji">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Hanamura_Shoma">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Akai_Suzaku">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">朱雀</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Kurono_Genbu">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Akiyama_Hayato">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">ハヤト</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">ナツキ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Wakazato_Haruna">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">春名さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Iseya_Shiki">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Amagase_Toma">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Mitarai_Shota">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Tendo_Teru">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">輝さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">薫さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">翼さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">圭さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Kagura_Rei">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">麗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Takajo_Kyoji">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭二さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Pierre">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエールくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Watanabe_Minori">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Aoi_Yusuke">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Akuno_Hideo">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Kimura_Ryu">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">龍さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Shingen_Seiji">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Hanamura_Shoma">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Akai_Suzaku">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">朱雀くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Kurono_Genbu">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Akai_Suzaku">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">朱雀</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Amagase_Toma">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Mitarai_Shota">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Tendo_Teru">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">輝アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">薫アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">翼アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">圭アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Kagura_Rei">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">麗</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Takajo_Kyoji">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭二アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Pierre">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエール</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Watanabe_Minori">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりアニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Aoi_Yusuke">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Akuno_Hideo">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Kimura_Ryu">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">龍アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Shingen_Seiji">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオアニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Hanamura_Shoma">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Akiyama_Hayato">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">隼人</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Fuyumi_Jun">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">旬</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">夏来</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Wakazato_Haruna">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">春名アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Iseya_Shiki">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">神谷</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Asselin_BB_2">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスランさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Uzuki_Makio">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻緒さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Mizushima_Saki">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">水嶋さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Amagase_Toma">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">天ヶ瀬さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">伊集院さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Mitarai_Shota">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">御手洗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Tendo_Teru">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">天道さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">桜庭さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">柏木さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">都築さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Kagura_Rei">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">神楽さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Takajo_Kyoji">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">鷹城さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Pierre">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエールさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Watanabe_Minori">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Aoi_Yusuke">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Akuno_Hideo">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">握野さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Kimura_Ryu">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">木村さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Shingen_Seiji">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">信玄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">猫柳さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Hanamura_Shoma">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">華村さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">清澄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Akiyama_Hayato">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">秋山さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Fuyumi_Jun">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">冬美さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">榊さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Wakazato_Haruna">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">若里さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Iseya_Shiki">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">伊瀬谷さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Tachibana_Shiro">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">しろうくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Himeno_Kanon">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのんくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Amagase_Toma">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">とうまくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">ほくとくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Mitarai_Shota">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">しょうたくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Tendo_Teru">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">てるさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">かおるさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">つばささん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">けいさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Kagura_Rei">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">れいくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Takajo_Kyoji">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">きょうじくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Pierre">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエールくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Watanabe_Minori">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Aoi_Yusuke">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">ゆうすけくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">きょうすけくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Akuno_Hideo">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">ひでおくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Kimura_Ryu">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">りゅうくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Shingen_Seiji">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">せいじさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">きりおくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Hanamura_Shoma">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">しょうまさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">くろうくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Akiyama_Hayato">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">はやとさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Fuyumi_Jun">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">じゅんさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">なつきくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Wakazato_Haruna">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">はるなくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Iseya_Shiki">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">しきくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Hazama_Michio">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">はざまさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Maita_Rui">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">るい</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Amagase_Toma">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">あまがせ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">みたらい</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Mitarai_Shota">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">いじゅういん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Tendo_Teru">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">てんどうせんせい</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">さくらばせんせい</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">かしわぎ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">つづきさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Kagura_Rei">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">かぐら</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Takajo_Kyoji">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">たかじょう</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Pierre">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエール</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Watanabe_Minori">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">わたなべさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Aoi_Yusuke">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介</imas:Called>
+    <imas:Called xml:lang="ja">ゆうすけ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介</imas:Called>
+    <imas:Called xml:lang="ja">きょうすけ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Akuno_Hideo">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">あくの</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Kimura_Ryu">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">きむら</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Shingen_Seiji">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">しんげんさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">ねこやなぎ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Hanamura_Shoma">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">はなむら</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">きよすみ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Akiyama_Hayato">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">あきやま</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Fuyumi_Jun">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">ふゆみ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">さかき</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Wakazato_Haruna">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">わかざと</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Iseya_Shiki">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">いせや</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Maita_Rui">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">舞田くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Yamashita_Jiro">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">山下くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Amagase_Toma">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">天ヶ瀬君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">伊集院君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Mitarai_Shota">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">御手洗君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Tendo_Teru">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">天道君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">桜庭君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">柏木君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">都築君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Kagura_Rei">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">神楽君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Takajo_Kyoji">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">鷹城君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Pierre">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエール君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Watanabe_Minori">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">渡辺君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Aoi_Yusuke">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Akuno_Hideo">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">握野君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Kimura_Ryu">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">木村君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Shingen_Seiji">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">信玄君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">猫柳君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Hanamura_Shoma">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">華村君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">清澄君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Akiyama_Hayato">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">秋山君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Fuyumi_Jun">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">冬美君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">榊君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Wakazato_Haruna">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">若里君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Iseya_Shiki">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">伊瀬谷君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Kabuto_Daigo">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">大吾</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Amagase_Toma">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Mitarai_Shota">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Tendo_Teru">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">輝さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">薫さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">翼さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">都築さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Kagura_Rei">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">神楽さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Takajo_Kyoji">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭二さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Pierre">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエールさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Watanabe_Minori">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Aoi_Yusuke">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Akuno_Hideo">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Kimura_Ryu">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">龍さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Shingen_Seiji">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Hanamura_Shoma">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Akiyama_Hayato">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">隼人さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Fuyumi_Jun">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">旬さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">夏来さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Wakazato_Haruna">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">春名さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Iseya_Shiki">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Kitamura_Sora">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">北村</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Koron_Chris">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">古論</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Amagase_Toma">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">天ヶ瀬</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">伊集院</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Mitarai_Shota">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">御手洗</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Tendo_Teru">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">天道サン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">桜庭サン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">柏木</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">都築サン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Kagura_Rei">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">神楽</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Takajo_Kyoji">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">鷹城</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Pierre">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエール</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Watanabe_Minori">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">渡辺サン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Aoi_Yusuke">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">蒼井兄</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">蒼井弟</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Akuno_Hideo">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">握野</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Kimura_Ryu">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">木村</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Shingen_Seiji">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">信玄サン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">猫柳</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Hanamura_Shoma">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">華村サン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">清澄</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Akiyama_Hayato">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">秋山</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Fuyumi_Jun">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">冬美</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">榊</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Wakazato_Haruna">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">若里</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Iseya_Shiki">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">伊瀬谷</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">雨彦</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Kitamura_Sora">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Amagase_Toma">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">天ヶ瀬さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">伊集院さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Mitarai_Shota">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">御手洗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Tendo_Teru">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">天道さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">桜庭さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">柏木さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">都築さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Kagura_Rei">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">神楽さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Takajo_Kyoji">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">鷹城さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Pierre">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエールさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Watanabe_Minori">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">渡辺さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Aoi_Yusuke">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Akuno_Hideo">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">握野さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Kimura_Ryu">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">木村さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Shingen_Seiji">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">信玄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">猫柳さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Hanamura_Shoma">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">華村さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">清澄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Akiyama_Hayato">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">秋山さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Fuyumi_Jun">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">冬美さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">榊さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Wakazato_Haruna">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">若里さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Iseya_Shiki">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">伊瀬谷さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amamine_Shu_Hanazono_Momohito">
+    <imas:Source rdf:resource="Amamine_Shu"/>
+    <imas:Destination rdf:resource="Hanazono_Momohito"/>
+    <imas:Called xml:lang="ja">百々人先輩</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amamine_Shu_Mayumi_Eishin">
+    <imas:Source rdf:resource="Amamine_Shu"/>
+    <imas:Destination rdf:resource="Mayumi_Eishin"/>
+    <imas:Called xml:lang="ja">鋭心先輩</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Amagase_Toma">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Tendo_Teru">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">輝さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">薫さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">翼さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">圭さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Kagura_Rei">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">麗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Takajo_Kyoji">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭二さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Pierre">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエールさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Watanabe_Minori">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Aoi_Yusuke">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Akuno_Hideo">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Kimura_Ryu">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">龍さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Shingen_Seiji">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Hanamura_Shoma">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Akiyama_Hayato">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">隼人さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Fuyumi_Jun">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">旬さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">夏来さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Wakazato_Haruna">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">春名さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Iseya_Shiki">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Akai_Suzaku">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">朱雀さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Kurono_Genbu">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">幸広さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">荘一郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Uzuki_Makio">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻緒さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Mizushima_Saki">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">咲さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Tendo_Teru">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">輝さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">薫さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Amagase_Toma">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Mitarai_Shota">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">都築さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Kagura_Rei">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">麗くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Takajo_Kyoji">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭二くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Pierre">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエールくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Watanabe_Minori">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Aoi_Yusuke">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Akuno_Hideo">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Kimura_Ryu">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">龍くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Shingen_Seiji">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司さん</imas:Called>
+    <imas:Called xml:lang="ja">信玄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Hanamura_Shoma">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Akiyama_Hayato">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">隼人くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Fuyumi_Jun">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">旬くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">夏来くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Wakazato_Haruna">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">春名くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Iseya_Shiki">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Akai_Suzaku">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">朱雀くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Kurono_Genbu">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Kagura_Rei">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">麗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Amagase_Toma">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Mitarai_Shota">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Tendo_Teru">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">輝さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">薫さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">翼さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Takajo_Kyoji">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭二さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Pierre">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエールさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Watanabe_Minori">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Aoi_Yusuke">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Akuno_Hideo">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Kimura_Ryu">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">龍さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Shingen_Seiji">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Hanamura_Shoma">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Akiyama_Hayato">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">隼人さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Fuyumi_Jun">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">旬さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">夏来さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Wakazato_Haruna">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">春名さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Iseya_Shiki">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Akai_Suzaku">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">朱雀さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Kurono_Genbu">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Takajo_Kyoji">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭二</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Watanabe_Minori">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのり</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Amagase_Toma">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Mitarai_Shota">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Tendo_Teru">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">輝</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">薫</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">翼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">圭</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Kagura_Rei">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">麗</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Aoi_Yusuke">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Akuno_Hideo">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Kimura_Ryu">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">龍</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Shingen_Seiji">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Hanamura_Shoma">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Akiyama_Hayato">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">隼人</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Fuyumi_Jun">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">旬</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">夏来</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Wakazato_Haruna">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">春名</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Iseya_Shiki">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Akai_Suzaku">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">朱雀</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Kurono_Genbu">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Amagase_Toma">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">とーまクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">ほくとクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Mitarai_Shota">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">しょーたクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Tendo_Teru">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">てるサン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">かおるサン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">つばさサン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">けいサン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Kagura_Rei">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">れいクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Takajo_Kyoji">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">きょーじクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Pierre">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエール</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Watanabe_Minori">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりサン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Akuno_Hideo">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">ひでおサン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Kimura_Ryu">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">りゅークン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Shingen_Seiji">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">せーじサン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Hanamura_Shoma">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">しょーまサン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">くろークン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Akiyama_Hayato">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">ハヤト</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Fuyumi_Jun">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">ジュン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">ナツキ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Wakazato_Haruna">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">ハルナ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Iseya_Shiki">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">シキ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Akai_Suzaku">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">スザク</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Kurono_Genbu">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">ゲンブ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Akuno_Hideo">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Kimura_Ryu">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">龍</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Amagase_Toma">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Mitarai_Shota">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Tendo_Teru">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">輝</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">薫</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">翼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">圭さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Kagura_Rei">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">麗</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Takajo_Kyoji">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭二</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Pierre">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエール</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Watanabe_Minori">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Aoi_Yusuke">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Hanamura_Shoma">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Akiyama_Hayato">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">隼人</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Fuyumi_Jun">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">旬</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">夏来</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Wakazato_Haruna">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">春名</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Iseya_Shiki">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Akai_Suzaku">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">朱雀</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Kurono_Genbu">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">ボーヤ</imas:Called>
+    <imas:Called xml:lang="ja">キリオちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Amagase_Toma">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Mitarai_Shota">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Tendo_Teru">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">てんてるちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">かおるちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">ウイングちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">圭ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Kagura_Rei">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">麗ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Takajo_Kyoji">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Pierre">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ケロンちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Watanabe_Minori">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのるん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Aoi_Yusuke">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">にいちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">おとうとちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Akuno_Hideo">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">ヒーローちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Kimura_Ryu">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">ドラゴンちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Shingen_Seiji">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司ちゃん</imas:Called>
+    <imas:Called xml:lang="ja">せーじちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Akiyama_Hayato">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">隼人ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Fuyumi_Jun">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">旬ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">夏来ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Wakazato_Haruna">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">春名ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Iseya_Shiki">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Akai_Suzaku">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">爆炎ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Kurono_Genbu">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">氷刃ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">猫柳さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Hanamura_Shoma">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">華村さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Amagase_Toma">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">天ヶ瀬さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">伊集院さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Mitarai_Shota">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">御手洗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Tendo_Teru">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">天道さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">桜庭さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">柏木さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">都築さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Kagura_Rei">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">神楽さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Takajo_Kyoji">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">鷹城さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Pierre">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエールさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Watanabe_Minori">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">渡辺さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Aoi_Yusuke">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Akuno_Hideo">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">握野さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Kimura_Ryu">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">木村さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Shingen_Seiji">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">信玄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Akiyama_Hayato">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">秋山さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Fuyumi_Jun">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">冬美さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">榊さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Wakazato_Haruna">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">若里さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Iseya_Shiki">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">伊瀬谷さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Akai_Suzaku">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">紅井さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Kurono_Genbu">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">黒野さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Akiyama_Hayato">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">ハヤト</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Fuyumi_Jun">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">ジュン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">ナツキ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Iseya_Shiki">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">シキ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Amagase_Toma">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Mitarai_Shota">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Tendo_Teru">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">輝さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">薫さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">翼さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">圭さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Kagura_Rei">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">麗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Takajo_Kyoji">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭二さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Pierre">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエール</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Watanabe_Minori">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Aoi_Yusuke">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Akuno_Hideo">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Kimura_Ryu">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">龍さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Shingen_Seiji">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Hanamura_Shoma">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Akai_Suzaku">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">朱雀</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Kurono_Genbu">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">東雲</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Asselin_BB_2">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスラン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Uzuki_Makio">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻緒</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Mizushima_Saki">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">咲</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Amagase_Toma">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Mitarai_Shota">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Tendo_Teru">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">輝さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">薫さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">翼さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">圭さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Kagura_Rei">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">麗くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Takajo_Kyoji">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭二くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Pierre">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエールくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Watanabe_Minori">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Aoi_Yusuke">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Akuno_Hideo">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Kimura_Ryu">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">龍くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Shingen_Seiji">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Hanamura_Shoma">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Akiyama_Hayato">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">隼人くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Fuyumi_Jun">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">旬くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">夏来くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Wakazato_Haruna">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">春名くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Iseya_Shiki">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">神谷さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">東雲さん</imas:Called>
+    <imas:Called xml:lang="ja">荘一郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Asselin_BB_2">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスランさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Mizushima_Saki">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">サキちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Amagase_Toma">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Mitarai_Shota">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Tendo_Teru">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">輝さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">薫さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">翼さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">圭さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Kagura_Rei">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">麗くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Takajo_Kyoji">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭二さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Pierre">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエールくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Watanabe_Minori">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Aoi_Yusuke">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Akuno_Hideo">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Kimura_Ryu">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">龍さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Shingen_Seiji">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Hanamura_Shoma">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Akiyama_Hayato">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">隼人くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Fuyumi_Jun">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">旬くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">夏来くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Wakazato_Haruna">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">春名くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Iseya_Shiki">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Okamura_Nao">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">なおくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Tachibana_Shiro">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">しろうくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Amagase_Toma">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">とうまくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">ほくとくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Mitarai_Shota">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">しょうたくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Tendo_Teru">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">てるくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">かおるくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">つばさくん</imas:Called>
+    <imas:Called xml:lang="ja">つばさおにいちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">けいくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Kagura_Rei">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">れいくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Takajo_Kyoji">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">きょうじくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Pierre">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエールくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Watanabe_Minori">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Aoi_Yusuke">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">ゆうすけくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">きょうすけくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Akuno_Hideo">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">ひでおくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Kimura_Ryu">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">りゅうくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Shingen_Seiji">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">せいじさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Hanamura_Shoma">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">しょうまさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">くろうくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Akiyama_Hayato">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">はやとくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Fuyumi_Jun">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">じゅんさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">なつきくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Wakazato_Haruna">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">はるなくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Iseya_Shiki">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">しきくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Hazama_Michio">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">ミスターはざま</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Yamashita_Jiro">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">ミスターやました</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Amagase_Toma">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">ミスターあまがせ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Mitarai_Shota">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">ミスターみたらい</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Tendo_Teru">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">ミスターてんどう</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">ミスターさくらば</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">ミスターかしわぎ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">ミスターつづき</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Kagura_Rei">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">ミスターかぐら</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Takajo_Kyoji">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">ミスターたかじょう</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Pierre">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエール</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Watanabe_Minori">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">ミスターわたなべ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Aoi_Yusuke">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">ミスターゆうすけ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">ミスターきょうすけ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Akuno_Hideo">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">ミスターあくの</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Kimura_Ryu">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">ミスターきむら</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Shingen_Seiji">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">ミスターしんげん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">ミスターねこやなぎ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Hanamura_Shoma">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">ミスターはなむら</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">ミスターきよすみ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Akiyama_Hayato">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">ミスターあきやま</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Fuyumi_Jun">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">ミスターふゆみ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">ミスターさかき</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Wakazato_Haruna">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">ミスターわかざと</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Iseya_Shiki">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">ミスターいせや</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Kabuto_Daigo">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">大吾くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">一希さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Amagase_Toma">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Mitarai_Shota">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Tendo_Teru">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">輝さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">薫さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">翼さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">都築さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Kagura_Rei">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">麗くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Takajo_Kyoji">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭二さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Pierre">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエールくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Watanabe_Minori">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Aoi_Yusuke">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Akuno_Hideo">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Kimura_Ryu">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">龍さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Shingen_Seiji">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Hanamura_Shoma">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Akiyama_Hayato">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">隼人くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Fuyumi_Jun">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">旬くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">夏来くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Wakazato_Haruna">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">春名くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Iseya_Shiki">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Akai_Suzaku">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">朱雀くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Kurono_Genbu">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">神谷さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">荘一郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Asselin_BB_2">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスランさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Uzuki_Makio">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻緒くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Mizushima_Saki">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">咲ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">雨彦さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Koron_Chris">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリスさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Amagase_Toma">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Mitarai_Shota">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Tendo_Teru">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">輝先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">薫先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">翼さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">圭先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Kagura_Rei">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">麗くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Takajo_Kyoji">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭二さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Pierre">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエールくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Watanabe_Minori">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Aoi_Yusuke">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Akuno_Hideo">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Kimura_Ryu">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">龍さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Shingen_Seiji">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオ先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Hanamura_Shoma">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Akiyama_Hayato">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">隼人くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Fuyumi_Jun">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">旬くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">夏来くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Wakazato_Haruna">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">春名くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Iseya_Shiki">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanazono_Momohito_Amamine_Shu">
+    <imas:Source rdf:resource="Hanazono_Momohito"/>
+    <imas:Destination rdf:resource="Amamine_Shu"/>
+    <imas:Called xml:lang="ja">アマミネくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Amagase_Toma">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">北斗さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Mitarai_Shota">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">翔太くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Tendo_Teru">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">輝さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">薫さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">翼さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">圭さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Kagura_Rei">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">麗くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Takajo_Kyoji">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">恭二さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Pierre">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ピエールくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Watanabe_Minori">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">みのりさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">享介くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Aoi_Yusuke">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">悠介くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Shingen_Seiji">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">誠司さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Akuno_Hideo">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Kimura_Ryu">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">龍さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">キリオくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Hanamura_Shoma">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Akiyama_Hayato">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">隼人くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Fuyumi_Jun">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">旬くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">夏来くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Wakazato_Haruna">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">春名くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Iseya_Shiki">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Akai_Suzaku">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">朱雀くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Kurono_Genbu">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Producer_Amagase_Toma">
+    <imas:Source rdf:resource="Producer"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">冬馬</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Producer_Tendo_Teru">
+    <imas:Source rdf:resource="Producer"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">天道さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Producer_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Producer"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">柏木さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Producer_Takajo_Kyoji">
+    <imas:Source rdf:resource="Producer"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">鷹城さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Producer_Shingen_Seiji">
+    <imas:Source rdf:resource="Producer"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">信玄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Producer_Akuno_Hideo">
+    <imas:Source rdf:resource="Producer"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">英雄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Producer_Hanamura_Shoma">
+    <imas:Source rdf:resource="Producer"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">翔真さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Producer_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Producer"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">九郎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Producer_Fuyumi_Jun">
+    <imas:Source rdf:resource="Producer"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">旬</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Producer_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Producer"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">夏来</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Producer_Iseya_Shiki">
+    <imas:Source rdf:resource="Producer"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Producer_Kurono_Genbu">
+    <imas:Source rdf:resource="Producer"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Okamura_Nao">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Tachibana_Shiro">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">志狼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Himeno_Kanon">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Hazama_Michio">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">硲さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Maita_Rui">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">舞田さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Yamashita_Jiro">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">山下さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Taiga_Takeru">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケル</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Enjoji_Michiru">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">円城寺さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Kizaki_Ren">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">牙崎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Kabuto_Daigo">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">大吾</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">九十九さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">葛之葉さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Kitamura_Sora">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">北村さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Koron_Chris">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">古論さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Yamamura_Ken">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">山村さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Amami_Haruka">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Amami_Haruka"/>
+    <imas:Called xml:lang="ja">天海</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Takatsuki_Yayoi">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Takatsuki_Yayoi"/>
+    <imas:Called xml:lang="ja">高槻</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Ganaha_Hibiki">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Ganaha_Hibiki"/>
+    <imas:Called xml:lang="ja">我那覇</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Minase_Iori">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Minase_Iori"/>
+    <imas:Called xml:lang="ja">水瀬</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Akizuki_Ritsuko">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Akizuki_Ritsuko"/>
+    <imas:Called xml:lang="ja">秋月</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Miura_Azusa">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Miura_Azusa"/>
+    <imas:Called xml:lang="ja">三浦さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Kuroi_Takao">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Kuroi_Takao"/>
+    <imas:Called xml:lang="ja">（黒井の）おっさん</imas:Called>
+    <imas:Called xml:lang="ja">黒井社長</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">神谷</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">荘一郎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Asselin_BB_2">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスラン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Uzuki_Makio">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻緒</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Mizushima_Saki">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">咲</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Okamura_Nao">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Tachibana_Shiro">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">志狼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Himeno_Kanon">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Hazama_Michio">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">硲先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Maita_Rui">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">類</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Yamashita_Jiro">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">山下さん</imas:Called>
+    <imas:Called xml:lang="ja">山下サン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Taiga_Takeru">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケル</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Kizaki_Ren">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">漣</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Enjoji_Michiru">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">道流</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Kabuto_Daigo">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">大吾</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">一希</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">雨彦</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Kitamura_Sora">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Koron_Chris">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリス</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Yamamura_Ken">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">ケン</imas:Called>
+    <imas:Called xml:lang="ja">賢</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">幸広</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">荘一郎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Asselin_BB_2">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスラン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Uzuki_Makio">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻緒くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Mizushima_Saki">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">咲くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Okamura_Nao">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Tachibana_Shiro">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">志狼くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Himeno_Kanon">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのんくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Hazama_Michio">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">道夫さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Maita_Rui">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">類</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Yamashita_Jiro">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">次郎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Taiga_Takeru">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケルくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Kizaki_Ren">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">漣くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Enjoji_Michiru">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">道流</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Kabuto_Daigo">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">大吾くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">一希くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">雨彦</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Kitamura_Sora">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Koron_Chris">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリス</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Yamamura_Ken">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">けんくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">幸広さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">荘一郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Asselin_BB_2">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスランさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Uzuki_Makio">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">卯月</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Mizushima_Saki">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">水嶋</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Okamura_Nao">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">岡村</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Tachibana_Shiro">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">橘</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Himeno_Kanon">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">姫野</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Hazama_Michio">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">道夫さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Maita_Rui">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">類さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Yamashita_Jiro">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">次郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Taiga_Takeru">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">大河</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Kizaki_Ren">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">牙崎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Enjoji_Michiru">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">道流さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">秋月</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Kabuto_Daigo">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">兜</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">九十九</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">雨彦さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Kitamura_Sora">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">北村</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Koron_Chris">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリスさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Yamamura_Ken">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">賢</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">神谷っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">東雲っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Asselin_BB_2">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスランっち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Uzuki_Makio">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻緒っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Mizushima_Saki">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">咲ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Okamura_Nao">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Tachibana_Shiro">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">志狼っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Himeno_Kanon">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのんっち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Hazama_Michio">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">硲っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Maita_Rui">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">類っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Yamashita_Jiro">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">次郎っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Taiga_Takeru">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケルっち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Kizaki_Ren">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">漣っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Enjoji_Michiru">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">道流っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼ちん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Kabuto_Daigo">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">大吾っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">九十九っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">雨彦っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Kitamura_Sora">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Koron_Chris">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリスっち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Yamamura_Ken">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">賢っち</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">神谷さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">東雲さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Asselin_BB_2">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスラン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Uzuki_Makio">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻緒</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Mizushima_Saki">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">咲</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Okamura_Nao">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Tachibana_Shiro">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">志狼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Himeno_Kanon">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Hazama_Michio">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">硲先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Maita_Rui">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">舞田先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Yamashita_Jiro">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">山下先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Taiga_Takeru">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケル</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Kizaki_Ren">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">漣</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Enjoji_Michiru">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">道流さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Kabuto_Daigo">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">大吾</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">一希さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">雨彦さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Kitamura_Sora">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Koron_Chris">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリスさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Yamamura_Ken">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">賢</imas:Called>
+    <imas:Called xml:lang="ja">ケン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">幸広さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">荘一郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Asselin_BB_2">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスランさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Uzuki_Makio">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻緒さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Mizushima_Saki">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">咲さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Okamura_Nao">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Tachibana_Shiro">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">志狼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Himeno_Kanon">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Hazama_Michio">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">道夫さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Maita_Rui">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">類さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Yamashita_Jiro">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">次郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Taiga_Takeru">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケルさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Kizaki_Ren">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">漣さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Enjoji_Michiru">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">道流さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Kabuto_Daigo">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">大吾</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">九十九さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">雨彦さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Kitamura_Sora">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Koron_Chris">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリスさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Yamamura_Ken">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">けんさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Akai_Suzaku">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">炎の使い手</imas:Called>
+    <imas:Called xml:lang="ja">スザク</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Kurono_Genbu">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">氷の使い手</imas:Called>
+    <imas:Called xml:lang="ja">ゲンブ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Okamura_Nao">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">ナオ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Tachibana_Shiro">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">シロウ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Himeno_Kanon">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">カノン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Hazama_Michio">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">ミチオ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Maita_Rui">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">ルイ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Yamashita_Jiro">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">ジロウ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Taiga_Takeru">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケル</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Kizaki_Ren">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">レン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Enjoji_Michiru">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">ミチル</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">リョウ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Kabuto_Daigo">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">ダイゴ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">運命を綴りし者ｶｽﾞｷ</imas:Called>
+    <imas:Called xml:lang="ja">カズキ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">アメヒコ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Kitamura_Sora">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">ソラ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Koron_Chris">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリス</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Yamamura_Ken">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">ケーン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Akai_Suzaku">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">すざく</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Kurono_Genbu">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">げんぶ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Okamura_Nao">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">なお</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Tachibana_Shiro">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">しろう</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Himeno_Kanon">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Hazama_Michio">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">みちお</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Maita_Rui">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">るい</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Yamashita_Jiro">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">じろう</imas:Called>
+    <imas:Called xml:lang="ja">じろー</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Taiga_Takeru">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">たける</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Kizaki_Ren">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">れん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Enjoji_Michiru">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">みちる</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">りょうちん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Kabuto_Daigo">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">だいご</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">かずき</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">あめひこ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Kitamura_Sora">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">そら</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Koron_Chris">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">くりす</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Yamamura_Ken">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">けん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Akai_Suzaku">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">すざくのあにき</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Kurono_Genbu">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">げんぶのあにき</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">かみや</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">そういちろう</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Asselin_BB_2">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスラン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Uzuki_Makio">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">まきお</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Mizushima_Saki">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">さき</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Hazama_Michio">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">みちおせんせい</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Maita_Rui">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">るいせんせい</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Yamashita_Jiro">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">じろうせんせい</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Taiga_Takeru">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">たける</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Kizaki_Ren">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">れん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Enjoji_Michiru">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">ししょー</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">りょう</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Kabuto_Daigo">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">だいご</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">かずき</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">あめひこ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Kitamura_Sora">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">そら</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Koron_Chris">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">くりす</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Yamamura_Ken">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">けん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Akai_Suzaku">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">朱雀さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Kurono_Genbu">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">神谷さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">荘一郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Asselin_BB_2">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスランさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Uzuki_Makio">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">卯月さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Mizushima_Saki">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">水嶋さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Okamura_Nao">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">岡村さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Tachibana_Shiro">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">橘さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Himeno_Kanon">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">姫野さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Hazama_Michio">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">硲さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Maita_Rui">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">舞田さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Yamashita_Jiro">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">山下さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">秋月さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Kabuto_Daigo">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">兜さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">九十九さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">葛之葉さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Kitamura_Sora">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">北村さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Koron_Chris">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">古論さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Akai_Suzaku">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">バーニン野郎</imas:Called>
+    <imas:Called xml:lang="ja">赤いの</imas:Called>
+    <imas:Called xml:lang="ja">朱雀</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Kurono_Genbu">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">デカメガネ</imas:Called>
+    <imas:Called xml:lang="ja">黒いの</imas:Called>
+    <imas:Called xml:lang="ja">玄武</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">幸広</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">（ｶﾌｪなんとかの）ｹｰｷ作るﾔﾂ</imas:Called>
+    <imas:Called xml:lang="ja">荘一郎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Asselin_BB_2">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">ｶﾌｪなんとかの料理作るﾔﾂ</imas:Called>
+    <imas:Called xml:lang="ja">アスラン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Uzuki_Makio">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">（ｶﾌｪなんとかの）ｹｰｷ食べるﾔﾂ</imas:Called>
+    <imas:Called xml:lang="ja">巻緒</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Mizushima_Saki">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">ｶﾌｪなんとかのｱｲﾂ</imas:Called>
+    <imas:Called xml:lang="ja">咲</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Okamura_Nao">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Tachibana_Shiro">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">志狼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Himeno_Kanon">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Hazama_Michio">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">メガネ</imas:Called>
+    <imas:Called xml:lang="ja">道夫</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Maita_Rui">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">類</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Yamashita_Jiro">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">次郎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Kabuto_Daigo">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">大吾</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">一希</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">メガネなし</imas:Called>
+    <imas:Called xml:lang="ja">雨彦</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Kitamura_Sora">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Koron_Chris">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリス</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Akai_Suzaku">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">朱雀</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Kurono_Genbu">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">幸広</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">荘一郎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Asselin_BB_2">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスラン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Uzuki_Makio">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻緒</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Mizushima_Saki">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">咲</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Okamura_Nao">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Tachibana_Shiro">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">志狼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Himeno_Kanon">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Hazama_Michio">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">道夫</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Maita_Rui">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">類</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Yamashita_Jiro">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">次郎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Kabuto_Daigo">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">大吾</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">一希</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">雨彦</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Kitamura_Sora">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Koron_Chris">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリス</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Yamamura_Ken">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">賢</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Akai_Suzaku">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">朱雀</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Kurono_Genbu">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">神谷</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">荘一郎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Asselin_BB_2">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスラン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Uzuki_Makio">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻緒</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Mizushima_Saki">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">咲</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Okamura_Nao">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Tachibana_Shiro">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">志狼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Himeno_Kanon">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Hazama_Michio">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">道夫</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Maita_Rui">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">類</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Yamashita_Jiro">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">次郎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Taiga_Takeru">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケル</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Kizaki_Ren">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">漣</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Enjoji_Michiru">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">道流</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">雨彦</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Kitamura_Sora">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Koron_Chris">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリス</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Yamamura_Ken">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">賢</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Okamura_Nao">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">岡村君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Tachibana_Shiro">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">橘君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Himeno_Kanon">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">姫野君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Hazama_Michio">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">硲さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Maita_Rui">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">マイケル</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Yamashita_Jiro">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">山下さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Taiga_Takeru">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">大河君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Kizaki_Ren">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">牙崎君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Enjoji_Michiru">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">円城寺さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">秋月君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Kabuto_Daigo">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">兜君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">九十九君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">葛之葉さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Kitamura_Sora">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">北村さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Koron_Chris">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">古論さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Yamamura_Ken">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">賢</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Amami_Haruka">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Amami_Haruka"/>
+    <imas:Called xml:lang="ja">春香ちゃん</imas:Called>
+    <imas:Called xml:lang="ja">りぼんちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Kikuchi_Makoto">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Kikuchi_Makoto"/>
+    <imas:Called xml:lang="ja">真ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Miura_Azusa">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Miura_Azusa"/>
+    <imas:Called xml:lang="ja">あずささん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Hagiwara_Yukiho">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Hagiwara_Yukiho"/>
+    <imas:Called xml:lang="ja">雪歩ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Ganaha_Hibiki">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Ganaha_Hibiki"/>
+    <imas:Called xml:lang="ja">響ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Shijou_Takane">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Shijou_Takane"/>
+    <imas:Called xml:lang="ja">貴音ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Kuroi_Takao">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Kuroi_Takao"/>
+    <imas:Called xml:lang="ja">黒井社長</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">神谷君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">東雲君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Asselin_BB_2">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">シェフ</imas:Called>
+    <imas:Called xml:lang="ja">アスラン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Uzuki_Makio">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">卯月君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Mizushima_Saki">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">メイド</imas:Called>
+    <imas:Called xml:lang="ja">水嶋君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Okamura_Nao">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">岡村君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Tachibana_Shiro">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">橘君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Himeno_Kanon">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">姫野君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Hazama_Michio">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">硲先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Maita_Rui">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">舞田先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Yamashita_Jiro">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">山下先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Taiga_Takeru">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">大河君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Kizaki_Ren">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">拳法家</imas:Called>
+    <imas:Called xml:lang="ja">牙崎君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Enjoji_Michiru">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">円城寺君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">秋月君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Kabuto_Daigo">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">兜君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">九十九君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">掃除屋</imas:Called>
+    <imas:Called xml:lang="ja">葛之葉さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Kitamura_Sora">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">雑貨屋</imas:Called>
+    <imas:Called xml:lang="ja">北村君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Koron_Chris">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">海洋学者</imas:Called>
+    <imas:Called xml:lang="ja">古論さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Yamamura_Ken">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">山村君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">神谷さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">東雲さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Asselin_BB_2">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスランさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Uzuki_Makio">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">卯月さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Mizushima_Saki">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">水嶋さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Okamura_Nao">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">岡村</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Tachibana_Shiro">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">橘</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Himeno_Kanon">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">姫野</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Hazama_Michio">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">硲さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Maita_Rui">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">舞田さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Yamashita_Jiro">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">山下さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Taiga_Takeru">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">大河さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Kizaki_Ren">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">牙崎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Enjoji_Michiru">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">円城寺さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">秋月さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Kabuto_Daigo">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">兜</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">九十九さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">葛之葉さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Kitamura_Sora">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">北村さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Koron_Chris">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">古論さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Yamamura_Ken">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">賢さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">神谷さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">東雲さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Asselin_BB_2">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスランさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Uzuki_Makio">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">卯月</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Mizushima_Saki">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">水嶋</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Okamura_Nao">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">岡村</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Tachibana_Shiro">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">橘</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Himeno_Kanon">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">姫野</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Hazama_Michio">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">硲さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Maita_Rui">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">舞田さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Yamashita_Jiro">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">山下さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Taiga_Takeru">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">大河</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Kizaki_Ren">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">牙崎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Enjoji_Michiru">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">円城寺さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">秋月さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Kabuto_Daigo">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">兜</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">九十九</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">葛之葉さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Kitamura_Sora">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">北村</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Koron_Chris">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">古論さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Yamamura_Ken">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">けん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">かみやさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">しののめさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Asselin_BB_2">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">あすらん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Uzuki_Makio">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">まきおくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Mizushima_Saki">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">さきちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Okamura_Nao">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">なおくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Tachibana_Shiro">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">しろうくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Himeno_Kanon">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのんくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Hazama_Michio">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">みちおせんせー</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Maita_Rui">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">るいせんせー</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Yamashita_Jiro">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">じろうせんせー</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Taiga_Takeru">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">たける</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Kizaki_Ren">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">れん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Enjoji_Michiru">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">みちるさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">りょーくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Kabuto_Daigo">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">だいごくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">かずきくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">あめひこさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Kitamura_Sora">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">そらくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Koron_Chris">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリスさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Yamamura_Ken">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">けん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">幸広</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">荘一郎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Asselin_BB_2">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスラン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Uzuki_Makio">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻緒</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Mizushima_Saki">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">咲</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Okamura_Nao">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Tachibana_Shiro">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">志狼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Himeno_Kanon">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Hazama_Michio">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">道夫</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Maita_Rui">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">類</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Yamashita_Jiro">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">次郎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Taiga_Takeru">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケル</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Kizaki_Ren">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">漣</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Enjoji_Michiru">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">道流</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Kabuto_Daigo">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">大吾</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">一希</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">雨彦</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Kitamura_Sora">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Koron_Chris">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリス</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">幸広クン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">荘一郎クン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Asselin_BB_2">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">サタンクン</imas:Called>
+    <imas:Called xml:lang="ja">サタンクン2号</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Uzuki_Makio">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻緒クン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Mizushima_Saki">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">さきクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Okamura_Nao">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">なおクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Tachibana_Shiro">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">おーかみクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Himeno_Kanon">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">ゆるふわクン</imas:Called>
+    <imas:Called xml:lang="ja">かのんクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Hazama_Michio">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">道夫クン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Maita_Rui">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">類クン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Yamashita_Jiro">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">次郎クン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Taiga_Takeru">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケルクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Kizaki_Ren">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">漣クン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Enjoji_Michiru">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">道流クン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼クン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Kabuto_Daigo">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">ろくクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">物書きクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">掃除屋クン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Kitamura_Sora">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽クン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Koron_Chris">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">学者クン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Yamamura_Ken">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">けんけんクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">神谷さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">東雲さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Asselin_BB_2">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスラン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Uzuki_Makio">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻緒</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Mizushima_Saki">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">咲</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Okamura_Nao">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Tachibana_Shiro">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">志狼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Himeno_Kanon">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Hazama_Michio">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">硲先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Maita_Rui">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">舞田先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Yamashita_Jiro">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">山下先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Taiga_Takeru">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケル</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Kizaki_Ren">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">漣</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Enjoji_Michiru">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">道流さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Kabuto_Daigo">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">大吾</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">一希さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">雨彦さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Kitamura_Sora">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Koron_Chris">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリスさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">神谷さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">東雲さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Asselin_BB_2">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスランさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Uzuki_Makio">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻緒くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Mizushima_Saki">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">咲くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Okamura_Nao">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Tachibana_Shiro">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">志狼くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Himeno_Kanon">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのんくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Hazama_Michio">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">硲先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Maita_Rui">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">舞田先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Yamashita_Jiro">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">山下先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Taiga_Takeru">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケルくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Kizaki_Ren">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">漣さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Enjoji_Michiru">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">道流さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Kabuto_Daigo">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">大吾くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">一希さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">雨彦さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Kitamura_Sora">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Koron_Chris">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリスさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">幸広アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">荘一郎アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Asselin_BB_2">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスランアニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Uzuki_Makio">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻緒アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Mizushima_Saki">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">咲アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Okamura_Nao">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Tachibana_Shiro">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">志狼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Himeno_Kanon">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Hazama_Michio">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">道夫アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Maita_Rui">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">類アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Yamashita_Jiro">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">次郎アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Taiga_Takeru">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケル</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Kizaki_Ren">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">漣アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Enjoji_Michiru">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">道流アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Kabuto_Daigo">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">大吾</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">一希アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">雨彦アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Kitamura_Sora">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Koron_Chris">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリスアニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Yamamura_Ken">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">賢アニさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Akai_Suzaku">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">紅井さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Kurono_Genbu">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">黒野さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Okamura_Nao">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">岡村さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Tachibana_Shiro">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">橘さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Himeno_Kanon">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">姫野さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Hazama_Michio">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">硲さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Maita_Rui">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">舞田さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Yamashita_Jiro">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">山下さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Taiga_Takeru">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">大河さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Kizaki_Ren">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">牙崎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Enjoji_Michiru">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">円城寺さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">秋月さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Kabuto_Daigo">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">兜さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">九十九さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">葛之葉さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Kitamura_Sora">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">北村さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Koron_Chris">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">古論さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Akai_Suzaku">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">すざくくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Kurono_Genbu">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">げんぶさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">かみやさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">そういちろうさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Asselin_BB_2">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスランさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Uzuki_Makio">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">まきおくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Mizushima_Saki">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">さきくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Hazama_Michio">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">みちおせんせい</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Maita_Rui">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">るいせんせい</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Yamashita_Jiro">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">じろうせんせい</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Taiga_Takeru">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">たけるくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Kizaki_Ren">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">れんくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Enjoji_Michiru">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">みちるさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">りょうくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Kabuto_Daigo">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">だいごくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">かずきくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">あめひこさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Kitamura_Sora">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">そらくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Koron_Chris">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリスさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Yamamura_Ken">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">けんくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Akai_Suzaku">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">あかい</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Kurono_Genbu">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">くろの</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">かみや</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">しののめ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Asselin_BB_2">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスラン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Uzuki_Makio">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">うづき</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Mizushima_Saki">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">みずしま</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Okamura_Nao">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">なおくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Tachibana_Shiro">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">しろうくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Himeno_Kanon">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのんくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Taiga_Takeru">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">たいが</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Kizaki_Ren">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">きざき</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Enjoji_Michiru">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">えんじょうじ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">あきづき</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Kabuto_Daigo">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">かぶと</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">つくも</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">くずのは</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Kitamura_Sora">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">きたむら</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Koron_Chris">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">ころん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Yamamura_Ken">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">けん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Akai_Suzaku">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">紅井君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Kurono_Genbu">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">黒野君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">神谷君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">東雲君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Asselin_BB_2">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスラン君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Uzuki_Makio">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">卯月君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Mizushima_Saki">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">水嶋君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Okamura_Nao">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">岡村君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Tachibana_Shiro">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">橘君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Himeno_Kanon">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">姫野君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Taiga_Takeru">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">大河君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Kizaki_Ren">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">牙崎君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Enjoji_Michiru">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">円城寺君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">秋月君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Kabuto_Daigo">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">兜君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">九十九君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">葛之葉君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Kitamura_Sora">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">北村君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Koron_Chris">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">古論君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Yamamura_Ken">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">山村君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Akai_Suzaku">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">朱雀さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Kurono_Genbu">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">神谷さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">荘一郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Asselin_BB_2">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスランさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Uzuki_Makio">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻緒さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Mizushima_Saki">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">咲さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Okamura_Nao">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Tachibana_Shiro">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">志狼さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Himeno_Kanon">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのんさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Hazama_Michio">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">道夫さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Maita_Rui">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">類さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Yamashita_Jiro">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">次郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Taiga_Takeru">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケルさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Kizaki_Ren">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">漣さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Enjoji_Michiru">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">道流さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">雨彦さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Kitamura_Sora">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Koron_Chris">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリスさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Yamamura_Ken">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">賢</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Akai_Suzaku">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">紅井</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Kurono_Genbu">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">黒野</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">神谷</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">東雲</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Asselin_BB_2">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスランサン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Uzuki_Makio">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">卯月</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Mizushima_Saki">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">水嶋</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Okamura_Nao">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">岡村</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Tachibana_Shiro">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">橘</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Himeno_Kanon">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">姫野</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Hazama_Michio">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">硲サン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Maita_Rui">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">舞田</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Yamashita_Jiro">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">山下サン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Taiga_Takeru">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">大河</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Kizaki_Ren">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">牙崎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Enjoji_Michiru">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">円城寺</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">秋月</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Kabuto_Daigo">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">兜</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">九十九</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Yamamura_Ken">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">山村</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Akai_Suzaku">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">紅井さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Kurono_Genbu">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">黒野さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">神谷さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">東雲さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Asselin_BB_2">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスランさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Uzuki_Makio">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">卯月さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Mizushima_Saki">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">水嶋さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Okamura_Nao">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">岡村さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Tachibana_Shiro">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">橘さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Himeno_Kanon">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">姫野さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Hazama_Michio">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">硲さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Maita_Rui">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">舞田さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Yamashita_Jiro">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">山下さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Taiga_Takeru">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">大河さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Kizaki_Ren">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">牙崎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Enjoji_Michiru">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">円城寺さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">秋月さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Kabuto_Daigo">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">兜さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">九十九さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Okamura_Nao">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Tachibana_Shiro">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">志狼ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Himeno_Kanon">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのんちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Hazama_Michio">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">道夫さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Maita_Rui">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">類さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Yamashita_Jiro">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">次郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Taiga_Takeru">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケルさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Kizaki_Ren">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">漣さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Enjoji_Michiru">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">道流さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Kabuto_Daigo">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">大吾さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">一希さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">雨彦さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Kitamura_Sora">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Koron_Chris">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリスさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Yamamura_Ken">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">賢君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Amami_Haruka">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Amami_Haruka"/>
+    <imas:Called xml:lang="ja">春香さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Takatsuki_Yayoi">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Takatsuki_Yayoi"/>
+    <imas:Called xml:lang="ja">やよいちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Minase_Iori">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Minase_Iori"/>
+    <imas:Called xml:lang="ja">伊織さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Kuroi_Takao">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Kuroi_Takao"/>
+    <imas:Called xml:lang="ja">黒ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">幸広くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">荘一郎くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Asselin_BB_2">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスランさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Uzuki_Makio">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻緒くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Mizushima_Saki">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">咲ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Okamura_Nao">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Tachibana_Shiro">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">志狼くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Himeno_Kanon">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのんくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Hazama_Michio">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">道夫さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Maita_Rui">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">類</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Yamashita_Jiro">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">次郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Taiga_Takeru">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケルくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Kizaki_Ren">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">漣くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Enjoji_Michiru">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">道流さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Kabuto_Daigo">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">大吾くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">一希くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">雨彦さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Kitamura_Sora">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Koron_Chris">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">古論さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Yamamura_Ken">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">賢くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">幸広さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">荘一郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Asselin_BB_2">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスランさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Uzuki_Makio">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻緒さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Mizushima_Saki">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">咲さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Okamura_Nao">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Tachibana_Shiro">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">志狼さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Himeno_Kanon">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのんさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Hazama_Michio">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">道夫さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Maita_Rui">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">類さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Yamashita_Jiro">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">次郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Taiga_Takeru">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケルさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Kizaki_Ren">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">漣さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Enjoji_Michiru">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">道流さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Kabuto_Daigo">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">大吾さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">一希さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">雨彦さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Kitamura_Sora">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Koron_Chris">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリスさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">幸広</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">荘一郎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Asselin_BB_2">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">サタン</imas:Called>
+    <imas:Called xml:lang="ja">サタンのサタン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Uzuki_Makio">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻緒</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Mizushima_Saki">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">咲</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Okamura_Nao">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Tachibana_Shiro">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">志狼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Himeno_Kanon">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Hazama_Michio">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">道夫</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Maita_Rui">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">類</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Yamashita_Jiro">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">次郎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Taiga_Takeru">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケル</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Kizaki_Ren">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">漣</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Enjoji_Michiru">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">道流</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Kabuto_Daigo">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">大吾</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">一希</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">雨彦</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Kitamura_Sora">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Koron_Chris">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリス</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Yamamura_Ken">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">けん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">かみやサン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">しののめサン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Asselin_BB_2">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスラン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Uzuki_Makio">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">まきおクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Mizushima_Saki">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">さきチャン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Okamura_Nao">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">なおクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Tachibana_Shiro">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">しろうクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Himeno_Kanon">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのんクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Hazama_Michio">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">みちおセンセー</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Maita_Rui">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">るいセンセー</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Yamashita_Jiro">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">じろーセンセー</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Taiga_Takeru">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケル</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Kizaki_Ren">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">レン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Enjoji_Michiru">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">みちるサン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">りょうクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Kabuto_Daigo">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">だいごクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">かずきクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">あめひこサン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Kitamura_Sora">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">そらクン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Koron_Chris">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリスサン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Yamamura_Ken">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">ケン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">幸広</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">荘一郎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Asselin_BB_2">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスラン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Uzuki_Makio">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻緒</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Mizushima_Saki">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">咲</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Okamura_Nao">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Tachibana_Shiro">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">志狼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Himeno_Kanon">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Hazama_Michio">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">道夫さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Maita_Rui">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">類</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Yamashita_Jiro">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">次郎</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Taiga_Takeru">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケル</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Kizaki_Ren">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">漣</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Enjoji_Michiru">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">道流</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Kabuto_Daigo">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">大吾</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">一希</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">雨彦</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Kitamura_Sora">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Koron_Chris">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリス</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Yamamura_Ken">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">賢</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">ゆきちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">そうちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Asselin_BB_2">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">サタンちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Uzuki_Makio">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻物ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Mizushima_Saki">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">ガールくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Okamura_Nao">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">ラムくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Tachibana_Shiro">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">がおがおくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Himeno_Kanon">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">ピョンちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Hazama_Michio">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">道夫ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Maita_Rui">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">まいたるちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Yamashita_Jiro">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">じろんこ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Taiga_Takeru">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケルちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Kizaki_Ren">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">キバちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Enjoji_Michiru">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">なるとちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Kabuto_Daigo">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">兜ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">ももちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">おきつねちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Kitamura_Sora">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Koron_Chris">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">古論ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">神谷さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">東雲さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Asselin_BB_2">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスランさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Uzuki_Makio">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">卯月さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Mizushima_Saki">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">水嶋さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Okamura_Nao">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">岡村さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Tachibana_Shiro">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">橘さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Himeno_Kanon">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">姫野さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Hazama_Michio">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">硲さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Maita_Rui">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">舞田さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Yamashita_Jiro">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">山下さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Taiga_Takeru">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">大河さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Kizaki_Ren">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">牙崎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Enjoji_Michiru">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">円城寺さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">秋月さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Kabuto_Daigo">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">兜さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">九十九さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">葛之葉さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Kitamura_Sora">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">北村さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Koron_Chris">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">古論さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Yamamura_Ken">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">賢さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">神谷さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">東雲さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Asselin_BB_2">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスラン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Uzuki_Makio">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻緒</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Mizushima_Saki">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">咲ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Okamura_Nao">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Tachibana_Shiro">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">志狼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Himeno_Kanon">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Hazama_Michio">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">硲先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Maita_Rui">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">舞田先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Yamashita_Jiro">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">山下先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Taiga_Takeru">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケル</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Kizaki_Ren">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">漣</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Enjoji_Michiru">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">道流さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Kabuto_Daigo">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">大吾</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">一希さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">雨彦さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Kitamura_Sora">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Koron_Chris">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリスさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Yamamura_Ken">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">賢</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Akai_Suzaku">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">朱雀くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Kurono_Genbu">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Okamura_Nao">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Tachibana_Shiro">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">志狼くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Himeno_Kanon">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのんくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Hazama_Michio">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">硲さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Maita_Rui">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">類さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Yamashita_Jiro">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">次郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Taiga_Takeru">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケルくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Kizaki_Ren">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">漣くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Enjoji_Michiru">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">道流さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Kabuto_Daigo">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">大吾くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">一希くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">雨彦さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Kitamura_Sora">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Koron_Chris">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリスさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Akiyama_Hayato">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">隼人くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Fuyumi_Jun">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">旬くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">夏来くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Wakazato_Haruna">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">春名くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Iseya_Shiki">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">四季くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Akai_Suzaku">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">朱雀くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Kurono_Genbu">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Okamura_Nao">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Tachibana_Shiro">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">志狼くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Himeno_Kanon">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのんくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Hazama_Michio">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">硲先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Maita_Rui">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">舞田先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Yamashita_Jiro">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">山下先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Taiga_Takeru">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケルくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Kizaki_Ren">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">漣くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Enjoji_Michiru">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">道流さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Kabuto_Daigo">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">大吾くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">一希さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">雨彦さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Kitamura_Sora">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Koron_Chris">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリスさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Yamamura_Ken">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">賢さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Akai_Suzaku">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">すざくくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Kurono_Genbu">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">げんぶくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">かみやくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">そういちろうくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Asselin_BB_2">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスランくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Uzuki_Makio">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">まきおくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Mizushima_Saki">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">さきちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Hazama_Michio">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">みちおせんせい</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Maita_Rui">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">るいせんせい</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Yamashita_Jiro">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">じろうせんせい</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Taiga_Takeru">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケルくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Kizaki_Ren">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">れんくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Enjoji_Michiru">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">みちるさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">りょうくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Kabuto_Daigo">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">だいごくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">かずきくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">あめひこさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Kitamura_Sora">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">そらくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Koron_Chris">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリスさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Yamamura_Ken">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">けんくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Akai_Suzaku">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">ミスターあかい</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Kurono_Genbu">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">ミスターくろの</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">ミスターかみや</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">ミスターしののめ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Asselin_BB_2">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスラン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Uzuki_Makio">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">ミスターうづき</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Mizushima_Saki">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">さき</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Okamura_Nao">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">ミスターおかむら</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Tachibana_Shiro">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">ミスターたちばな</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Himeno_Kanon">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Taiga_Takeru">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">ミスターたいが</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Kizaki_Ren">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">ミスターきざき</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Enjoji_Michiru">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">ミスターえんじょうじ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">ミスターあきづき</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Kabuto_Daigo">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">ミスターかぶと</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">ミスターつくも</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">ミスターくずのは</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Kitamura_Sora">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">ミスターきたむら</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Koron_Chris">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">ミスターころん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Yamamura_Ken">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">KEN</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">神谷さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">荘一郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Asselin_BB_2">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスランさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Uzuki_Makio">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻緒くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Mizushima_Saki">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">咲ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Okamura_Nao">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Tachibana_Shiro">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">志狼ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Himeno_Kanon">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのんちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Hazama_Michio">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">道夫さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Maita_Rui">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">類さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Yamashita_Jiro">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">次郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Taiga_Takeru">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケルくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Kizaki_Ren">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">漣くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Enjoji_Michiru">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">道流さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">雨彦さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Kitamura_Sora">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Koron_Chris">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリスさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Yamamura_Ken">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">賢くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+<!--秋月涼DS(876Pro)分-->
+  <rdf:Description rdf:about="Akizuki_Ryo_876_Hidaka_Ai">
+    <imas:Source rdf:resource="Akizuki_Ryo_876"/>
+    <imas:Destination rdf:resource="Hidaka_Ai"/>
+    <imas:Called xml:lang="ja">愛ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_876_Mizutani_Eri">
+    <imas:Source rdf:resource="Akizuki_Ryo_876"/>
+    <imas:Destination rdf:resource="Mizutani_Eri"/>
+    <imas:Called xml:lang="ja">絵理ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_876_Sakurai_Yumeko">
+    <imas:Source rdf:resource="Akizuki_Ryo_876"/>
+    <imas:Destination rdf:resource="Sakurai_Yumeko"/>
+    <imas:Called xml:lang="ja">夢子ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_876_Amami_Haruka">
+    <imas:Source rdf:resource="Akizuki_Ryo_876"/>
+    <imas:Destination rdf:resource="Amami_Haruka"/>
+    <imas:Called xml:lang="ja">春香さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_876_Minase_Iori">
+    <imas:Source rdf:resource="Akizuki_Ryo_876"/>
+    <imas:Destination rdf:resource="Minase_Iori"/>
+    <imas:Called xml:lang="ja">伊織さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_876_Miura_Azusa">
+    <imas:Source rdf:resource="Akizuki_Ryo_876"/>
+    <imas:Destination rdf:resource="Miura_Azusa"/>
+    <imas:Called xml:lang="ja">あずささん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_876_Kisaragi_Chihaya">
+    <imas:Source rdf:resource="Akizuki_Ryo_876"/>
+    <imas:Destination rdf:resource="Kisaragi_Chihaya"/>
+    <imas:Called xml:lang="ja">千早さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_876_Takatsuki_Yayoi">
+    <imas:Source rdf:resource="Akizuki_Ryo_876"/>
+    <imas:Destination rdf:resource="Takatsuki_Yayoi"/>
+    <imas:Called xml:lang="ja">やよいさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_876_Kikuchi_Makoto">
+    <imas:Source rdf:resource="Akizuki_Ryo_876"/>
+    <imas:Destination rdf:resource="Kikuchi_Makoto"/>
+    <imas:Called xml:lang="ja">真さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_876_Hagiwara_Yukiho">
+    <imas:Source rdf:resource="Akizuki_Ryo_876"/>
+    <imas:Destination rdf:resource="Hagiwara_Yukiho"/>
+    <imas:Called xml:lang="ja">雪歩さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_876_Akizuki_Ritsuko">
+    <imas:Source rdf:resource="Akizuki_Ryo_876"/>
+    <imas:Destination rdf:resource="Akizuki_Ritsuko"/>
+    <imas:Called xml:lang="ja">律子姉ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_876_Futami_Ami">
+    <imas:Source rdf:resource="Akizuki_Ryo_876"/>
+    <imas:Destination rdf:resource="Futami_Ami"/>
+    <imas:Called xml:lang="ja">亜美ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_876_Shijou_Takane">
+    <imas:Source rdf:resource="Akizuki_Ryo_876"/>
+    <imas:Destination rdf:resource="Shijou_Takane"/>
+    <imas:Called xml:lang="ja">貴音さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_876_Hoshii_Miki">
+    <imas:Source rdf:resource="Akizuki_Ryo_876"/>
+    <imas:Destination rdf:resource="Hoshii_Miki"/>
+    <imas:Called xml:lang="ja">星井さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+<!--秋月涼DS(876Pro)分 ここまで-->
+  <rdf:Description rdf:about="Kitamura_Sora_Akai_Suzaku">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">朱雀くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Kurono_Genbu">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">幸広さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">荘一郎先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Asselin_BB_2">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスラン先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Uzuki_Makio">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻緒くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Mizushima_Saki">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">咲くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Okamura_Nao">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Tachibana_Shiro">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">志狼くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Himeno_Kanon">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのんくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Hazama_Michio">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">道夫先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Maita_Rui">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">類先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Yamashita_Jiro">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">次郎先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Taiga_Takeru">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケルくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Kizaki_Ren">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">漣くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Enjoji_Michiru">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">道流さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Kabuto_Daigo">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">大吾くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">一希先生</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Yamamura_Ken">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">賢くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">幸広さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">東雲さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Asselin_BB_2">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">アスランさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Mizushima_Saki">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">咲ちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Uzuki_Makio">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">巻緒くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Tachibana_Shiro">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">志狼くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Okamura_Nao">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Himeno_Kanon">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのんくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Hazama_Michio">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">道夫さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Maita_Rui">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">類さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Yamashita_Jiro">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">次郎さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Taiga_Takeru">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケルくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Kizaki_Ren">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">漣くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Enjoji_Michiru">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">道流さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">涼くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Kabuto_Daigo">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">大吾くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">一希くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">雨彦さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Kitamura_Sora">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Koron_Chris">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">クリスさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Producer_Kurono_Genbu">
+    <imas:Source rdf:resource="Producer"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">玄武さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Producer_Mizushima_Saki">
+    <imas:Source rdf:resource="Producer"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">咲</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Producer_Okamura_Nao">
+    <imas:Source rdf:resource="Producer"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">直央</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Producer_Himeno_Kanon">
+    <imas:Source rdf:resource="Producer"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのんくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Producer_Hazama_Michio">
+    <imas:Source rdf:resource="Producer"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">硲さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Producer_Yamashita_Jiro">
+    <imas:Source rdf:resource="Producer"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">山下さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Producer_Taiga_Takeru">
+    <imas:Source rdf:resource="Producer"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">タケルくん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Producer_Kizaki_Ren">
+    <imas:Source rdf:resource="Producer"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">漣</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Producer_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Producer"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">九十九さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Producer_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Producer"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">葛之葉さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Producer_Kitamura_Sora">
+    <imas:Source rdf:resource="Producer"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">想楽くん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Producer_Koron_Chris">
+    <imas:Source rdf:resource="Producer"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">古論さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Producer_Yamamura_Ken">
+    <imas:Source rdf:resource="Producer"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">賢さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Amagase_Toma">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Amagase_Toma"/>
+    <imas:Called xml:lang="ja">俺</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Tendo_Teru">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Tendo_Teru"/>
+    <imas:Called xml:lang="ja">俺</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Watanabe_Minori">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Watanabe_Minori"/>
+    <imas:Called xml:lang="ja">俺</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Kimura_Ryu">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Kimura_Ryu"/>
+    <imas:Called xml:lang="ja">俺</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Iseya_Shiki">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Iseya_Shiki"/>
+    <imas:Called xml:lang="ja">オレ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Akiyama_Hayato">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Akiyama_Hayato"/>
+    <imas:Called xml:lang="ja">俺</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Akai_Suzaku">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Akai_Suzaku"/>
+    <imas:Called xml:lang="ja">オレ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Asselin_BB_2">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Asselin_BB_2"/>
+    <imas:Called xml:lang="ja">我</imas:Called>
+    <imas:Called xml:lang="ja">僕</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Mizushima_Saki">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Mizushima_Saki"/>
+    <imas:Called xml:lang="ja">あたし</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Tachibana_Shiro">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Tachibana_Shiro"/>
+    <imas:Called xml:lang="ja">オレ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Taiga_Takeru">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Taiga_Takeru"/>
+    <imas:Called xml:lang="ja">オレ</imas:Called>
+    <imas:Called xml:lang="ja">俺</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Kizaki_Ren">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Kizaki_Ren"/>
+    <imas:Called xml:lang="ja">オレ様</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Enjoji_Michiru">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Enjoji_Michiru"/>
+    <imas:Called xml:lang="ja">自分</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Kabuto_Daigo">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Kabuto_Daigo"/>
+    <imas:Called xml:lang="ja">ワシ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mayumi_Eishin_Mayumi_Eishin">
+    <imas:Source rdf:resource="Mayumi_Eishin"/>
+    <imas:Destination rdf:resource="Mayumi_Eishin"/>
+    <imas:Called xml:lang="ja">俺</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Ijuin_Hokuto">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Ijuin_Hokuto"/>
+    <imas:Called xml:lang="ja">俺</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Sakuraba_Kaoru">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Called xml:lang="ja">僕</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Kagura_Rei">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Kagura_Rei"/>
+    <imas:Called xml:lang="ja">わたし</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Takajo_Kyoji">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Takajo_Kyoji"/>
+    <imas:Called xml:lang="ja">俺</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Aoi_Kyosuke">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Aoi_Kyosuke"/>
+    <imas:Called xml:lang="ja">俺</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Akuno_Hideo">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Akuno_Hideo"/>
+    <imas:Called xml:lang="ja">俺</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Nekoyanagi_Kirio">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Called xml:lang="ja">ワガハイ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Sakaki_Natsuki">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Sakaki_Natsuki"/>
+    <imas:Called xml:lang="ja">俺</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Fuyumi_Jun">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Fuyumi_Jun"/>
+    <imas:Called xml:lang="ja">僕</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Kurono_Genbu">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Kurono_Genbu"/>
+    <imas:Called xml:lang="ja">俺</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Shinonome_Soichiro">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Shinonome_Soichiro"/>
+    <imas:Called xml:lang="ja">私</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Okamura_Nao">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Okamura_Nao"/>
+    <imas:Called xml:lang="ja">ボク</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Yamashita_Jiro">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Yamashita_Jiro"/>
+    <imas:Called xml:lang="ja">俺</imas:Called>
+    <imas:Called xml:lang="ja">おじさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Hazama_Michio">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Hazama_Michio"/>
+    <imas:Called xml:lang="ja">私</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Tsukumo_Kazuki">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Called xml:lang="ja">おれ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Kuzunoha_Amehiko">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Called xml:lang="ja">俺</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Koron_Chris">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Koron_Chris"/>
+    <imas:Called xml:lang="ja">私</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amamine_Shu_Amamine_Shu">
+    <imas:Source rdf:resource="Amamine_Shu"/>
+    <imas:Destination rdf:resource="Amamine_Shu"/>
+    <imas:Called xml:lang="ja">俺</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Mitarai_Shota">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Mitarai_Shota"/>
+    <imas:Called xml:lang="ja">僕</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Kashiwagi_Tsubasa">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Called xml:lang="ja">オレ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Tsuzuki_Kei">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Tsuzuki_Kei"/>
+    <imas:Called xml:lang="ja">僕</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Pierre">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Pierre"/>
+    <imas:Called xml:lang="ja">ボク</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Aoi_Yusuke">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Aoi_Yusuke"/>
+    <imas:Called xml:lang="ja">オレ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Shingen_Seiji">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Shingen_Seiji"/>
+    <imas:Called xml:lang="ja">自分</imas:Called>
+    <imas:Called xml:lang="ja">俺</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Hanamura_Shoma">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Hanamura_Shoma"/>
+    <imas:Called xml:lang="ja">アタシ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Kiyosumi_Kuro">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Called xml:lang="ja">私</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Wakazato_Haruna">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Wakazato_Haruna"/>
+    <imas:Called xml:lang="ja">オレ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Kamiya_Yukihiro">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Called xml:lang="ja">俺</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Uzuki_Makio">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Uzuki_Makio"/>
+    <imas:Called xml:lang="ja">俺</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Himeno_Kanon">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Himeno_Kanon"/>
+    <imas:Called xml:lang="ja">かのん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Maita_Rui">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Maita_Rui"/>
+    <imas:Called xml:lang="ja">俺</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Akizuki_Ryo_315">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Called xml:lang="ja">僕</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Kitamura_Sora">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Kitamura_Sora"/>
+    <imas:Called xml:lang="ja">僕</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanazono_Momohito_Hanazono_Momohito">
+    <imas:Source rdf:resource="Hanazono_Momohito"/>
+    <imas:Destination rdf:resource="Hanazono_Momohito"/>
+    <imas:Called xml:lang="ja">ボク</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Yamamura_Ken">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Yamamura_Ken"/>
+    <imas:Called xml:lang="ja">ぼく</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amagase_Toma_Producer">
+    <imas:Source rdf:resource="Amagase_Toma"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサー</imas:Called>
+    <imas:Called xml:lang="ja">あんた</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tendo_Teru_Producer">
+    <imas:Source rdf:resource="Tendo_Teru"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサー</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Watanabe_Minori_Producer">
+    <imas:Source rdf:resource="Watanabe_Minori"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサー</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kimura_Ryu_Producer">
+    <imas:Source rdf:resource="Kimura_Ryu"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサーさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Iseya_Shiki_Producer">
+    <imas:Source rdf:resource="Iseya_Shiki"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサーちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akiyama_Hayato_Producer">
+    <imas:Source rdf:resource="Akiyama_Hayato"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサー</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akai_Suzaku_Producer">
+    <imas:Source rdf:resource="Akai_Suzaku"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサーさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Asselin_BB_2_Producer">
+    <imas:Source rdf:resource="Asselin_BB_2"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">主</imas:Called>
+    <imas:Called xml:lang="ja">プロデューサーさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mizushima_Saki_Producer">
+    <imas:Source rdf:resource="Mizushima_Saki"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサー</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tachibana_Shiro_Producer">
+    <imas:Source rdf:resource="Tachibana_Shiro"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサー</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Taiga_Takeru_Producer">
+    <imas:Source rdf:resource="Taiga_Takeru"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">アンタ</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kizaki_Ren_Producer">
+    <imas:Source rdf:resource="Kizaki_Ren"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">オマエ</imas:Called>
+    <imas:Called xml:lang="ja">テメー</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Enjoji_Michiru_Producer">
+    <imas:Source rdf:resource="Enjoji_Michiru"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">師匠</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kabuto_Daigo_Producer">
+    <imas:Source rdf:resource="Kabuto_Daigo"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">ボス</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mayumi_Eishin_Producer">
+    <imas:Source rdf:resource="Mayumi_Eishin"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">お前</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ijuin_Hokuto_Producer">
+    <imas:Source rdf:resource="Ijuin_Hokuto"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサー</imas:Called>
+    <imas:Called xml:lang="ja">あなた</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakuraba_Kaoru_Producer">
+    <imas:Source rdf:resource="Sakuraba_Kaoru"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">君</imas:Called>
+    <imas:Called xml:lang="ja">プロデューサー</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kagura_Rei_Producer">
+    <imas:Source rdf:resource="Kagura_Rei"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">貴殿</imas:Called>
+    <imas:Called xml:lang="ja">プロデューサーさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Takajo_Kyoji_Producer">
+    <imas:Source rdf:resource="Takajo_Kyoji"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサー</imas:Called>
+    <imas:Called xml:lang="ja">あんた</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Kyosuke_Producer">
+    <imas:Source rdf:resource="Aoi_Kyosuke"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">監督</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akuno_Hideo_Producer">
+    <imas:Source rdf:resource="Akuno_Hideo"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサー</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Nekoyanagi_Kirio_Producer">
+    <imas:Source rdf:resource="Nekoyanagi_Kirio"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサークン</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sakaki_Natsuki_Producer">
+    <imas:Source rdf:resource="Sakaki_Natsuki"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサーさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Fuyumi_Jun_Producer">
+    <imas:Source rdf:resource="Fuyumi_Jun"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサーさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kurono_Genbu_Producer">
+    <imas:Source rdf:resource="Kurono_Genbu"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">番長さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shinonome_Soichiro_Producer">
+    <imas:Source rdf:resource="Shinonome_Soichiro"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサーさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Okamura_Nao_Producer">
+    <imas:Source rdf:resource="Okamura_Nao"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサーさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamashita_Jiro_Producer">
+    <imas:Source rdf:resource="Yamashita_Jiro"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサーちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hazama_Michio_Producer">
+    <imas:Source rdf:resource="Hazama_Michio"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサー</imas:Called>
+    <imas:Called xml:lang="ja">君</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsukumo_Kazuki_Producer">
+    <imas:Source rdf:resource="Tsukumo_Kazuki"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサー</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kuzunoha_Amehiko_Producer">
+    <imas:Source rdf:resource="Kuzunoha_Amehiko"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサー</imas:Called>
+    <imas:Called xml:lang="ja">お前さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Koron_Chris_Producer">
+    <imas:Source rdf:resource="Koron_Chris"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサーさん</imas:Called>
+    <imas:Called xml:lang="ja">あなた</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Amamine_Shu_Producer">
+    <imas:Source rdf:resource="Amamine_Shu"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサー</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Mitarai_Shota_Producer">
+    <imas:Source rdf:resource="Mitarai_Shota"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサーさん</imas:Called>
+    <imas:Called xml:lang="ja">お兄さん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kashiwagi_Tsubasa_Producer">
+    <imas:Source rdf:resource="Kashiwagi_Tsubasa"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサー</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Tsuzuki_Kei_Producer">
+    <imas:Source rdf:resource="Tsuzuki_Kei"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサーさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Pierre_Producer">
+    <imas:Source rdf:resource="Pierre"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサーさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Aoi_Yusuke_Producer">
+    <imas:Source rdf:resource="Aoi_Yusuke"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">監督</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Shingen_Seiji_Producer">
+    <imas:Source rdf:resource="Shingen_Seiji"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサーさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamura_Shoma_Producer">
+    <imas:Source rdf:resource="Hanamura_Shoma"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサーちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kiyosumi_Kuro_Producer">
+    <imas:Source rdf:resource="Kiyosumi_Kuro"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサーさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Wakazato_Haruna_Producer">
+    <imas:Source rdf:resource="Wakazato_Haruna"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサー</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kamiya_Yukihiro_Producer">
+    <imas:Source rdf:resource="Kamiya_Yukihiro"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサーさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Uzuki_Makio_Producer">
+    <imas:Source rdf:resource="Uzuki_Makio"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサーさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Himeno_Kanon_Producer">
+    <imas:Source rdf:resource="Himeno_Kanon"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサーさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Maita_Rui_Producer">
+    <imas:Source rdf:resource="Maita_Rui"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサーちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Akizuki_Ryo_315_Producer">
+    <imas:Source rdf:resource="Akizuki_Ryo_315"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサーさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Kitamura_Sora_Producer">
+    <imas:Source rdf:resource="Kitamura_Sora"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサーさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanazono_Momohito_Producer">
+    <imas:Source rdf:resource="Hanazono_Momohito"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">ぴぃちゃん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Yamamura_Ken_Producer">
+    <imas:Source rdf:resource="Yamamura_Ken"/>
+    <imas:Destination rdf:resource="Producer"/>
+    <imas:Called xml:lang="ja">プロデューサーさん</imas:Called>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#CallName"/>
+  </rdf:Description>
 <!-- ShinyColors -->
   <rdf:Description rdf:about="Sakuragi_Mano_Kazano_Hiori">
     <imas:Source rdf:resource="Sakuragi_Mano"/>


### PR DESCRIPTION
sideMとシャイニーカラーズの呼称データ追加
ソース
 - [アイドルマスターSideM:呼称表](https://dic.nicovideo.jp/a/%E3%82%A2%E3%82%A4%E3%83%89%E3%83%AB%E3%83%9E%E3%82%B9%E3%82%BF%E3%83%BCsidem%3A%E5%91%BC%E7%A7%B0%E8%A1%A8#ryo)
 - [アイドルマスター シャイニーカラーズ:呼称表](https://dic.nicovideo.jp/a/%E3%82%A2%E3%82%A4%E3%83%89%E3%83%AB%E3%83%9E%E3%82%B9%E3%82%BF%E3%83%BC%20%E3%82%B7%E3%83%A3%E3%82%A4%E3%83%8B%E3%83%BC%E3%82%AB%E3%83%A9%E3%83%BC%E3%82%BA%3A%E5%91%BC%E7%A7%B0%E8%A1%A8)

シンデレラガールズに関しては、今あるデータとの差分を取らないといけないので追加未実施
ファイルの行数が膨大になってきたので、衣装・ユニットと同様にファイル分割すべき…?
※ファイル分割の方法は、まだ完全にはわかりません