### PR TITLE
MOIW2023出演メンバーのキャラカラーを追加

### DIFF
--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -5743,6 +5743,7 @@
     <imas:cv xml:lang="ja">生田輝</imas:cv>
     <!--<imas:cv rdf:resource="http://ja.dbpedia.org/resource/生田輝"/>-->
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q66736457"/>
+	<imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D95E25</imas:Color>
     <imas:Hobby xml:lang="ja">ベリーダンス</imas:Hobby>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20113"/>
   </rdf:Description>

--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -4279,6 +4279,7 @@
     <imas:cv xml:lang="ja">河瀬茉希</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/河瀬茉希"/>
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q24867153"/>
+	<imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">B04EC5</imas:Color>
     <imas:Hobby xml:lang="ja">異業種交流</imas:Hobby>
     <imas:Hobby xml:lang="ja">ホットヨガ</imas:Hobby>
     <imas:Hobby xml:lang="ja">ぬか床の世話</imas:Hobby>

--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -5298,6 +5298,7 @@
     <imas:cv xml:lang="ja">集貝はな</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/集貝はな"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q74548472"/>
+	<imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E31C93</imas:Color>
     <imas:Hobby xml:lang="ja">ダンス</imas:Hobby>
     <imas:Hobby xml:lang="ja">パパとデート</imas:Hobby>
     <imas:SchoolGrade xml:lang="ja">小学6年生</imas:SchoolGrade>

--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -4279,7 +4279,7 @@
     <imas:cv xml:lang="ja">河瀬茉希</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/河瀬茉希"/>
     <imas:cv rdf:resource="https://www.wikidata.org/wiki/Q24867153"/>
-	<imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">B04EC5</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">B04EC5</imas:Color>
     <imas:Hobby xml:lang="ja">異業種交流</imas:Hobby>
     <imas:Hobby xml:lang="ja">ホットヨガ</imas:Hobby>
     <imas:Hobby xml:lang="ja">ぬか床の世話</imas:Hobby>
@@ -5298,7 +5298,7 @@
     <imas:cv xml:lang="ja">集貝はな</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/集貝はな"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q74548472"/>
-	<imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E31C93</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">E31C93</imas:Color>
     <imas:Hobby xml:lang="ja">ダンス</imas:Hobby>
     <imas:Hobby xml:lang="ja">パパとデート</imas:Hobby>
     <imas:SchoolGrade xml:lang="ja">小学6年生</imas:SchoolGrade>
@@ -5745,7 +5745,7 @@
     <imas:cv xml:lang="ja">生田輝</imas:cv>
     <!--<imas:cv rdf:resource="http://ja.dbpedia.org/resource/生田輝"/>-->
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q66736457"/>
-	<imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D95E25</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D95E25</imas:Color>
     <imas:Hobby xml:lang="ja">ベリーダンス</imas:Hobby>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20113"/>
   </rdf:Description>

--- a/RDFs/SideM.rdf
+++ b/RDFs/SideM.rdf
@@ -1794,7 +1794,7 @@
     <imas:cv xml:lang="ja">伊瀬結陸</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/伊瀬結陸"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q108390594"/>
-	<imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">1D9ADD</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">1D9ADD</imas:Color>
     <imas:Hobby xml:lang="ja">音楽</imas:Hobby>
     <imas:Hobby xml:lang="ja">アニメ</imas:Hobby>
     <imas:Hobby xml:lang="ja">情報収集</imas:Hobby>
@@ -1831,7 +1831,7 @@
     <imas:cv xml:lang="ja">宮﨑雅也</imas:cv>
     <!-- <imas:cv rdf:resource="http://ja.dbpedia.org/resource/宮﨑雅也"/> -->
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q108390543"/>
-	<imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">A2D55E</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">A2D55E</imas:Color>
     <imas:Hobby xml:lang="ja">なし</imas:Hobby>
     <imas:Talent xml:lang="ja">人に愛されること❤</imas:Talent>
     <!-- <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary"></imas:Color> -->
@@ -1866,7 +1866,7 @@
     <imas:cv xml:lang="ja">大塚剛央</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/大塚剛央"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q55536620"/>
-	<imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D72630</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D72630</imas:Color>
     <imas:Hobby xml:lang="ja">映画鑑賞</imas:Hobby>
     <imas:Talent xml:lang="ja">水上オートバイの操縦</imas:Talent>
     <!-- <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary"></imas:Color> -->

--- a/RDFs/SideM.rdf
+++ b/RDFs/SideM.rdf
@@ -1866,6 +1866,7 @@
     <imas:cv xml:lang="ja">大塚剛央</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/大塚剛央"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q55536620"/>
+	<imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D72630</imas:Color>
     <imas:Hobby xml:lang="ja">映画鑑賞</imas:Hobby>
     <imas:Talent xml:lang="ja">水上オートバイの操縦</imas:Talent>
     <!-- <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary"></imas:Color> -->

--- a/RDFs/SideM.rdf
+++ b/RDFs/SideM.rdf
@@ -1794,6 +1794,7 @@
     <imas:cv xml:lang="ja">伊瀬結陸</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/伊瀬結陸"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q108390594"/>
+	<imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">1D9ADD</imas:Color>
     <imas:Hobby xml:lang="ja">音楽</imas:Hobby>
     <imas:Hobby xml:lang="ja">アニメ</imas:Hobby>
     <imas:Hobby xml:lang="ja">情報収集</imas:Hobby>

--- a/RDFs/SideM.rdf
+++ b/RDFs/SideM.rdf
@@ -1831,6 +1831,7 @@
     <imas:cv xml:lang="ja">宮﨑雅也</imas:cv>
     <!-- <imas:cv rdf:resource="http://ja.dbpedia.org/resource/宮﨑雅也"/> -->
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q108390543"/>
+	<imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">A2D55E</imas:Color>
     <imas:Hobby xml:lang="ja">なし</imas:Hobby>
     <imas:Talent xml:lang="ja">人に愛されること❤</imas:Talent>
     <!-- <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary"></imas:Color> -->


### PR DESCRIPTION
MOIW2023に出演するメンバーのキャラカラーを追加しました。
色はアソビストアの「MOIW!!!!! 2023公式プロデュースタオル」画像から抽出しました。
抽出した色と参照ページの一覧をリストアップします。

ナターリア
D95E25
https://shop.asobistore.jp/products/detail/178017-cdg_c_nt-00-00

桐生つかさ
B04EC5
https://shop.asobistore.jp/products/detail/178017-cdg_c_tk-00-00

的場梨沙
E31C93
https://shop.asobistore.jp/products/detail/178017-cdg_c_rm-00-00

天峰 秀
1D9ADD
https://shop.asobistore.jp/products/detail/178042-862-00-00

花園 百々人
A2D55E
https://shop.asobistore.jp/products/detail/178042-863-00-00

眉見 鋭心
D72630
https://shop.asobistore.jp/products/detail/178042-864-00-00