### PR TITLE
シンデレラガールズの県立北高校制服の衣装データ追加

### DIFF
--- a/RDFs/Clothes/CinderellaStageUnit.rdf
+++ b/RDFs/Clothes/CinderellaStageUnit.rdf
@@ -430,7 +430,7 @@
     <imas:Whose rdf:resource="Hoshi_Syoko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="KenritsuKita_HighSchool_Uniform">
+  <rdf:Description rdf:about="Prefectural_Kita_High_School_Uniform">
     <schema:name xml:lang="ja">県立北高校制服</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">県立北高校制服</rdfs:label>
     <schema:description xml:lang="ja">世界を大いに盛り上げる少女達の制服ドレス。世の中がつまらないなら、自分たちで面白くしてしまおう。不思議な力はなくても、仲間と一緒なら変えていけるはずだ。</schema:description>

--- a/RDFs/Clothes/CinderellaStageUnit.rdf
+++ b/RDFs/Clothes/CinderellaStageUnit.rdf
@@ -433,7 +433,7 @@
   <rdf:Description rdf:about="KenritsuKita_HighSchool_Uniform">
     <schema:name xml:lang="ja">県立北高校制服</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">県立北高校制服</rdfs:label>
-    <schema:description xml:lang="ja">世界を大いに盛り上げる少女達の制服ドレス。世の中が詰まらないなら、自分たちで面白くしてしまおう。不思議な力はなくても、仲間と一緒なら変えていけるはずだ。</schema:description>
+    <schema:description xml:lang="ja">世界を大いに盛り上げる少女達の制服ドレス。世の中がつまらないなら、自分たちで面白くしてしまおう。不思議な力はなくても、仲間と一緒なら変えていけるはずだ。</schema:description>
     <imas:Whose rdf:resource="Abe_Nana"/>
     <imas:Whose rdf:resource="Sajo_Yukimi"/>
     <imas:Whose rdf:resource="Yumemi_Riamu"/>

--- a/RDFs/Clothes/CinderellaStageUnit.rdf
+++ b/RDFs/Clothes/CinderellaStageUnit.rdf
@@ -430,4 +430,13 @@
     <imas:Whose rdf:resource="Hoshi_Syoko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="KenritsuKita_HighSchool_Uniform">
+    <schema:name xml:lang="ja">県立北高校制服</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">県立北高校制服</rdfs:label>
+    <schema:description xml:lang="ja">世界を大いに盛り上げる少女達の制服ドレス。世の中が詰まらないなら、自分たちで面白くしてしまおう。不思議な力はなくても、仲間と一緒なら変えていけるはずだ。</schema:description>
+    <imas:Whose rdf:resource="Abe_Nana"/>
+    <imas:Whose rdf:resource="Sajo_Yukimi"/>
+    <imas:Whose rdf:resource="Yumemi_Riamu"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 </rdf:RDF>


### PR DESCRIPTION
涼宮ハルヒの憂鬱コラボで追加された「県立北高校制服」のデータ追加です。

`<rdf:Description rdf:about="KenritsuKita_HighSchool_Uniform">` よりももうちょっといいabout名があるような気がしますが、いい解釈の仕方が思いつきませんでした。。。

![Screenshot_20230517-211037](https://github.com/imas/imasparql/assets/12590762/8c0fb98e-955e-4166-a1bb-0d4a47ab62c4)

![Screenshot_20230517-211825](https://github.com/imas/imasparql/assets/12590762/26a70977-163a-4383-b518-5566390963e3)

