### PR TITLE
シャイニーカラーズの新衣装を追加

### DIFF
--- a/RDFs/Clothes/ShinyColorsCommon.rdf
+++ b/RDFs/Clothes/ShinyColorsCommon.rdf
@@ -1679,6 +1679,20 @@
     <schema:description xml:lang="ja">ルームウェア。wear and tear</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="PrivateDressDown_HachimiyaMeguru">
+    <schema:name xml:lang="ja">プライベートドレスダウン</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プライベートドレスダウン</rdfs:label>
+    <imas:Whose rdf:resource="Hachimiya_Meguru"/>
+    <schema:description xml:lang="ja">ルームウェア。瞬発力オッケー！</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="PrivateDressDown_KomiyaKaho">
+    <schema:name xml:lang="ja">プライベートドレスダウン</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プライベートドレスダウン</rdfs:label>
+    <imas:Whose rdf:resource="Komiya_Kaho"/>
+    <schema:description xml:lang="ja">ルームウェア。小宮家のヒーロー</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
   <!-- ファウンテンサマー -->
   <rdf:Description rdf:about="FountainSummer_SakuragiMano">
     <schema:name xml:lang="ja">ファウンテンサマー</schema:name>

--- a/RDFs/Clothes/ShinyColorsCommon.rdf
+++ b/RDFs/Clothes/ShinyColorsCommon.rdf
@@ -840,6 +840,20 @@
     <schema:description xml:lang="ja">メリークリスマス！欲しい物は、全部欲しい</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="HolyNightCape_NanakusaNichika">
+    <schema:name xml:lang="ja">ホーリーナイトケープ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ホーリーナイトケープ</rdfs:label>
+    <imas:Whose rdf:resource="Nanakusa_Nichika"/>
+    <schema:description xml:lang="ja">メリークリスマス！クリスマスのばかやろ</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="HolyNightCape_AketaMikoto">
+    <schema:name xml:lang="ja">ホーリーナイトケープ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ホーリーナイトケープ</rdfs:label>
+    <imas:Whose rdf:resource="Aketa_Mikoto"/>
+    <schema:description xml:lang="ja">メリークリスマス！Winter wishes</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
   <!-- ファッショナブルサマー -->
   <rdf:Description rdf:about="FashionableSummer_SakuragiMano">
     <schema:name xml:lang="ja">ファッショナブルサマー</schema:name>

--- a/RDFs/Clothes/ShinyColorsCommon.rdf
+++ b/RDFs/Clothes/ShinyColorsCommon.rdf
@@ -199,6 +199,20 @@
     <schema:description xml:lang="ja">ワンステップ。曇ってたら見えないでしょ？</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="OvercastMonochrome_NanakusaNichika">
+    <schema:name xml:lang="ja">オーバーキャストモノクローム</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">オーバーキャストモノクローム</rdfs:label>
+    <imas:Whose rdf:resource="Nanakusa_Nichika"/>
+    <schema:description xml:lang="ja">ワンステップ。めちゃめちゃ灰色</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="OvercastMonochrome_AketaMikoto">
+    <schema:name xml:lang="ja">オーバーキャストモノクローム</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">オーバーキャストモノクローム</rdfs:label>
+    <imas:Whose rdf:resource="Aketa_Mikoto"/>
+    <schema:description xml:lang="ja">ワンステップ。Cloudy, fine later</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
   <!-- シャイニーサマー -->
   <rdf:Description rdf:about="ShinySummer_SakuragiMano">
     <schema:name xml:lang="ja">シャイニーサマー</schema:name>

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -628,6 +628,28 @@
     <imas:Whose rdf:resource="Osaki_Tenka"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="OpporsiParadiso_OsakiAmana">
+    <schema:name xml:lang="ja">オポーズパラディーソ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">オポーズパラディーソ</rdfs:label>
+    <imas:Whose rdf:resource="Osaki_Amana"/>
+    <schema:description xml:lang="ja">たとえ堕ちるとも君となら</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="OpporsiParadiso_OsakiTenka">
+    <schema:name xml:lang="ja">オポーズパラディーソ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">オポーズパラディーソ</rdfs:label>
+    <imas:Whose rdf:resource="Osaki_Tenka"/>
+    <schema:description xml:lang="ja">たとえ君が堕ちようとも</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="OpporsiParadiso_KuwayamaChiyuki">
+    <schema:name xml:lang="ja">オポーズパラディーソ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">オポーズパラディーソ</rdfs:label>
+    <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
+    <schema:description xml:lang="ja">受け止めて抱きしめる、両の腕</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+
   <!-- Straylight -->
   <rdf:Description rdf:about="Neon_Light_Romancer">
     <schema:name xml:lang="ja">ネオンライトロマンサー</schema:name>

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -872,4 +872,18 @@
     <imas:Whose rdf:resource="Aketa_Mikoto"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="SetupCrazy_NanakusaNichika">
