### PR TITLE
ポプマス追加実装アイドルの属性データ追加 2022/1

### DIFF
--- a/RDFs/765MillionStars.rdf
+++ b/RDFs/765MillionStars.rdf
@@ -1370,6 +1370,10 @@
     <schema:memberOf rdf:resource="765Production"/>
     <schema:birthPlace xml:lang="ja">広島</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
+    <imas:PopLinksAttribute xml:lang="en">love</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">愛</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">wind</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">風</imas:PopLinksAttribute>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/30036"/>
   </rdf:Description>

--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -2425,6 +2425,10 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">3F59A6</imas:Color>
     <imas:Hobby xml:lang="ja">掃除</imas:Hobby>
     <imas:Hobby xml:lang="ja">洗濯</imas:Hobby>
+    <imas:PopLinksAttribute xml:lang="en">dream</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">夢</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">ocean</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">海</imas:PopLinksAttribute>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20043"/>
   </rdf:Description>
 
@@ -6271,6 +6275,10 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E44E8E</imas:Color>
     <imas:Hobby xml:lang="ja">ドレスアップ</imas:Hobby>
     <imas:Hobby xml:lang="ja">衣装作り</imas:Hobby>
+    <imas:PopLinksAttribute xml:lang="en">light</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">光</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">love</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">愛</imas:PopLinksAttribute>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20078"/>
   </rdf:Description>
 


### PR DESCRIPTION
既にポプマス属性が登録されているアイドルと同様に、
ポプマス追加実装アイドルにもポプマス属性データを入れました。

対象：「川島 瑞樹」「佐藤 心」「百瀬 莉緒」
https://poplinks.idolmaster-official.jp/idol/index.php?sh=true
※ソースは公式のみです