### PR TITLE
シャイニーカラーズの新衣装を追加

### DIFF
--- a/RDFs/Clothes/ShinyColorsCommon.rdf
+++ b/RDFs/Clothes/ShinyColorsCommon.rdf
@@ -2407,4 +2407,11 @@
     <imas:Whose rdf:resource="Yukoku_Kiriko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="RespectiveWorkStyle_HiguchiMadoka">
+    <schema:name xml:lang="ja">リスペクティブワークスタイル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リスペクティブワークスタイル</rdfs:label>
+    <schema:description xml:lang="ja">WORKING：事務員なめんなよ※H.N.参考</schema:description>
+    <imas:Whose rdf:resource="Higuchi_Madoka"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 </rdf:RDF>

--- a/RDFs/Clothes/ShinyColorsCommon.rdf
+++ b/RDFs/Clothes/ShinyColorsCommon.rdf
@@ -1292,6 +1292,20 @@
     <schema:description xml:lang="ja">スタッカート。しあわせの海は空にあるの？</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="SunsetSkyPassage_NanakusaNichika">
+    <schema:name xml:lang="ja">サンセットスカイパッセージ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">サンセットスカイパッセージ</rdfs:label>
+    <schema:description xml:lang="ja">スタッカート。跳べない音符のために</schema:description>
+    <imas:Whose rdf:resource="Nanakusa_Nichika"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="SunsetSkyPassage_AketaMikoto">
+    <schema:name xml:lang="ja">サンセットスカイパッセージ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">サンセットスカイパッセージ</rdfs:label>
+    <schema:description xml:lang="ja">スタッカート。RGB</schema:description>
+    <imas:Whose rdf:resource="Aketa_Mikoto"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- リフレッシュサマー -->
   <rdf:Description rdf:about="RefreshSummer_SakuragiMano">
@@ -2412,6 +2426,13 @@
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リスペクティブワークスタイル</rdfs:label>
     <schema:description xml:lang="ja">WORKING：事務員なめんなよ※H.N.参考</schema:description>
     <imas:Whose rdf:resource="Higuchi_Madoka"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="RespectiveWorkStyle_SonodaChiyoko">
+    <schema:name xml:lang="ja">リスペクティブワークスタイル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リスペクティブワークスタイル</rdfs:label>
+    <schema:description xml:lang="ja">WORKING：チーズがとろとろなうちにお届け</schema:description>
+    <imas:Whose rdf:resource="Sonoda_Chiyoko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
 </rdf:RDF>

