### PR TITLE
ポプマス追加実装アイドルの属性データ追加 2022/2

### DIFF
--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -314,6 +314,10 @@
     <imas:Constellation xml:lang="ja">双子座</imas:Constellation>
     <schema:birthPlace xml:lang="ja">秋田</schema:birthPlace>
     <imas:Hobby xml:lang="ja">読書</imas:Hobby>
+    <imas:PopLinksAttribute xml:lang="en">flower</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">花</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">wind</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">風</imas:PopLinksAttribute>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20038"/>
   </rdf:Description>
 
@@ -2985,6 +2989,10 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1186964"/>
     <imas:Hobby xml:lang="ja">本屋めぐり</imas:Hobby>
     <imas:Hobby xml:lang="ja">栞作り</imas:Hobby>
+    <imas:PopLinksAttribute xml:lang="en">wind</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">風</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">star</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">星</imas:PopLinksAttribute>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20073"/>
   </rdf:Description>
 
@@ -3727,6 +3735,10 @@
     <schema:birthPlace xml:lang="ja">栃木</schema:birthPlace>
     <imas:Hobby xml:lang="ja">冒険小説を読む</imas:Hobby>
     <imas:Hobby xml:lang="ja">冒険映画を見る事</imas:Hobby>
+    <imas:PopLinksAttribute xml:lang="en">sky</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">空</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">rainbow</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">虹</imas:PopLinksAttribute>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20024"/>
   </rdf:Description>
 


### PR DESCRIPTION
既にポプマス属性が登録されているアイドルと同様に、
ポプマス追加実装アイドルにもポプマス属性データを入れました。

https://poplinks.idolmaster-official.jp/idol/index.php?sh=true
https://youtu.be/-PNeG49e_NY
※ソースは公式のみです