### PR TITLE
アンティーカの新衣装を追加

### DIFF
--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -217,6 +217,16 @@
     <imas:Whose rdf:resource="Yukoku_Kiriko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Papillonia_Feerique">
+    <schema:name xml:lang="ja">パピロニアフェリーク</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">パピロニアフェリーク</rdfs:label>
+    <imas:Whose rdf:resource="Tsukioka_Kogane"/>
+    <imas:Whose rdf:resource="Mitsumine_Yuika"/>
+    <imas:Whose rdf:resource="Yukoku_Kiriko"/>
+    <imas:Whose rdf:resource="Shirase_Sakuya"/>
+    <imas:Whose rdf:resource="Tanaka_Mamimi"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
   <rdf:Description rdf:about="Wonderland_Hoppin">
     <schema:name xml:lang="ja">ワンダーランドホッピン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ワンダーランドホッピン</rdfs:label>


### PR DESCRIPTION
アンティーカの新衣装、パピロニアフェリークを追加しました。

> https://mobile.twitter.com/imassc_official/status/1527529804983021568

衣装名の語源は

- [papillon](https://kotobank.jp/frjaword/papillon) ... 蝶
- [feerique](https://kotobank.jp/frjaword/feerique) ... 妖精の, 夢のように美しい

かな...と思ったので、リソース名は `Papillonia_Feerique` としてみました。
