### PR TITLE
ポプマス追加実装アイドルの属性データ追加 2022/3

### DIFF
--- a/RDFs/283.rdf
+++ b/RDFs/283.rdf
@@ -842,6 +842,10 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Brand xml:lang="en">ShinyColors</imas:Brand>
     <schema:memberOf rdf:resource="283Production"/>
+    <imas:PopLinksAttribute xml:lang="en">wind</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">風</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">ocean</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">海</imas:PopLinksAttribute>
     <schema:description xml:lang="ja">自然体で飾らない性格。周囲からどう見られるかということを気にせず、おおらかでマイペース。しかしその透明感あふれる佇まいには誰をも惹きつけるオーラがある。高校2年生。</schema:description>
     <imas:SchoolGrade xml:lang="ja">高校2年生</imas:SchoolGrade>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>

--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -3151,6 +3151,10 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q6356324"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">202449</imas:Color>
     <imas:Hobby xml:lang="ja">ホラー映画鑑賞</imas:Hobby>
+    <imas:PopLinksAttribute xml:lang="en">fire</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">炎</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">thunder</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">雷</imas:PopLinksAttribute>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20150"/>
   </rdf:Description>
 
@@ -3965,6 +3969,10 @@
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11666486"/>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">0D386D</imas:Color>
     <imas:Hobby xml:lang="ja">映画鑑賞</imas:Hobby>
+    <imas:PopLinksAttribute xml:lang="en">moon</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">月</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">darkness</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">闇</imas:PopLinksAttribute>
     <imas:SchoolGrade xml:lang="ja">高校2年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20128"/>
   </rdf:Description>


### PR DESCRIPTION
既にポプマス属性が登録されているアイドルと同様に、
ポプマス追加実装アイドルにもポプマス属性データを入れました。

https://poplinks.idolmaster-official.jp/idol/index.php?sh=true
https://www.youtube.com/watch?v=uOD-4Rz5oCo
※ソースは公式のみです