### PR TITLE
シャニの新衣装を追加

### DIFF
--- a/RDFs/Clothes/ShinyColorsCommon.rdf
+++ b/RDFs/Clothes/ShinyColorsCommon.rdf
@@ -2076,7 +2076,7 @@
   <rdf:Description rdf:about="DressUpParfum_MorinoRinze">
     <schema:name xml:lang="ja">ドレスアップパルファム</schema:name>
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ドレスアップパルファム</rdfs:label>
-    <schema:description xml:lang="ja">Cheers! 月夜で染めた衣装に</schema:description>
+    <schema:description xml:lang="ja">Cheers! 月夜で染めた衣裳に</schema:description>
     <imas:Whose rdf:resource="Morino_Rinze"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>

--- a/RDFs/Clothes/ShinyColorsCommon.rdf
+++ b/RDFs/Clothes/ShinyColorsCommon.rdf
@@ -2536,5 +2536,12 @@
     <imas:Whose rdf:resource="Arisugawa_Natsuha"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="RespectiveWorkStyle_SerizawaAsahi">
+    <schema:name xml:lang="ja">リスペクティブワークスタイル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リスペクティブワークスタイル</rdfs:label>
+    <schema:description xml:lang="ja">WORKING：わたしの前に謎なんてない</schema:description>
+    <imas:Whose rdf:resource="Serizawa_Asahi"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 </rdf:RDF>
 

--- a/RDFs/Clothes/ShinyColorsCommon.rdf
+++ b/RDFs/Clothes/ShinyColorsCommon.rdf
@@ -2543,5 +2543,188 @@
     <imas:Whose rdf:resource="Serizawa_Asahi"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-</rdf:RDF>
 
+  <!-- フローウィングベル -->
+  <rdf:Description rdf:about="FlowingBhel_SakuragiMano">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Sakuragi_Mano"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。それはきらめきの向こうへ駆けて</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_KazanoHiori">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Kazano_Hiori"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。何があっても、何度でも。</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_HachimiyaMeguru">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Hachimiya_Meguru"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。一緒ならどこへでもゆけるの</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_TsukiokaKogane">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Tsukioka_Kogane"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。ふわり、ひらり、いざゆかん！</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_TanakaMamimi">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Tanaka_Mamimi"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。ナイスホワイト</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_ShiraseSakuya">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Shirase_Sakuya"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。ともに掴む可能性</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_MitsumineYuika">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Mitsumine_Yuika"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。どんな色でもほしいままに</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_YukokuKiriko">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Yukoku_Kiriko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。きみが愛するとき</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_KomiyaKaho">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Komiya_Kaho"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。これははじまりの色</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_SonodaChiyoko">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Sonoda_Chiyoko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。チョコとかこぼしたら大事故</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_SaijoJuri">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Saijo_Juri"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。折り重なる幾重もの</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_MorinoRinze">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Morino_Rinze"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。駆けよ天の階</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_ArisugawaNatsuha">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Arisugawa_Natsuha"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。雪の彼方の、その先へ</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_OsakiAmana">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Osaki_Amana"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。貴方がくれたこの羽でどこまでも</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_OsakiTenka">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Osaki_Tenka"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。何度でもまっしろな心で</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_KuwayamaChiyuki">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。純白の強さを知るものよ</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_SerizawaAsahi">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Serizawa_Asahi"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。重力すら振り切って</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_MayuzumiFuyuko">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。この翼に届かぬ空はない</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_IzumiMei">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Izumi_Mei"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。これは何度でも挑み続ける為の翼</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_AsakuraToru">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Asakura_Toru"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。海になる前の</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_HiguchiMadoka">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Higuchi_Madoka"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。光は混ざると</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_FukumaruKoito">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Fukumaru_Koito"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。白い小鳥は青空を見上げる</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_IchikawaHinana">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Ichikawa_Hinana"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。飛んでけ、しあわせいっぱいの羽</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_NanakusaNichika">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Nanakusa_Nichika"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。おかえり</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_AketaMikoto">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Aketa_Mikoto"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。歌い続ける、私を求めて</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_IkarugaLuca">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Ikaruga_Luca"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。翼なんか　いらねぇ</schema:description>
+  </rdf:Description>
+</rdf:RDF>

--- a/RDFs/Clothes/ShinyColorsCommon.rdf
+++ b/RDFs/Clothes/ShinyColorsCommon.rdf
@@ -2073,6 +2073,13 @@
     <imas:Whose rdf:resource="Saijo_Juri"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="DressUpParfum_MorinoRinze">
+    <schema:name xml:lang="ja">ドレスアップパルファム</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ドレスアップパルファム</rdfs:label>
+    <schema:description xml:lang="ja">Cheers! 月夜で染めた衣装に</schema:description>
+    <imas:Whose rdf:resource="Morino_Rinze"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- セレスティアルカラーズ -->
   <rdf:Description rdf:about="CelestialColors_SakuragiMano">
@@ -2541,6 +2548,13 @@
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リスペクティブワークスタイル</rdfs:label>
     <schema:description xml:lang="ja">WORKING：わたしの前に謎なんてない</schema:description>
     <imas:Whose rdf:resource="Serizawa_Asahi"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="RespectiveWorkStyle_TanakaMamimi">
