### PR TITLE
Fix labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,3 +10,4 @@ jobs:
       - uses: actions/labeler@v4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: ''


### PR DESCRIPTION
actions/labeler がラベルを勝手に剥がしてしまうバグのワークアラウンドです。

https://github.com/actions/labeler/issues/112#issuecomment-1000491676