--- a/RDFs/Clothes/ShinyColorsPersonal.rdf
+++ b/RDFs/Clothes/ShinyColorsPersonal.rdf
@@ -10,42 +10,36 @@
   <rdf:Description rdf:about="Flourish_Bloom">
     <schema:name xml:lang="ja">フロウリッシュブルーム</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フロウリッシュブルーム</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Sakuragi_Mano"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Ponpon_Support">
     <schema:name xml:lang="ja">ポンポンサポート</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ポンポンサポート</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Sakuragi_Mano"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Prayed_Pigeon">
     <schema:name xml:lang="ja">プレイドピジョン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プレイドピジョン</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Sakuragi_Mano"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Pengy_Guide">
     <schema:name xml:lang="ja">ペンギィガイド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ペンギィガイド</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Sakuragi_Mano"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Caprice_Bold">
     <schema:name xml:lang="ja">カプリスボールド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">カプリスボールド</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Sakuragi_Mano"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Detective_Pigeon">
     <schema:name xml:lang="ja">ディテクティブピジョン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディテクティブピジョン</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Sakuragi_Mano"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -54,35 +48,30 @@
   <rdf:Description rdf:about="Sterling_Diamond">
     <schema:name xml:lang="ja">スターリングダイアモンド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スターリングダイアモンド</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Kazano_Hiori"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Check_De_Noel">
     <schema:name xml:lang="ja">チェックドノエル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">チェックドノエル</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Kazano_Hiori"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Cooking_Idol">
     <schema:name xml:lang="ja">クッキングアイドル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">クッキングアイドル</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Kazano_Hiori"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="October_Witch">
     <schema:name xml:lang="ja">オクトーバーウィッチ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">オクトーバーウィッチ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Kazano_Hiori"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Phantom_Pharos">
     <schema:name xml:lang="ja">ファンタムファロス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ファンタムファロス</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Kazano_Hiori"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -91,28 +80,24 @@
   <rdf:Description rdf:about="Rhythmical_Preppy_Girl">
     <schema:name xml:lang="ja">リズミカルプレッピーガール</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">リズミカルプレッピーガール</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Hachimiya_Meguru"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Red_Merry_Reindeer">
     <schema:name xml:lang="ja">レッドメリーレインディア</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">レッドメリーレインディア</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Hachimiya_Meguru"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Burger_Roller_Skater">
     <schema:name xml:lang="ja">バーガーローラースケーター</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">バーガーローラースケーター</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Hachimiya_Meguru"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Blue_In_Your_Eyes">
     <schema:name xml:lang="ja">ブルーイン・ユアアイズ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブルーイン・ユアアイズ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Hachimiya_Meguru"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -121,35 +106,30 @@
   <rdf:Description rdf:about="Wonderland_Rabbit">
     <schema:name xml:lang="ja">ワンダーランドラビット</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ワンダーランドラビット</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Tsukioka_Kogane"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Pinky_My_Heart">
     <schema:name xml:lang="ja">ピンキーマイハート</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ピンキーマイハート</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Tsukioka_Kogane"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Love_Rob_Thief">
     <schema:name xml:lang="ja">ラブロブシーフ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ラブロブシーフ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Tsukioka_Kogane"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Sailing_Sailor">
     <schema:name xml:lang="ja">セイリングセイラー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">セイリングセイラー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Tsukioka_Kogane"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Moonly_Rabbit">
     <schema:name xml:lang="ja">ムーンリーラビット</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ムーンリーラビット</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Tsukioka_Kogane"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -158,35 +138,30 @@
   <rdf:Description rdf:about="Mystic_Maestra">
     <schema:name xml:lang="ja">ミスティックマエストラ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ミスティックマエストラ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Tanaka_Mamimi"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Drap_De_Purple">
     <schema:name xml:lang="ja">ドレープドパープル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ドレープドパープル</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Tanaka_Mamimi"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Panky_My_Go_Round">
     <schema:name xml:lang="ja">パンキーマイゴーラウンド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">パンキーマイゴーラウンド</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Tanaka_Mamimi"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Sampling_Butterfly">
     <schema:name xml:lang="ja">サンプリングバタフライ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">サンプリングバタフライ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Tanaka_Mamimi"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Pastel_Lazy">
     <schema:name xml:lang="ja">パステルレイジー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">パステルレイジー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Tanaka_Mamimi"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -195,28 +170,24 @@
   <rdf:Description rdf:about="Noble_Bella">
     <schema:name xml:lang="ja">ノーブルベッラ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ノーブルベッラ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Shirase_Sakuya"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Military_Tamer">
     <schema:name xml:lang="ja">ミリタリーテイマー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ミリタリーテイマー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Shirase_Sakuya"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Sampling_Adorable">
     <schema:name xml:lang="ja">サンプリングアドラブル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">サンプリングアドラブル</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Shirase_Sakuya"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Spirit_Of_Zorro">
     <schema:name xml:lang="ja">スピリットオブゾロ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スピリットオブゾロ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Shirase_Sakuya"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -225,28 +196,24 @@
   <rdf:Description rdf:about="Pastelic_Lively">
     <schema:name xml:lang="ja">パステリックライブリー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">パステリックライブリー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Mitsumine_Yuika"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Emotional_Rainy">
     <schema:name xml:lang="ja">エモーショナルレイニー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エモーショナルレイニー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Mitsumine_Yuika"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Open_Mind_Roller">
     <schema:name xml:lang="ja">オープンマインドローラー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">オープンマインドローラー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Mitsumine_Yuika"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Isekai_Elevator_Girl">
     <schema:name xml:lang="ja">イセカイエレベーターガール</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">イセカイエレベーターガール</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Mitsumine_Yuika"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -255,35 +222,30 @@
   <rdf:Description rdf:about="Secret_Curely">
     <schema:name xml:lang="ja">シークレットキュアリー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シークレットキュアリー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Yukoku_Kiriko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Promise_De_Rose">
     <schema:name xml:lang="ja">プロミスドローズ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プロミスドローズ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Yukoku_Kiriko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Diamond_Check_Gothic">
     <schema:name xml:lang="ja">ダイヤチェックゴシック</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ダイヤチェックゴシック</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Yukoku_Kiriko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Melty_Honey">
     <schema:name xml:lang="ja">メルティハニー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">メルティハニー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Yukoku_Kiriko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Player_Unknown">
     <schema:name xml:lang="ja">プレイヤーアンノウン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プレイヤーアンノウン</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Yukoku_Kiriko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -292,35 +254,30 @@
   <rdf:Description rdf:about="Passionate_Bonita">
     <schema:name xml:lang="ja">パッショネイトボニータ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">パッショネイトボニータ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Komiya_Kaho"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Tricky_Shiba">
     <schema:name xml:lang="ja">トリッキーシバ★</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">トリッキーシバ★</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Komiya_Kaho"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Start_Checker">
     <schema:name xml:lang="ja">スタートチェッカー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スタートチェッカー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Komiya_Kaho"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Rocking_You">
     <schema:name xml:lang="ja">ロッキングユー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ロッキングユー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Komiya_Kaho"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Longing_Prince">
     <schema:name xml:lang="ja">ロンギングプリンス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ロンギングプリンス</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Komiya_Kaho"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -329,28 +286,24 @@
   <rdf:Description rdf:about="Chocolat_Chocolate">
     <schema:name xml:lang="ja">ショコラチョコレート</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ショコラチョコレート</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Sonoda_Chiyoko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Yum_Yum_Waitress">
     <schema:name xml:lang="ja">ヤムヤムウェイトレス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ヤムヤムウェイトレス</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Sonoda_Chiyoko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Fragile_Darling">
     <schema:name xml:lang="ja">フラジールダーリン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フラジールダーリン</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Sonoda_Chiyoko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Magical_Chocolate">
     <schema:name xml:lang="ja">マジカルショコラーチ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">マジカルショコラーチ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Sonoda_Chiyoko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -359,28 +312,24 @@
   <rdf:Description rdf:about="Rockin_Bad_Girl">
     <schema:name xml:lang="ja">ロッキンバッドガール</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ロッキンバッドガール</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Saijo_Juri"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Tight_Rope_Style">
     <schema:name xml:lang="ja">タイトロープスタイル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">タイトロープスタイル</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Saijo_Juri"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Furifuri_Lovely_Maid_Ribbon">
     <schema:name xml:lang="ja">フリフリラブリーメイドリボン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フリフリラブリーメイドリボン</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Saijo_Juri"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Im_Your_Knight">
     <schema:name xml:lang="ja">アイムユアナイト</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アイムユアナイト</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Saijo_Juri"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -389,42 +338,36 @@
   <rdf:Description rdf:about="Ruriiro_Flare">
     <schema:name xml:lang="ja">ルリイロフレア</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ルリイロフレア</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Morino_Rinze"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Minty_Attendant">
     <schema:name xml:lang="ja">ミンティアテンダント</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ミンティアテンダント</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Morino_Rinze"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Elegant_Veil_Tail">
     <schema:name xml:lang="ja">エレガントベールテール</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エレガントベールテール</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Morino_Rinze"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Steady_My_Cat">
     <schema:name xml:lang="ja">ステディマイキャット</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ステディマイキャット</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Morino_Rinze"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Gothic_Dolly_Lolita">
     <schema:name xml:lang="ja">ゴシックドーリィロリータ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ゴシックドーリィロリータ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Morino_Rinze"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Sheepy_Sleepy">
     <schema:name xml:lang="ja">シーピースリーピー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シーピースリーピー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Morino_Rinze"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -433,28 +376,24 @@
   <rdf:Description rdf:about="Glitter_Bubbly">
     <schema:name xml:lang="ja">グリッターバブリー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">グリッターバブリー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Arisugawa_Natsuha"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="High_Mandarin_Dress">
     <schema:name xml:lang="ja">ハイ・マンダリンドレス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ハイ・マンダリンドレス</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Arisugawa_Natsuha"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Classy_Second_Flash">
     <schema:name xml:lang="ja">クラッシィセカンドフラッシュ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">クラッシィセカンドフラッシュ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Arisugawa_Natsuha"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Agent_D">
     <schema:name xml:lang="ja">エイジェント[D]</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エイジェント[D]</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Arisugawa_Natsuha"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -463,35 +402,30 @@
   <rdf:Description rdf:about="Angelic_Ribbon">
     <schema:name xml:lang="ja">エンジェリックリボン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エンジェリックリボン</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Osaki_Amana"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Sweetie_Black_Nurse">
     <schema:name xml:lang="ja">スウィーティーブラックナース</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スウィーティーブラックナース</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Osaki_Amana"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Poppin_Sweetie">
     <schema:name xml:lang="ja">ポッピンスウィーティー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ポッピンスウィーティー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Osaki_Amana"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Arabient_Raqsah">
     <schema:name xml:lang="ja">アラビエントラッカーサ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アラビエントラッカーサ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Osaki_Amana"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Mazentacchi_Race_Queen">
     <schema:name xml:lang="ja">マゼンタッチレースクイーン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">マゼンタッチレースクイーン</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Osaki_Amana"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -500,42 +434,36 @@
   <rdf:Description rdf:about="Devilish_Future">
     <schema:name xml:lang="ja">デビリッシュフューチャー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">デビリッシュフューチャー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Osaki_Tenka"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Poppin_Juicy">
     <schema:name xml:lang="ja">ポッピンジューシー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ポッピンジューシー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Osaki_Tenka"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Precious_Doll_Bonnet">
     <schema:name xml:lang="ja">プレシャスドールボンネット</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">プレシャスドールボンネット</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Osaki_Tenka"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Sweet_Patissiere">
     <schema:name xml:lang="ja">スウィートパティシエール</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スウィートパティシエール</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Osaki_Tenka"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Childish_Smock">
     <schema:name xml:lang="ja">チャイルディッシュスモック</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">チャイルディッシュスモック</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Osaki_Tenka"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Nostalgic_Girly">
     <schema:name xml:lang="ja">ノスタルジックガーリィ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ノスタルジックガーリィ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Osaki_Tenka"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -544,35 +472,30 @@
   <rdf:Description rdf:about="Saintly_White">
     <schema:name xml:lang="ja">セイントリーホワイト</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">セイントリーホワイト</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Calmy_Bloom">
     <schema:name xml:lang="ja">カーミィブルーム</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">カーミィブルーム</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Suggestive_Tender">
     <schema:name xml:lang="ja">サジェスティブテンダー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">サジェスティブテンダー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Wellcome_Boutique">
     <schema:name xml:lang="ja">ウェルカムブティック</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ウェルカムブティック</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Cheer_Up_Leader">
     <schema:name xml:lang="ja">チアアップリーダー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">チアアップリーダー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -581,28 +504,24 @@
   <rdf:Description rdf:about="Space_Attendant">
     <schema:name xml:lang="ja">スペイスアテンダント</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スペイスアテンダント</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Serizawa_Asahi"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Dram_Major_March">
     <schema:name xml:lang="ja">ドラムメジャーマーチ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ドラムメジャーマーチ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Serizawa_Asahi"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Possession_Prince">
     <schema:name xml:lang="ja">ポゼッションプリンス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ポゼッションプリンス</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Serizawa_Asahi"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Maidy_Rock_R">
     <schema:name xml:lang="ja">メイディロック・l2</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">メイディロック・l2</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Serizawa_Asahi"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -611,21 +530,18 @@
   <rdf:Description rdf:about="Yumekawa_Pastel">
     <schema:name xml:lang="ja">ユメカワパステル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ユメカワパステル</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Aquatic_Mermaid">
     <schema:name xml:lang="ja">アクアティックマーメイド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アクアティックマーメイド</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Lonely_Lop_Ear">
     <schema:name xml:lang="ja">ロンリィロップイヤー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ロンリィロップイヤー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -634,28 +550,24 @@
   <rdf:Description rdf:about="Keep_Out_Bind">
     <schema:name xml:lang="ja">キープアウトバインド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">キープアウトバインド</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Izumi_Mei"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Silk_Hat_Magic">
     <schema:name xml:lang="ja">シルクハットマジック</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シルクハットマジック</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Izumi_Mei"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Two-Tone_Ribbon_Ribbon">
     <schema:name xml:lang="ja">ツートンリボンリボン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ツートンリボンリボン</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Izumi_Mei"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Burn_Up_Floor">
     <schema:name xml:lang="ja">バーンナップフロア</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">バーンナップフロア</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Izumi_Mei"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -664,21 +576,18 @@
   <rdf:Description rdf:about="Sparkle_Glass">
     <schema:name xml:lang="ja">スパークル・ガラス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スパークル・ガラス</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Asakura_Toru"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Citrustic_Yellow">
     <schema:name xml:lang="ja">シトラスティックイエロー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シトラスティックイエロー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Asakura_Toru"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Darkest_Ever_Red">
     <schema:name xml:lang="ja">ダーケストエバーレッド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ダーケストエバーレッド</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Asakura_Toru"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -687,14 +596,12 @@
   <rdf:Description rdf:about="Time_In_A_Glass">
     <schema:name xml:lang="ja">タイムイン・ア・ガラス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">タイムイン・ア・ガラス</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Higuchi_Madoka"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Pastelic_PVC">
     <schema:name xml:lang="ja">パステリックピーヴイシー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">パステリックピーヴイシー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Higuchi_Madoka"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -703,7 +610,6 @@
   <rdf:Description rdf:about="Mignon_Petit_L%27ange">
     <schema:name xml:lang="ja">ミニヨンプチランジュ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ミニヨンプチランジュ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Fukumaru_Koito"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -712,14 +618,12 @@
   <rdf:Description rdf:about="Sunny_Sunny_Sunflower">
     <schema:name xml:lang="ja">サニサニサンフラワー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">サニサニサンフラワー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Ichikawa_Hinana"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Loosely_Hearty">
     <schema:name xml:lang="ja">ルーズリーハーティー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ルーズリーハーティー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Ichikawa_Hinana"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -728,7 +632,6 @@
   <rdf:Description rdf:about="Academical_Blue">
     <schema:name xml:lang="ja">アカデミカルブルー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アカデミカルブルー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Nanakusa_Nichika"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -737,14 +640,12 @@
   <rdf:Description rdf:about="Buriki_Steamy_Blue">
     <schema:name xml:lang="ja">ブリキスチーミィブルー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ブリキスチーミィブルー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Aketa_Mikoto"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Danceable_Sheer">
     <schema:name xml:lang="ja">ダンサブルシアー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ダンサブルシアー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Aketa_Mikoto"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>

