### PR TITLE
Update color

### DIFF
--- a/RDFs/961.rdf
+++ b/RDFs/961.rdf
@@ -17,6 +17,7 @@
     <imas:cv xml:lang="ja">茅原実里</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/茅原実里"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q256910"/>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">5A2B8D</imas:Color>
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Brand xml:lang="en">Other</imas:Brand>
     <schema:memberOf rdf:resource="961Production"/>
@@ -46,6 +47,7 @@
     <imas:cv xml:lang="ja">高橋李依</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/高橋李依"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q17160610"/>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E5F9E4</imas:Color>
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Brand xml:lang="en">Other</imas:Brand>
     <schema:memberOf rdf:resource="961Production"/>
@@ -73,6 +75,7 @@
     <imas:cv xml:lang="ja">日高里菜</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/日高里菜"/>
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q152707"/>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">3F3538</imas:Color>
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Brand xml:lang="en">Other</imas:Brand>
     <schema:memberOf rdf:resource="961Production"/>

--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -1173,7 +1173,7 @@
     <imas:cv xml:lang="ja">五十嵐裕美</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/五十嵐裕美"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q5770504"/>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F19DB4</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F8A3BC</imas:Color>
     <imas:Hobby xml:lang="ja">なし</imas:Hobby>
     <imas:PopLinksAttribute xml:lang="en">dream</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">夢</imas:PopLinksAttribute>
@@ -1680,7 +1680,7 @@
     <imas:cv xml:lang="ja">三宅麻理恵</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/三宅麻理恵"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q6127820"/>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E64A79</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">EF4A81</imas:Color>
     <imas:Hobby xml:lang="ja">ウサミン星との交信</imas:Hobby>
     <imas:PopLinksAttribute xml:lang="en">moon</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">月</imas:PopLinksAttribute>
@@ -3263,7 +3263,7 @@
     <imas:cv xml:lang="ja">早見沙織</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/早見沙織"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q1153079"/>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">33D5AC</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">47D7AC</imas:Color>
     <imas:Hobby xml:lang="ja">温泉めぐり</imas:Hobby>
     <imas:PopLinksAttribute xml:lang="en">wind</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">風</imas:PopLinksAttribute>
@@ -3301,7 +3301,7 @@
     <imas:cv xml:lang="ja">内田真礼</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/内田真礼"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q44552"/>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">7E3188</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">84329B</imas:Color>
     <imas:Hobby xml:lang="ja">絵を描くこと</imas:Hobby>
     <imas:PopLinksAttribute xml:lang="en">light</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">光</imas:PopLinksAttribute>
@@ -5532,7 +5532,7 @@
     <imas:cv xml:lang="ja">佳村はるか</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/佳村はるか"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11385438"/>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F4982B</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">FF9E1B</imas:Color>
     <imas:Hobby xml:lang="ja">カラオケ</imas:Hobby>
     <imas:PopLinksAttribute xml:lang="en">love</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">愛</imas:PopLinksAttribute>
@@ -5676,7 +5676,7 @@
     <imas:cv xml:lang="ja">松嵜麗</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/松嵜麗"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q391799"/>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F8CA02</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E0E101</imas:Color>
     <imas:Hobby xml:lang="ja">かわいい物集め</imas:Hobby>
     <imas:PopLinksAttribute xml:lang="en">sky</imas:PopLinksAttribute>
     <imas:PopLinksAttribute xml:lang="ja">空</imas:PopLinksAttribute>


### PR DESCRIPTION
1. 一部シンデレラガールズアイドルのイメージカラーを更新.

   - 双葉杏: F8A3BC
   - 安部菜々: EF4A81
   - 高垣楓: 47D7AC
   - 神崎蘭子: 84329B
   - 城ヶ崎美嘉: FF9E1B
   - 諸星きらり: E0E101

2. 961 のアイドルにイメージカラーを追加します。

出所はスターリットシーズン公式サイトのアイドル背景.
