### PR TITLE
Twinkle LIVE Constellation Gradation出演メンバーのキャラカラーを追加

### DIFF
--- a/RDFs/CinderellaGirls.rdf
+++ b/RDFs/CinderellaGirls.rdf
@@ -1140,6 +1140,7 @@
     <imas:cv xml:lang="ja">安齋由香里</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/安齋由香里"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q50286740"/>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">ECCCCD</imas:Color>
     <imas:Hobby xml:lang="ja">押し花作り</imas:Hobby>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20068"/>
   </rdf:Description>
@@ -2115,6 +2116,7 @@
     <imas:cv xml:lang="ja">梅澤めぐ</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/梅澤めぐ"/>
     <schema:birthPlace xml:lang="ja">山形</schema:birthPlace>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">D3161C</imas:Color>
     <imas:Hobby xml:lang="ja">ラーメン</imas:Hobby>
     <imas:Hobby xml:lang="ja">編み物</imas:Hobby>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20106"/>
@@ -2184,6 +2186,7 @@
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/佐倉薫"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q11383006"/>
     <schema:birthPlace xml:lang="ja">東京</schema:birthPlace>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">F6303F</imas:Color>
     <imas:Hobby xml:lang="ja">美味しいものを食べること</imas:Hobby>
     <imas:Hobby xml:lang="ja">月光浴</imas:Hobby>
     <imas:SchoolGrade xml:lang="ja">高校3年生</imas:SchoolGrade>
@@ -3037,6 +3040,7 @@
     <imas:cv xml:lang="ja">二ノ宮ゆい</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/二ノ宮ゆい"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q55532483"/>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">A9A3E1</imas:Color>
     <imas:Hobby xml:lang="ja">諜報活動</imas:Hobby>
     <imas:SchoolGrade xml:lang="ja">高校3年生</imas:SchoolGrade>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20175"/>
@@ -5097,6 +5101,7 @@
     <imas:cv xml:lang="ja">長野佑紀</imas:cv>
     <!--<imas:cv rdf:resource="http://ja.dbpedia.org/resource/長野佑紀"/>-->
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q30108577"/>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">9F25B6</imas:Color>
     <imas:Hobby xml:lang="ja">いたずら</imas:Hobby>
     <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/20063"/>
   </rdf:Description>


### PR DESCRIPTION
ソースは公式コンサートライト(Constellation Gradation ver.)のストラップの色です。

西園寺琴歌 ECCCCD https://shop.asobistore.jp/products/detail/176488-cdg_c_yzt-00-00
辻野あかり D3161C https://shop.asobistore.jp/products/detail/176488-cdg_c_at-00-00
八神マキノ A9A3E1 https://shop.asobistore.jp/products/detail/176488-cdg_c_yzw-00-00
小関麗奈 9F25B6 https://shop.asobistore.jp/products/detail/176488-cdg_c_rk-00-00
黒埼ちとせ F6303F https://shop.asobistore.jp/products/detail/176488-cdg_c_ck-00-00