--- a/RDFs/Clothes/ShinyColorsPersonal.rdf
+++ b/RDFs/Clothes/ShinyColorsPersonal.rdf
@@ -545,6 +545,12 @@
     <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Deep_Deep_Lover">
+    <schema:name xml:lang="ja">ディープディープラバー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ディープディープラバー</rdfs:label>
+    <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- 和泉愛依 -->
   <rdf:Description rdf:about="Keep_Out_Bind">
@@ -632,6 +638,12 @@
   <rdf:Description rdf:about="Academical_Blue">
     <schema:name xml:lang="ja">アカデミカルブルー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アカデミカルブルー</rdfs:label>
+    <imas:Whose rdf:resource="Nanakusa_Nichika"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Astroly_Chyu">
+    <schema:name xml:lang="ja">アストロリーチュー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">アストロリーチュー</rdfs:label>
     <imas:Whose rdf:resource="Nanakusa_Nichika"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -218,21 +218,21 @@
   <rdf:Description rdf:about="HaruMatsuriko_SakuragiMano">
     <schema:name xml:lang="ja">春、祀り子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">春、祀り子</rdfs:label>
-    <schema:description xml:lang="ja">木の芽の時。みっつなかよく春をうたう</schema:description>
+    <schema:description xml:lang="ja">木の芽時。みっつなかよく春をうたう</schema:description>
     <imas:Whose rdf:resource="Sakuragi_Mano"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="HaruMatsuriko_KazanoHiori">
     <schema:name xml:lang="ja">春、祀り子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">春、祀り子</rdfs:label>