+    <schema:name xml:lang="ja">セットアップクレイジー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">セットアップクレイジー</rdfs:label>
+    <imas:Whose rdf:resource="Nanakusa_Nichika"/>
+    <schema:description xml:lang="ja">意地っ張りのツイード</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="SetupCrazy_AketaMikoto">
+    <schema:name xml:lang="ja">セットアップクレイジー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">セットアップクレイジー</rdfs:label>
+    <imas:Whose rdf:resource="Aketa_Mikoto"/>
+    <schema:description xml:lang="ja">checkmate!</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 </rdf:RDF>

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -738,6 +738,28 @@
     <imas:Whose rdf:resource="Izumi_Mei"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="FreesideJK_SerizawaAsahi">
+    <schema:name xml:lang="ja">フリーサイドジェイケー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フリーサイドジェイケー</rdfs:label>
+    <imas:Whose rdf:resource="Serizawa_Asahi"/>
+    <schema:description xml:lang="ja">サイキョーの仲間入り！</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="FreesideJK_MayuzumiFuyuko">
+    <schema:name xml:lang="ja">フリーサイドジェイケー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フリーサイドジェイケー</rdfs:label>
+    <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
+    <schema:description xml:lang="ja">この手のカワイイだって余裕</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="FreesideJK_IzumiMei">
+    <schema:name xml:lang="ja">フリーサイドジェイケー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フリーサイドジェイケー</rdfs:label>
+    <imas:Whose rdf:resource="Izumi_Mei"/>
+    <schema:description xml:lang="ja">ちょーハンパない系のうちら♪</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+
   <!-- noctchill -->
   <rdf:Description rdf:about="Clear_Marine_Calm">
     <schema:name xml:lang="ja">クリアマリンカーム</schema:name>

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -494,6 +494,42 @@
     <imas:Whose rdf:resource="Sonoda_Chiyoko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="KissaClimaxSeifuku_KomiyaKaho">
+    <schema:name xml:lang="ja">喫茶くらいまっくす制服</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">喫茶くらいまっくす制服</rdfs:label>
+    <imas:Whose rdf:resource="Komiya_Kaho"/>
+    <schema:description xml:lang="ja">おやつは手作りケーキで</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="KissaClimaxSeifuku_SonodaChiyoko">
+    <schema:name xml:lang="ja">喫茶くらいまっくす制服</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">喫茶くらいまっくす制服</rdfs:label>
+    <imas:Whose rdf:resource="Sonoda_Chiyoko"/>
+    <schema:description xml:lang="ja">樹里ちゃん直伝の極意を武器に</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="KissaClimaxSeifuku_SaijoJuri">
+    <schema:name xml:lang="ja">喫茶くらいまっくす制服</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">喫茶くらいまっくす制服</rdfs:label>
+    <imas:Whose rdf:resource="Saijo_Juri"/>
+    <schema:description xml:lang="ja">筋書き通りにはいかないもの</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="KissaClimaxSeifuku_MorinoRinze">
+    <schema:name xml:lang="ja">喫茶くらいまっくす制服</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">喫茶くらいまっくす制服</rdfs:label>
+    <imas:Whose rdf:resource="Morino_Rinze"/>
+    <schema:description xml:lang="ja">純情完売。</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="KissaClimaxSeifuku_ArisugawaNatsuha">
+    <schema:name xml:lang="ja">喫茶くらいまっくす制服</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">喫茶くらいまっくす制服</rdfs:label>
+    <imas:Whose rdf:resource="Arisugawa_Natsuha"/>
+    <schema:description xml:lang="ja">紅茶に檸檬を添えて</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+
   <!-- ALSTROEMERIA -->
   <rdf:Description rdf:about="Wishful_Lily">
     <schema:name xml:lang="ja">ウィッシュフルリリー</schema:name>

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -125,6 +125,28 @@
     <schema:description xml:lang="ja">星ときみと、未来を唄う</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="BytodayRestaurant_SakuragiMano">
+    <schema:name xml:lang="ja">バイトゥデイレストラント</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">バイトゥデイレストラント</rdfs:label>
+    <imas:Whose rdf:resource="Sakuragi_Mano"/>
+    <schema:description xml:lang="ja">いらっしゃいませ、輝ける場所へ</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="BytodayRestaurant_KazanoHiori">
+    <schema:name xml:lang="ja">バイトゥデイレストラント</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">バイトゥデイレストラント</rdfs:label>
+    <imas:Whose rdf:resource="Kazano_Hiori"/>
+    <schema:description xml:lang="ja">オーダーはお決まりですか？</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="BytodayRestaurant_HachimiyaMeguru">
+    <schema:name xml:lang="ja">バイトゥデイレストラント</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">バイトゥデイレストラント</rdfs:label>
+    <imas:Whose rdf:resource="Hachimiya_Meguru"/>
+    <schema:description xml:lang="ja">トレイ捌きはお任せ♪</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+
   <!-- L'Antica -->
   <rdf:Description rdf:about="Symphonic_Steam">
     <schema:name xml:lang="ja">シンフォニックスチーム</schema:name>

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -125,21 +125,21 @@
     <schema:description xml:lang="ja">星ときみと、未来を唄う</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="BytodayRestaurant_SakuragiMano">
