### PR TITLE
ポプマス追加実装アイドルの属性データ追加 2021/9 実装分2

### DIFF
--- a/RDFs/283.rdf
+++ b/RDFs/283.rdf
@@ -585,6 +585,10 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Brand xml:lang="en">ShinyColors</imas:Brand>
     <schema:memberOf rdf:resource="283Production"/>
+    <imas:PopLinksAttribute xml:lang="en">fire</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">炎</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">rainbow</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">虹</imas:PopLinksAttribute>
     <schema:description xml:lang="ja">裕福な家庭に生まれた社長令嬢。家名に誇りを持ち、自らもその肩書に恥じぬよう日々鍛錬を積んでいる。スタイルがよく、引き締まっている。大学2年生。</schema:description>
     <imas:SchoolGrade xml:lang="ja">大学2年生</imas:SchoolGrade>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>

--- a/RDFs/765MillionStars.rdf
+++ b/RDFs/765MillionStars.rdf
@@ -661,6 +661,10 @@
     <schema:memberOf rdf:resource="765Production"/>
     <schema:birthPlace xml:lang="ja">千葉</schema:birthPlace>
     <imas:Division xml:lang="en">Princess</imas:Division>
+    <imas:PopLinksAttribute xml:lang="en">fire</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">炎</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">ocean</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">海</imas:PopLinksAttribute>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/30008"/>
   </rdf:Description>

--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -4079,6 +4079,10 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">276E4E</imas:Color>
     <imas:Hobby xml:lang="ja">サバゲー</imas:Hobby>
     <imas:Hobby xml:lang="ja">プラモ収集</imas:Hobby>
+    <imas:PopLinksAttribute xml:lang="en">fire</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">炎</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">heaven</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">天</imas:PopLinksAttribute>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20179"/>
   </rdf:Description>
 


### PR DESCRIPTION
ref. #439
既にポプマス属性が登録されているアイドルと同様に、
ポプマス追加実装アイドルにもポプマス属性データを入れました。

対象：「大和 亜季」「高坂 海美」「有栖川 夏葉」
https://twitter.com/imas_poplinks/status/1433755401527255049