+    <schema:name xml:lang="ja">リスペクティブワークスタイル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リスペクティブワークスタイル</rdfs:label>
+    <schema:description xml:lang="ja">WORKING：ビューティーはお任せで</schema:description>
+    <imas:Whose rdf:resource="Tanaka_Mamimi"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
 

--- a/RDFs/Clothes/ShinyColorsCommon.rdf
+++ b/RDFs/Clothes/ShinyColorsCommon.rdf
@@ -35,6 +35,7 @@
     <imas:Whose rdf:resource="Ichikawa_Hinana"/>
     <imas:Whose rdf:resource="Nanakusa_Nichika"/>
     <imas:Whose rdf:resource="Aketa_Mikoto"/>
+    <imas:Whose rdf:resource="Ikaruga_Luca"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
 
@@ -2063,6 +2064,13 @@
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ドレスアップパルファム</rdfs:label>
     <schema:description xml:lang="ja">Cheers! 華やかチョコレートです！</schema:description>
     <imas:Whose rdf:resource="Sonoda_Chiyoko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="DressUpParfum_SaijoJuri">
+    <schema:name xml:lang="ja">ドレスアップパルファム</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ドレスアップパルファム</rdfs:label>
+    <schema:description xml:lang="ja">Cheers! 見ていいのは2秒以内</schema:description>
+    <imas:Whose rdf:resource="Saijo_Juri"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
 

--- a/RDFs/Clothes/ShinyColorsPersonal.rdf
+++ b/RDFs/Clothes/ShinyColorsPersonal.rdf
@@ -727,4 +727,12 @@
     <imas:Whose rdf:resource="Aketa_Mikoto"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+
+  <!-- 斑鳩ルカ -->
+  <rdf:Description rdf:about="Breaking_Caution">
+    <schema:name xml:lang="ja">ブレイキングコーション</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ブレイキングコーション</rdfs:label>
+    <imas:Whose rdf:resource="Ikaruga_Luca"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 </rdf:RDF>

--- a/RDFs/Clothes/ShinyColorsPersonal.rdf
+++ b/RDFs/Clothes/ShinyColorsPersonal.rdf
@@ -459,6 +459,12 @@
     <imas:Whose rdf:resource="Osaki_Amana"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Cherish_Memories">
+    <schema:name xml:lang="ja">チェリッシュメモリーズ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">チェリッシュメモリーズ</rdfs:label>
+    <imas:Whose rdf:resource="Osaki_Amana"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- 大崎甜花 -->
   <rdf:Description rdf:about="Devilish_Future">
@@ -596,6 +602,12 @@
   <rdf:Description rdf:about="Deep_Deep_Lover">
     <schema:name xml:lang="ja">ディープディープラバー</schema:name>
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ディープディープラバー</rdfs:label>
+    <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Special_On_Special">
+    <schema:name xml:lang="ja">スペシャルオンスペシアル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">スペシャルオンスペシアル</rdfs:label>
     <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>

--- a/RDFs/Clothes/ShinyColorsPersonal.rdf
+++ b/RDFs/Clothes/ShinyColorsPersonal.rdf
@@ -401,6 +401,12 @@
     <imas:Whose rdf:resource="Morino_Rinze"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Exciteen_Collection">
+    <schema:name xml:lang="ja">エキサイティーンコレクション</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エキサイティーンコレクション</rdfs:label>
+    <imas:Whose rdf:resource="Morino_Rinze"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- 有栖川夏葉 -->
   <rdf:Description rdf:about="Glitter_Bubbly">

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -84,7 +84,7 @@
   <rdf:Description rdf:about="Explore_Serata">
     <schema:name xml:lang="ja">エクスプロアセラータ</schema:name>
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">エクスプロアセラータ</rdfs:label>
-    <!-- <imas:Whose rdf:resource="Kazano_Hiori"/> -->
+    <imas:Whose rdf:resource="Kazano_Hiori"/>
     <imas:Whose rdf:resource="Sakuragi_Mano"/>
     <!-- <imas:Whose rdf:resource="Hachimiya_Meguru"/> -->
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -1259,7 +1259,7 @@
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">パルミエーレインビュー</rdfs:label>
     <imas:Whose rdf:resource="Asakura_Toru"/>
     <imas:Whose rdf:resource="Higuchi_Madoka"/>
-    <!-- <imas:Whose rdf:resource="Fukumaru_Koito"/> -->
+    <imas:Whose rdf:resource="Fukumaru_Koito"/>
     <imas:Whose rdf:resource="Ichikawa_Hinana"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>


### PR DESCRIPTION
以下の衣装を追加しました。

- ドレスアップパルファム (西城樹里, 杜野凛世)
- ビヨンドザブルースカイ (斑鳩ルカ)
- パルミエーレインビュー (福丸小糸)
-  リスペクティブワークスタイル (芹沢あさひ, 田中摩美々)
- ブレイキングコーション (斑鳩ルカ) 
- チェリッシュメモリーズ (大崎甘奈)
- スペシャルオンスペシアル (黛冬優子)
- エキサイティーンコレクション(杜野凛世)
- フローウィングベル
  - [衣装名の由来によると](https://twitter.com/imassc_official/status/1637763373864738818) `ベル` には Bhel, Belle, Bell がかかっているようなので、`FlowingBhel` として登録していいのかご意見をいただきたい感じがします…
- エクスプロアセラータ (風野灯織)