### PR TITLE
ルカのイメージカラーを修正

### DIFF
--- a/RDFs/283.rdf
+++ b/RDFs/283.rdf
@@ -1067,7 +1067,7 @@
     <imas:cv xml:lang="ja">川口莉奈</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/川口莉奈"/>
     <imas:cv rdf:resource="http://www.wikidata.org/entity/Q106152263"/>
-    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">1E140E</imas:Color>
+    <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">24130D</imas:Color>
     <schema:birthPlace xml:lang="ja">神奈川県</schema:birthPlace>
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Brand xml:lang="en">ShinyColors</imas:Brand>


### PR DESCRIPTION
ユニットカラーと同様の色が、公式サイトのキャラクターの枠線に使用されていたため