-    <schema:description xml:lang="ja">木の芽の時。着付け確認しました</schema:description>
+    <schema:description xml:lang="ja">木の芽時。着付け確認しました</schema:description>
     <imas:Whose rdf:resource="Kazano_Hiori"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="HaruMatsuriko_HachimiyaMeguru">
     <schema:name xml:lang="ja">春、祀り子</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">春、祀り子</rdfs:label>
-    <schema:description xml:lang="ja">木の芽の時。いつだって大吉</schema:description>
+    <schema:description xml:lang="ja">木の芽時。いつだって大吉</schema:description>
     <imas:Whose rdf:resource="Hachimiya_Meguru"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -85,6 +85,14 @@
     <imas:Whose rdf:resource="Hachimiya_Meguru"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Explore_Serata">
+    <schema:name xml:lang="ja">エクスプロアセラータ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">エクスプロアセラータ</rdfs:label>
+    <!-- <imas:Whose rdf:resource="Kazano_Hiori"/> -->
+    <imas:Whose rdf:resource="Sakuragi_Mano"/>
+    <!-- <imas:Whose rdf:resource="Hachimiya_Meguru"/> -->
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
   <rdf:Description rdf:about="One_Day_Officer">
     <schema:name xml:lang="ja">ワンデイオフィサー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ワンデイオフィサー</rdfs:label>
