### PR TITLE
ポプマス追加実装アイドルの属性データ追加 2021/12

### DIFF
--- a/RDFs/765MillionStars.rdf
+++ b/RDFs/765MillionStars.rdf
@@ -421,6 +421,10 @@
     <schema:memberOf rdf:resource="765Production"/>
     <schema:birthPlace xml:lang="ja">埼玉</schema:birthPlace>
     <imas:Division xml:lang="en">Angel</imas:Division>
+    <imas:PopLinksAttribute xml:lang="en">wind</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">風</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">heaven</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">天</imas:PopLinksAttribute>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <imas:SchoolGrade xml:lang="ja">高校1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/30026"/>

--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -918,6 +918,10 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1107456"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">CA113A</imas:Color>
     <imas:Hobby xml:lang="ja">猫カフェ巡り</imas:Hobby>
+    <imas:PopLinksAttribute xml:lang="en">moon</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">月</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">love</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">愛</imas:PopLinksAttribute>
     <imas:SchoolGrade xml:lang="ja">高校1年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20147"/>
   </rdf:Description>
@@ -4245,6 +4249,10 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">長野</schema:birthPlace>
     <imas:Hobby xml:lang="ja">歌を口ずさむこと</imas:Hobby>
+    <imas:PopLinksAttribute xml:lang="en">snow</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">雪</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">light</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">光</imas:PopLinksAttribute>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20170"/>
   </rdf:Description>
 
@@ -4279,6 +4287,10 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q55875405"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">5C068F</imas:Color>
     <imas:Hobby xml:lang="ja">隠し芸</imas:Hobby>
+    <imas:PopLinksAttribute xml:lang="en">heaven</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">天</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">dream</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">夢</imas:PopLinksAttribute>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20100"/>
   </rdf:Description>
 
@@ -6328,6 +6340,10 @@
     <imas:Constellation xml:lang="ja">山羊座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">グリーンランド</schema:birthPlace>
     <imas:Hobby xml:lang="ja">煙突探し</imas:Hobby>
+    <imas:PopLinksAttribute xml:lang="en">snow</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">雪</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">dream</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">夢</imas:PopLinksAttribute>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20015"/>
   </rdf:Description>
 

--- a/RDFs/SideM.rdf
+++ b/RDFs/SideM.rdf
@@ -651,6 +651,10 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male</schema:gender>
     <imas:Brand xml:lang="en">SideM</imas:Brand>
     <schema:memberOf rdf:resource="315Production"/>
+    <imas:PopLinksAttribute xml:lang="en">wind</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">風</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">moon</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">月</imas:PopLinksAttribute>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/40035"/>
   </rdf:Description>


### PR DESCRIPTION
既にポプマス属性が登録されているアイドルと同様に、
ポプマス追加実装アイドルにもポプマス属性データを入れました。

対象：「前川 みく」「野々原 茜」「猫柳 キリオ」「鷹富士 茄子」「望月 聖」「イヴ・サンタクロース」
https://poplinks.idolmaster-official.jp/idol/index.php?sh=true
※ソースは公式のみです