### PR TITLE
プライベートドレスダウンの追加・修正

### DIFF
--- a/RDFs/Clothes/ShinyColorsCommon.rdf
+++ b/RDFs/Clothes/ShinyColorsCommon.rdf
@@ -1735,6 +1735,20 @@
     <schema:description xml:lang="ja">ルームウェア。寝る時も美味しそうであるべき</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="PrivateDressDown_KuwayamaChiyuki">
+    <schema:name xml:lang="ja">プライベートドレスダウン</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プライベートドレスダウン</rdfs:label>
+    <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
+    <schema:description xml:lang="ja">ルームウェア。夢の岸辺に泳ぎつくための——</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="PrivateDressDown_FukumaruKoito">
+    <schema:name xml:lang="ja">プライベートドレスダウン</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プライベートドレスダウン</rdfs:label>
+    <imas:Whose rdf:resource="Fukumaru_Koito"/>
+    <schema:description xml:lang="ja">ルームウェア。おなかのシャツをいれておやすみ</schema:description>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
   <!-- ファウンテンサマー -->
   <rdf:Description rdf:about="FountainSummer_SakuragiMano">
     <schema:name xml:lang="ja">ファウンテンサマー</schema:name>

--- a/RDFs/Clothes/ShinyColorsCommon.rdf
+++ b/RDFs/Clothes/ShinyColorsCommon.rdf
@@ -1697,14 +1697,14 @@
     <schema:name xml:lang="ja">プライベートドレスダウン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プライベートドレスダウン</rdfs:label>
     <imas:Whose rdf:resource="Tsukioka_Kogane"/>
-    <schema:description xml:lang="ja">夢で逢っても焦らない</schema:description>
+    <schema:description xml:lang="ja">ルームウェア。夢で逢っても焦らない</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="PrivateDressDown_OsakiTenka">
     <schema:name xml:lang="ja">プライベートドレスダウン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プライベートドレスダウン</rdfs:label>
     <imas:Whose rdf:resource="Osaki_Tenka"/>
-    <schema:description xml:lang="ja">閉店時の正装</schema:description>
+    <schema:description xml:lang="ja">ルームウェア。閉店時の正装</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="PrivateDressDown_SaijoJuri">


### PR DESCRIPTION
シャイニーカラーズの以下の衣装を追加しました。

- プライベートドレスダウン（桑山千雪, 福丸小糸）

また、恋鐘さんと甜花ちゃんの衣装ポエムが修正されていたので、対応しました。

> https://mobile.twitter.com/arrow_2nd/status/1510479843208491013

何か意味があったわけじゃなかったんですね……。