@@ -584,7 +592,7 @@
     <!-- <imas:Whose rdf:resource="Komiya_Kaho"/> -->
     <imas:Whose rdf:resource="Saijo_Juri"/>
     <!-- <imas:Whose rdf:resource="Sonoda_Chiyoko"/> -->
-    <!-- <imas:Whose rdf:resource="Morino_Rinze"/> -->
+    <imas:Whose rdf:resource="Morino_Rinze"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Pajamas_De_Kabukabu">

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -18,7 +18,6 @@
   <rdf:Description rdf:about="Siriusly_Crown">
     <schema:name xml:lang="ja">シリウスリークラウン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シリウスリークラウン</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Kazano_Hiori"/>
     <imas:Whose rdf:resource="Sakuragi_Mano"/>
     <imas:Whose rdf:resource="Hachimiya_Meguru"/>
@@ -27,7 +26,6 @@
   <rdf:Description rdf:about="Twinkly_Cheerful">
     <schema:name xml:lang="ja">トゥインクリーチアフル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">トゥインクリーチアフル</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Kazano_Hiori"/>
     <imas:Whose rdf:resource="Sakuragi_Mano"/>
     <imas:Whose rdf:resource="Hachimiya_Meguru"/>
@@ -70,7 +68,6 @@
   <rdf:Description rdf:about="One_Two_Marching_Parade">
     <schema:name xml:lang="ja">ワンツーマーチングパレード</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ワンツーマーチングパレード</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Sakuragi_Mano"/>
     <imas:Whose rdf:resource="Hachimiya_Meguru"/>
     <imas:Whose rdf:resource="Kazano_Hiori"/>
@@ -79,7 +76,6 @@
   <rdf:Description rdf:about="Divine_Couronne">
     <schema:name xml:lang="ja">ディバインクロンヌ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディバインクロンヌ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <!-- <imas:Whose rdf:resource="Kazano_Hiori"/> -->
     <imas:Whose rdf:resource="Sakuragi_Mano"/>
     <imas:Whose rdf:resource="Hachimiya_Meguru"/>
@@ -234,7 +230,6 @@
   <rdf:Description rdf:about="Faith_Of_Treasure">
     <schema:name xml:lang="ja">フェイスオブトレジャー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フェイスオブトレジャー</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Shirase_Sakuya"/>
     <imas:Whose rdf:resource="Tanaka_Mamimi"/>
     <imas:Whose rdf:resource="Tsukioka_Kogane"/>
@@ -245,7 +240,6 @@
   <rdf:Description rdf:about="La_Rosso_Grimm">
     <schema:name xml:lang="ja">ラ・ロッソグリム</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ラ・ロッソグリム</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Shirase_Sakuya"/>
     <imas:Whose rdf:resource="Tanaka_Mamimi"/>
     <imas:Whose rdf:resource="Tsukioka_Kogane"/>
@@ -306,7 +300,6 @@
   <rdf:Description rdf:about="Encadrement_Coupe">
     <schema:name xml:lang="ja">アンカードルモンクーペ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アンカードルモンクーペ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Shirase_Sakuya"/>
     <imas:Whose rdf:resource="Tanaka_Mamimi"/>
     <imas:Whose rdf:resource="Tsukioka_Kogane"/>
@@ -504,7 +497,6 @@
   <rdf:Description rdf:about="I_Love_Climax">
     <schema:name xml:lang="ja">愛羅武紅蘭偉魔空珠</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">愛羅武紅蘭偉魔空珠</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Arisugawa_Natsuha"/>
     <imas:Whose rdf:resource="Komiya_Kaho"/>
     <imas:Whose rdf:resource="Saijo_Juri"/>
@@ -515,7 +507,6 @@
   <rdf:Description rdf:about="Decodeco_Clear_Splash">
     <schema:name xml:lang="ja">デコデコクリアスプラッシュ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">デコデコクリアスプラッシュ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Arisugawa_Natsuha"/>
     <imas:Whose rdf:resource="Komiya_Kaho"/>
     <imas:Whose rdf:resource="Saijo_Juri"/>
@@ -565,7 +556,6 @@
   <rdf:Description rdf:about="C_Cats_Uniform">
     <schema:name xml:lang="ja">C.キャッツユニフォーム</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C.キャッツユニフォーム</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Arisugawa_Natsuha"/>
     <imas:Whose rdf:resource="Komiya_Kaho"/>
     <imas:Whose rdf:resource="Saijo_Juri"/>
@@ -576,7 +566,6 @@
   <rdf:Description rdf:about="Donsyan_Matsuribayashi">
     <schema:name xml:lang="ja">ドンシャンマツリバヤシ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ドンシャンマツリバヤシ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Arisugawa_Natsuha"/>
     <imas:Whose rdf:resource="Komiya_Kaho"/>
     <imas:Whose rdf:resource="Saijo_Juri"/>
@@ -587,7 +576,6 @@
   <rdf:Description rdf:about="Witch_Craft_Academical">
     <schema:name xml:lang="ja">ウィッチクラフトアカデミカル</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ウィッチクラフトアカデミカル</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Arisugawa_Natsuha"/>
     <!-- <imas:Whose rdf:resource="Komiya_Kaho"/> -->
     <imas:Whose rdf:resource="Saijo_Juri"/>
@@ -783,7 +771,6 @@
   <rdf:Description rdf:about="Dormir_Atenta">
     <schema:name xml:lang="ja">ドルミールアテンタ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ドルミールアテンタ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Osaki_Amana"/>
     <imas:Whose rdf:resource="Osaki_Tenka"/>
     <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