+  <rdf:Description rdf:about="BaitwudeiRestaurant_SakuragiMano">
     <schema:name xml:lang="ja">バイトゥデイレストラント</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">バイトゥデイレストラント</rdfs:label>
     <imas:Whose rdf:resource="Sakuragi_Mano"/>
     <schema:description xml:lang="ja">いらっしゃいませ、輝ける場所へ</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="BytodayRestaurant_KazanoHiori">
+  <rdf:Description rdf:about="BaitwudeiRestaurant_KazanoHiori">
     <schema:name xml:lang="ja">バイトゥデイレストラント</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">バイトゥデイレストラント</rdfs:label>
     <imas:Whose rdf:resource="Kazano_Hiori"/>
     <schema:description xml:lang="ja">オーダーはお決まりですか？</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="BytodayRestaurant_HachimiyaMeguru">
+  <rdf:Description rdf:about="BaitwudeiRestaurant_HachimiyaMeguru">
     <schema:name xml:lang="ja">バイトゥデイレストラント</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">バイトゥデイレストラント</rdfs:label>
     <imas:Whose rdf:resource="Hachimiya_Meguru"/>

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -303,6 +303,42 @@
     <imas:Whose rdf:resource="Tanaka_Mamimi"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="ReflectionThemePark_TsukiokaKogane">
+    <schema:name xml:lang="ja">リフレクションテーマパーク</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">リフレクションテーマパーク</rdfs:label>
+    <imas:Whose rdf:resource="Tsukioka_Kogane"/>
+    <schema:description xml:lang="ja">尻尾は素直なお年頃</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="ReflectionThemePark_TanakaMamimi">
+    <schema:name xml:lang="ja">リフレクションテーマパーク</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">リフレクションテーマパーク</rdfs:label>
+    <imas:Whose rdf:resource="Tanaka_Mamimi"/>
+    <schema:description xml:lang="ja">ようこそ、ここではみんな子ども</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="ReflectionThemePark_ShiraseSakuya">
+    <schema:name xml:lang="ja">リフレクションテーマパーク</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">リフレクションテーマパーク</rdfs:label>
+    <imas:Whose rdf:resource="Shirase_Sakuya"/>
+    <schema:description xml:lang="ja">君がキミを忘れるまで</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="ReflectionThemePark_MitsumineYuika">
+    <schema:name xml:lang="ja">リフレクションテーマパーク</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">リフレクションテーマパーク</rdfs:label>
+    <imas:Whose rdf:resource="Mitsumine_Yuika"/>
+    <schema:description xml:lang="ja">キララ乱反射</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="ReflectionThemePark_YukokuKiriko">
+    <schema:name xml:lang="ja">リフレクションテーマパーク</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">リフレクションテーマパーク</rdfs:label>
+    <imas:Whose rdf:resource="Yukoku_Kiriko"/>
+    <schema:description xml:lang="ja">心の鍵、お預かりします</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+
   <!-- 放課後クライマックスガールズ -->
   <rdf:Description rdf:about="Brave_Hero_Jogging_Suits">
     <schema:name xml:lang="ja">ブレイブヒーロージャージ</schema:name>

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -835,6 +835,35 @@
     <imas:Whose rdf:resource="Ichikawa_Hinana"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="FancyFreeNursing_AsakuraToru">
+    <schema:name xml:lang="ja">ファンシーフリーナーシング</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ファンシーフリーナーシング</rdfs:label>
+    <imas:Whose rdf:resource="Asakura_Toru"/>
+    <schema:description xml:lang="ja">はい、心臓出してー</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="FancyFreeNursing_HiguchiMadoka">
+    <schema:name xml:lang="ja">ファンシーフリーナーシング</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ファンシーフリーナーシング</rdfs:label>
+    <imas:Whose rdf:resource="Higuchi_Madoka"/>
+    <schema:description xml:lang="ja">あまやかに、ちくっとするの</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="FancyFreeNursing_FukumaruKoito">
+    <schema:name xml:lang="ja">ファンシーフリーナーシング</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ファンシーフリーナーシング</rdfs:label>
+    <imas:Whose rdf:resource="Fukumaru_Koito"/>
+    <schema:description xml:lang="ja">どうぞおだいじに</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="FancyFreeNursing_IchikawaHinana">
+    <schema:name xml:lang="ja">ファンシーフリーナーシング</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ファンシーフリーナーシング</rdfs:label>
+    <imas:Whose rdf:resource="Ichikawa_Hinana"/>
+    <schema:description xml:lang="ja">しあわせ1週間分処方</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+
   <!-- SHHis -->
   <rdf:Description rdf:about="Silky_Gemsilica">
     <schema:name xml:lang="ja">シルキージェムシリカ</schema:name>


### PR DESCRIPTION
2021/11/30 の更新で追加された、以下の衣装を追加しました。

- オーバーキャストモノクローム（にちか, 美琴）
- ホーリーナイトケープ（にちか, 美琴）
- プライベートドレスダウン（めぐる, 果穂）
