### PR TITLE
ポプマス追加実装アイドルの属性データ追加 2022/4_2

### DIFF
--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -1360,6 +1360,10 @@
     <schema:birthPlace xml:lang="ja">名古屋</schema:birthPlace>
     <imas:Hobby xml:lang="ja">史跡巡り</imas:Hobby>
     <imas:Hobby xml:lang="ja">武将グッズ収集</imas:Hobby>
+    <imas:PopLinksAttribute xml:lang="en">flower</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">花</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">fire</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">炎</imas:PopLinksAttribute>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20122"/>
   </rdf:Description>
 
@@ -3913,6 +3917,10 @@
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">3A75BB</imas:Color>
     <imas:Hobby xml:lang="ja">時代小説を読むこと</imas:Hobby>
     <imas:Hobby xml:lang="ja">剣道</imas:Hobby>
+    <imas:PopLinksAttribute xml:lang="en">wind</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">風</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">thunder</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">雷</imas:PopLinksAttribute>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20189"/>
   </rdf:Description>
 
@@ -6171,6 +6179,10 @@
     <imas:Hobby xml:lang="ja">撮影所巡り</imas:Hobby>
     <imas:Hobby xml:lang="ja">忍者グッズ収集</imas:Hobby>
     <imas:Hobby xml:lang="ja">時代劇鑑賞</imas:Hobby>
+    <imas:PopLinksAttribute xml:lang="en">moon</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">月</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="en">darkness</imas:PopLinksAttribute>
+    <imas:PopLinksAttribute xml:lang="ja">闇</imas:PopLinksAttribute>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20126"/>
   </rdf:Description>
 


### PR DESCRIPTION
既にポプマス属性が登録されているアイドルと同様に、
ポプマス追加実装アイドルにもポプマス属性データを入れました。

https://poplinks.idolmaster-official.jp/idol/index.php?sh=true
https://www.youtube.com/watch?v=dqOqrW72EPg
※ソースは公式のみです