@@ -792,7 +779,6 @@
   <rdf:Description rdf:about="Devoting_Linnaea">
     <schema:name xml:lang="ja">デヴォーティングリンネ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">デヴォーティングリンネ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Osaki_Amana"/>
     <imas:Whose rdf:resource="Osaki_Tenka"/>
     <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
@@ -827,7 +813,6 @@
   <rdf:Description rdf:about="Magique_Allure">
     <schema:name xml:lang="ja">マジーク・アルーア</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">マジーク・アルーア</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Osaki_Amana"/>
     <imas:Whose rdf:resource="Osaki_Tenka"/>
     <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
@@ -836,7 +821,6 @@
   <rdf:Description rdf:about="Woolly_Mailer_Secret">
     <schema:name xml:lang="ja">ウーリーメイラースクレ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ウーリーメイラースクレ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Osaki_Amana"/>
     <imas:Whose rdf:resource="Osaki_Tenka"/>
     <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
@@ -845,7 +829,6 @@
   <rdf:Description rdf:about="Roma_Classical_Trench">
     <schema:name xml:lang="ja">ローマクラシカルトレンチ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ローマクラシカルトレンチ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Osaki_Amana"/>
     <!-- <imas:Whose rdf:resource="Osaki_Tenka"/>
     <imas:Whose rdf:resource="Kuwayama_Chiyuki"/> -->
@@ -964,7 +947,6 @@
   <rdf:Description rdf:about="Tracing_Mute">
     <schema:name xml:lang="ja">トレーシングミュート</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">トレーシングミュート</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Izumi_Mei"/>
     <imas:Whose rdf:resource="Serizawa_Asahi"/>
     <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
@@ -973,7 +955,6 @@
   <rdf:Description rdf:about="Skeleton_Overdrive">
     <schema:name xml:lang="ja">スケルトンオーヴァドライヴ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スケルトンオーヴァドライヴ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Izumi_Mei"/>
     <imas:Whose rdf:resource="Serizawa_Asahi"/>
     <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
@@ -982,7 +963,6 @@
   <rdf:Description rdf:about="Jack_In_Matrix">
     <schema:name xml:lang="ja">ジャックインマトリックス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ジャックインマトリックス</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Izumi_Mei"/>
     <imas:Whose rdf:resource="Serizawa_Asahi"/>
     <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
@@ -1095,7 +1075,6 @@
   <rdf:Description rdf:about="Sail_Tail_Breeze">
     <schema:name xml:lang="ja">セイルテイルブリーズ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">セイルテイルブリーズ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Asakura_Toru"/>
     <imas:Whose rdf:resource="Ichikawa_Hinana"/>
     <imas:Whose rdf:resource="Higuchi_Madoka"/>
@@ -1105,7 +1084,6 @@
   <rdf:Description rdf:about="Clear_Belt_Surface">
     <schema:name xml:lang="ja">クリアベルトサーフェス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">クリアベルトサーフェス</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Asakura_Toru"/>
     <imas:Whose rdf:resource="Ichikawa_Hinana"/>
     <imas:Whose rdf:resource="Higuchi_Madoka"/>
@@ -1208,7 +1186,6 @@
   <rdf:Description rdf:about="Champ_De_Voguing">
     <schema:name xml:lang="ja">シャンドゥ・ヴォーギン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">シャンドゥ・ヴォーギン</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Aketa_Mikoto"/>
     <imas:Whose rdf:resource="Nanakusa_Nichika"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
@@ -1216,7 +1193,6 @@
   <rdf:Description rdf:about="Forbidden_Sincerely">
     <schema:name xml:lang="ja">フォービドゥンシンシアリ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フォービドゥンシンシアリ</rdfs:label>
-    <schema:description xml:lang="ja"/>
     <imas:Whose rdf:resource="Aketa_Mikoto"/>
     <imas:Whose rdf:resource="Nanakusa_Nichika"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -76,7 +76,7 @@
   <rdf:Description rdf:about="Divine_Couronne">
     <schema:name xml:lang="ja">ディバインクロンヌ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディバインクロンヌ</rdfs:label>
-    <!-- <imas:Whose rdf:resource="Kazano_Hiori"/> -->
+    <imas:Whose rdf:resource="Kazano_Hiori"/>
     <imas:Whose rdf:resource="Sakuragi_Mano"/>
     <imas:Whose rdf:resource="Hachimiya_Meguru"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
@@ -215,6 +215,27 @@
     <schema:description xml:lang="ja">ショコラティエ。きみにとっておきをお届け</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="HaruMatsuriko_SakuragiMano">
+    <schema:name xml:lang="ja">春、祀り子</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">春、祀り子</rdfs:label>
+    <schema:description xml:lang="ja">木の芽の時。みっつなかよく春をうたう</schema:description>
+    <imas:Whose rdf:resource="Sakuragi_Mano"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="HaruMatsuriko_KazanoHiori">
+    <schema:name xml:lang="ja">春、祀り子</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">春、祀り子</rdfs:label>
+    <schema:description xml:lang="ja">木の芽の時。着付け確認しました</schema:description>
+    <imas:Whose rdf:resource="Kazano_Hiori"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="HaruMatsuriko_HachimiyaMeguru">
+    <schema:name xml:lang="ja">春、祀り子</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">春、祀り子</rdfs:label>
+    <schema:description xml:lang="ja">木の芽の時。いつだって大吉</schema:description>
+    <imas:Whose rdf:resource="Hachimiya_Meguru"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- L'Antica -->
   <rdf:Description rdf:about="Symphonic_Steam">
