### PR TITLE
シャイニーカラーズの新衣装を追加

### DIFF
--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -734,6 +734,15 @@
     <schema:description xml:lang="ja">受け止めて抱きしめる、両の腕</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Magique_Allure">
+    <schema:name xml:lang="ja">マジーク・アルーア</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">マジーク・アルーア</rdfs:label>
+    <schema:description xml:lang="ja"/>
+    <imas:Whose rdf:resource="Osaki_Amana"/>
+    <imas:Whose rdf:resource="Osaki_Tenka"/>
+    <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- Straylight -->
   <rdf:Description rdf:about="Neon_Light_Romancer">


### PR DESCRIPTION
アルストロメリアの新衣装、[マジーク・アルーア](https://twitter.com/imassc_official/status/1549998607482269696) を追加しました。

リソース名は以下を参考にしています。

- [magique](https://kotobank.jp/frjaword/magique)
- [allure](https://eow.alc.co.jp/search?q=allure)