### PR TITLE
ポプマス追加実装アイドルの属性データ追加 2022/1_2

### DIFF
--- a/RDFs/283.rdf
+++ b/RDFs/283.rdf
@@ -916,6 +916,10 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Brand xml:lang="en">ShinyColors</imas:Brand>
     <schema:memberOf rdf:resource="283Production"/>
+    <imas:PopLinksAttribute xml:lang="en">rainbow</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">虹</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">ocean</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">海</imas:PopLinksAttribute>
     <schema:description xml:lang="ja">内弁慶な小動物系の女の子。真面目な努力家で、勉強が得意。騙されやすく、幼なじみによくからかわれている。高校1年生。</schema:description>
     <imas:SchoolGrade xml:lang="ja">高校1年生</imas:SchoolGrade>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>

--- a/RDFs/765MillionStars.rdf
+++ b/RDFs/765MillionStars.rdf
@@ -1493,6 +1493,10 @@
     <schema:memberOf rdf:resource="765Production"/>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
     <imas:Division xml:lang="en">Fairy</imas:Division>
+    <imas:PopLinksAttribute xml:lang="en">sky</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">空</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">dream</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">夢</imas:PopLinksAttribute>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
     <imas:SchoolGrade xml:lang="ja">小学5年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/30015"/>

--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -2946,6 +2946,10 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">5881C1</imas:Color>
     <imas:Hobby xml:lang="ja">読書（ミステリー）</imas:Hobby>
     <imas:Hobby xml:lang="ja">ゲーム</imas:Hobby>
+    <imas:PopLinksAttribute xml:lang="en">snow</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">雪</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">moon</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">月</imas:PopLinksAttribute>
     <imas:SchoolGrade xml:lang="ja">小学6年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20104"/>
   </rdf:Description>


### PR DESCRIPTION
既にポプマス属性が登録されているアイドルと同様に、
ポプマス追加実装アイドルにもポプマス属性データを入れました。

https://poplinks.idolmaster-official.jp/idol/index.php?sh=true
https://www.youtube.com/watch?v=qIhhS9xNpP4
※ソースは公式のみです