@@ -305,6 +326,16 @@
     <imas:Whose rdf:resource="Tsukioka_Kogane"/>
     <imas:Whose rdf:resource="Mitsumine_Yuika"/>
     <imas:Whose rdf:resource="Yukoku_Kiriko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Haute_Couture_Arte_Piece">
+    <schema:name xml:lang="ja">オートクチュールアルテピエス</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">オートクチュールアルテピエス</rdfs:label>
+    <!-- <imas:Whose rdf:resource="Shirase_Sakuya"/> -->
+    <imas:Whose rdf:resource="Tanaka_Mamimi"/>
+    <!-- <imas:Whose rdf:resource="Tsukioka_Kogane"/> -->
+    <!-- <imas:Whose rdf:resource="Mitsumine_Yuika"/> -->
+    <!-- <imas:Whose rdf:resource="Yukoku_Kiriko"/> -->
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Wonderland_Hoppin">
@@ -479,6 +510,41 @@
     <schema:name xml:lang="ja">オルカドサーヴァント</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">オルカドサーヴァント</rdfs:label>
     <schema:description xml:lang="ja">BOO！６６６^ ^</schema:description>
+    <imas:Whose rdf:resource="Yukoku_Kiriko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="YourSideMagia_TsukiokaKogane">
+    <schema:name xml:lang="ja">ユアサイドマジーア</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ユアサイドマジーア</rdfs:label>
+    <schema:description xml:lang="ja">MAGIA——春風、桃色に染めて</schema:description>
+    <imas:Whose rdf:resource="Tsukioka_Kogane"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="YourSideMagia_TanakaMamimi">
+    <schema:name xml:lang="ja">ユアサイドマジーア</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ユアサイドマジーア</rdfs:label>
+    <schema:description xml:lang="ja">MAGIA——イタズラは紫色で</schema:description>
+    <imas:Whose rdf:resource="Tanaka_Mamimi"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="YourSideMagia_ShiraseSakuya">
+    <schema:name xml:lang="ja">ユアサイドマジーア</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ユアサイドマジーア</rdfs:label>
+    <schema:description xml:lang="ja">MAGIA——碧色は乙女を想う</schema:description>
+    <imas:Whose rdf:resource="Shirase_Sakuya"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="YourSideMagia_MitsumineYuika">
+    <schema:name xml:lang="ja">ユアサイドマジーア</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ユアサイドマジーア</rdfs:label>
+    <schema:description xml:lang="ja">MAGIA——魔法ごと翻弄する青磁色</schema:description>
+    <imas:Whose rdf:resource="Mitsumine_Yuika"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="YourSideMagia_YukokuKiriko">
+    <schema:name xml:lang="ja">ユアサイドマジーア</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ユアサイドマジーア</rdfs:label>
+    <schema:description xml:lang="ja">MAGIA——水縹の楽句</schema:description>
     <imas:Whose rdf:resource="Yukoku_Kiriko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -758,6 +824,41 @@
     <schema:description xml:lang="ja">White heart! 青色チェックで包装</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="DefeatOfEncounter_KomiyaKaho">
+    <schema:name xml:lang="ja">デフィートオブエンカウンター</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">デフィートオブエンカウンター</rdfs:label>
+    <schema:description xml:lang="ja">MISSION：銀河にまたたく正義の光！</schema:description>
+    <imas:Whose rdf:resource="Komiya_Kaho"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="DefeatOfEncounter_SonodaChiyoko">
+    <schema:name xml:lang="ja">デフィートオブエンカウンター</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">デフィートオブエンカウンター</rdfs:label>
+    <schema:description xml:lang="ja">MISSION：食べてる時の襲撃はよくない！</schema:description>
+    <imas:Whose rdf:resource="Sonoda_Chiyoko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="DefeatOfEncounter_SaijoJuri">
+    <schema:name xml:lang="ja">デフィートオブエンカウンター</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">デフィートオブエンカウンター</rdfs:label>
+    <schema:description xml:lang="ja">MISSION：太陽系の切り込み隊長</schema:description>
+    <imas:Whose rdf:resource="Saijo_Juri"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="DefeatOfEncounter_MorinoRinze">
+    <schema:name xml:lang="ja">デフィートオブエンカウンター</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">デフィートオブエンカウンター</rdfs:label>
+    <schema:description xml:lang="ja">MISSION：冷静沈着作戦参謀</schema:description>
+    <imas:Whose rdf:resource="Morino_Rinze"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="DefeatOfEncounter_ArisugawaNatsuha">
+    <schema:name xml:lang="ja">デフィートオブエンカウンター</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">デフィートオブエンカウンター</rdfs:label>
+    <schema:description xml:lang="ja">MISSION：パーフェクトオペレーター</schema:description>
+    <imas:Whose rdf:resource="Arisugawa_Natsuha"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- ALSTROEMERIA -->
   <rdf:Description rdf:about="Wishful_Lily">
@@ -918,6 +1019,27 @@
     <schema:description xml:lang="ja">受け止めて抱きしめる、両の腕</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="CheckingKyun_OsakiAmana">
+    <schema:name xml:lang="ja">チェッキンキューン</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">チェッキンキューン</rdfs:label>
+    <schema:description xml:lang="ja">with us＠『キューン』だよっ☆</schema:description>
+    <imas:Whose rdf:resource="Osaki_Amana"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="CheckingKyun_OsakiTenka">
+    <schema:name xml:lang="ja">チェッキンキューン</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">チェッキンキューン</rdfs:label>
+    <schema:description xml:lang="ja">with us＠いいたぬきさん</schema:description>
+    <imas:Whose rdf:resource="Osaki_Tenka"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="CheckingKyun_KuwayamaChiyuki">
+    <schema:name xml:lang="ja">チェッキンキューン</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">チェッキンキューン</rdfs:label>
+    <schema:description xml:lang="ja">with us＠遊んでくれるかな……？</schema:description>
+    <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- Straylight -->
   <rdf:Description rdf:about="Neon_Light_Romancer">
@@ -1052,6 +1174,27 @@
     <schema:description xml:lang="ja">ちょーハンパない系のうちら♪</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="OrderNonSweet_SerizawaAsahi">
+    <schema:name xml:lang="ja">オーダー・ノンスウィート</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">オーダー・ノンスウィート</rdfs:label>
+    <schema:description xml:lang="ja">Chaser／指令。あの光を追うのだ</schema:description>
+    <imas:Whose rdf:resource="Serizawa_Asahi"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="OrderNonSweet_MayuzumiFuyuko">
+    <schema:name xml:lang="ja">オーダー・ノンスウィート</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">オーダー・ノンスウィート</rdfs:label>
+    <schema:description xml:lang="ja">Chaser／……覚悟はできてる？</schema:description>
+    <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="OrderNonSweet_IzumiMei">
+    <schema:name xml:lang="ja">オーダー・ノンスウィート</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">オーダー・ノンスウィート</rdfs:label>
+    <schema:description xml:lang="ja">Chaser／かんぶ？っぽいって弟に言われた</schema:description>
+    <imas:Whose rdf:resource="Izumi_Mei"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- noctchill -->
   <rdf:Description rdf:about="Clear_Marine_Calm">
@@ -1090,6 +1233,16 @@
     <imas:Whose rdf:resource="Fukumaru_Koito"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Palmiere_In_View">
+    <schema:name xml:lang="ja">パルミエーレインビュー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">パルミエーレインビュー</rdfs:label>
+    <!-- <imas:Whose rdf:resource="Asakura_Toru"/> -->
+    <imas:Whose rdf:resource="Higuchi_Madoka"/>
+    <!-- <imas:Whose rdf:resource="Fukumaru_Koito"/> -->
+    <!-- <imas:Whose rdf:resource="Ichikawa_Hinana"/> -->
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+
   <rdf:Description rdf:about="LoveLaughRabbits_AsakuraToru">
     <schema:name xml:lang="ja">ラブラフラビッツ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ラブラフラビッツ</rdfs:label>
@@ -1174,6 +1327,34 @@
     <schema:description xml:lang="ja">しあわせ1週間分処方</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="PaintingOar_AsakuraToru">
+    <schema:name xml:lang="ja">ペインティングオール</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ペインティングオール</rdfs:label>
+    <schema:description xml:lang="ja">;) ステッカー式日常</schema:description>
+    <imas:Whose rdf:resource="Asakura_Toru"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="PaintingOar_HiguchiMadoka">
+    <schema:name xml:lang="ja">ペインティングオール</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ペインティングオール</rdfs:label>
+    <schema:description xml:lang="ja">;) ヌリタクリ・ハリタクル</schema:description>
+    <imas:Whose rdf:resource="Higuchi_Madoka"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="PaintingOar_FukumaruKoito">
+    <schema:name xml:lang="ja">ペインティングオール</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ペインティングオール</rdfs:label>
+    <schema:description xml:lang="ja">;) 翼も描けるかも</schema:description>
+    <imas:Whose rdf:resource="Fukumaru_Koito"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="PaintingOar_IchikawaHinana">
+    <schema:name xml:lang="ja">ペインティングオール</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ペインティングオール</rdfs:label>
+    <schema:description xml:lang="ja">;) しあわせ色で塗って</schema:description>
+    <imas:Whose rdf:resource="Ichikawa_Hinana"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- SHHis -->
   <rdf:Description rdf:about="Silky_Gemsilica">
@@ -1222,6 +1403,20 @@
     <schema:name xml:lang="ja">紅玉兎ノ装</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">紅玉兎ノ装</rdfs:label>
     <schema:description xml:lang="ja">とおかんや。under the mask</schema:description>
+    <imas:Whose rdf:resource="Aketa_Mikoto"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="HorreurTreat_NanakusaNichika">
+    <schema:name xml:lang="ja">オルールトリィト</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">オルールトリィト</rdfs:label>
+    <schema:description xml:lang="ja">HORROR…夜が来る</schema:description>
+    <imas:Whose rdf:resource="Nanakusa_Nichika"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="HorreurTreat_AketaMikoto">
+    <schema:name xml:lang="ja">オルールトリィト</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">オルールトリィト</rdfs:label>
+    <schema:description xml:lang="ja">HORROR…satiety</schema:description>
     <imas:Whose rdf:resource="Aketa_Mikoto"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>


### PR DESCRIPTION
以下の新衣装を追加しました。

- オートクチュールアルテピエス（田中摩美々）
- ディープディープラバー（黛冬優子）
- ディバインクロンヌ（風野灯織）
- サンセットスカイパッセージ（SHHis）
- リスペクティブワークスタイル（樋口円香 / 園田智代子）
- ウィッチクラフトアカデミカル（杜野凛世）
- エクスプロアセラータ（櫻木真乃）
  - serata は  https://kotobank.jp/itjaword/serata から
- アストロリーチュー（七草にちか）
  - `チュー` の意味がわからなかったので、暫定的に `Chyu` としました

また、空の `<schema:description xml:lang="ja"/>` が幾つかあったので削除しました。