### PR TITLE
シャイニーカラーズの新衣装を追加

### DIFF
--- a/RDFs/Clothes/ShinyColorsCommon.rdf
+++ b/RDFs/Clothes/ShinyColorsCommon.rdf
@@ -2087,6 +2087,20 @@
     <imas:Whose rdf:resource="Arisugawa_Natsuha"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="DressUpParfum_OsakiAmana">
+    <schema:name xml:lang="ja">ドレスアップパルファム</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ドレスアップパルファム</rdfs:label>
+    <schema:description xml:lang="ja">Cheers! いっしょにふわふわ</schema:description>
+    <imas:Whose rdf:resource="Osaki_Amana"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="DressUpParfum_OsakiTenka">
+    <schema:name xml:lang="ja">ドレスアップパルファム</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ドレスアップパルファム</rdfs:label>
+    <schema:description xml:lang="ja">Cheers! ふたりできらきら</schema:description>
+    <imas:Whose rdf:resource="Osaki_Tenka"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- セレスティアルカラーズ -->
   <rdf:Description rdf:about="CelestialColors_SakuragiMano">
@@ -2569,6 +2583,20 @@
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リスペクティブワークスタイル</rdfs:label>
     <schema:description xml:lang="ja">WORKING：フロアもキッチンもちょうせん！</schema:description>
     <imas:Whose rdf:resource="Komiya_Kaho"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="RespectiveWorkStyle_IchikawaHinana">
+    <schema:name xml:lang="ja">リスペクティブワークスタイル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リスペクティブワークスタイル</rdfs:label>
+    <schema:description xml:lang="ja">WORKING：ふわふわかわいいと一緒♡</schema:description>
+    <imas:Whose rdf:resource="Ichikawa_Hinana"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="RespectiveWorkStyle_KazanoHiori">
+    <schema:name xml:lang="ja">リスペクティブワークスタイル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リスペクティブワークスタイル</rdfs:label>
+    <schema:description xml:lang="ja">WORKING：滞在中、最高の時間を提供します</schema:description>
+    <imas:Whose rdf:resource="Kazano_Hiori"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
 

--- a/RDFs/Clothes/ShinyColorsCommon.rdf
+++ b/RDFs/Clothes/ShinyColorsCommon.rdf
@@ -2080,6 +2080,13 @@
     <imas:Whose rdf:resource="Morino_Rinze"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="DressUpParfum_ArisugawaNatsuha">
+    <schema:name xml:lang="ja">ドレスアップパルファム</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ドレスアップパルファム</rdfs:label>
+    <schema:description xml:lang="ja">Cheers! シャンパンの泡よりも煌めいて</schema:description>
+    <imas:Whose rdf:resource="Arisugawa_Natsuha"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- セレスティアルカラーズ -->
   <rdf:Description rdf:about="CelestialColors_SakuragiMano">
@@ -2555,6 +2562,13 @@
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リスペクティブワークスタイル</rdfs:label>
     <schema:description xml:lang="ja">WORKING：ビューティーはお任せで</schema:description>
     <imas:Whose rdf:resource="Tanaka_Mamimi"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="RespectiveWorkStyle_KomiyaKaho">
+    <schema:name xml:lang="ja">リスペクティブワークスタイル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リスペクティブワークスタイル</rdfs:label>
+    <schema:description xml:lang="ja">WORKING：フロアもキッチンもちょうせん！</schema:description>
+    <imas:Whose rdf:resource="Komiya_Kaho"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
 

--- a/RDFs/Clothes/ShinyColorsPersonal.rdf
+++ b/RDFs/Clothes/ShinyColorsPersonal.rdf
@@ -413,12 +413,6 @@
     <imas:Whose rdf:resource="Morino_Rinze"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Exciteen_Collection">
-    <schema:name xml:lang="ja">エキサイティーンコレクション</schema:name>
-    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エキサイティーンコレクション</rdfs:label>
-    <imas:Whose rdf:resource="Morino_Rinze"/>
-    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
-  </rdf:Description>
 
   <!-- 有栖川夏葉 -->
   <rdf:Description rdf:about="Glitter_Bubbly">

--- a/RDFs/Clothes/ShinyColorsPersonal.rdf
+++ b/RDFs/Clothes/ShinyColorsPersonal.rdf
@@ -585,12 +585,6 @@
     <imas:Whose rdf:resource="Serizawa_Asahi"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Energy_Desiderata">
-    <schema:name xml:lang="ja">エナジーデシデラータ</schema:name>
-    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">エナジーデシデラータ</rdfs:label>
-    <imas:Whose rdf:resource="Serizawa_Asahi"/>
-    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
-  </rdf:Description>
   <rdf:Description rdf:about="Strawberry_Cover">
     <schema:name xml:lang="ja">ストロベリーカバー</schema:name>
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ストロベリーカバー</rdfs:label>

--- a/RDFs/Clothes/ShinyColorsPersonal.rdf
+++ b/RDFs/Clothes/ShinyColorsPersonal.rdf
@@ -183,6 +183,12 @@
     <imas:Whose rdf:resource="Tanaka_Mamimi"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Melty_Identity">
+    <schema:name xml:lang="ja">メルティアイデンティティ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">メルティアイデンティティ</rdfs:label>
+    <imas:Whose rdf:resource="Tanaka_Mamimi"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- 白瀬咲耶 -->
   <rdf:Description rdf:about="Noble_Bella">
@@ -322,6 +328,12 @@
   <rdf:Description rdf:about="Magical_Chocolate">
     <schema:name xml:lang="ja">マジカルショコラーチ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">マジカルショコラーチ</rdfs:label>
+    <imas:Whose rdf:resource="Sonoda_Chiyoko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Sunday_Choco_Date">
+    <schema:name xml:lang="ja">サンデーチョコデート♡</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">サンデーチョコデート♡</rdfs:label>
     <imas:Whose rdf:resource="Sonoda_Chiyoko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -335,7 +335,7 @@
     <imas:Whose rdf:resource="Tanaka_Mamimi"/>
     <imas:Whose rdf:resource="Tsukioka_Kogane"/>
     <imas:Whose rdf:resource="Mitsumine_Yuika"/>
-    <!-- <imas:Whose rdf:resource="Yukoku_Kiriko"/> -->
+    <imas:Whose rdf:resource="Yukoku_Kiriko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Wonderland_Hoppin">

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -331,7 +331,7 @@
   <rdf:Description rdf:about="Haute_Couture_Arte_Piece">
     <schema:name xml:lang="ja">オートクチュールアルテピエス</schema:name>
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">オートクチュールアルテピエス</rdfs:label>
-    <!-- <imas:Whose rdf:resource="Shirase_Sakuya"/> -->
+    <imas:Whose rdf:resource="Shirase_Sakuya"/>
     <imas:Whose rdf:resource="Tanaka_Mamimi"/>
     <imas:Whose rdf:resource="Tsukioka_Kogane"/>
     <imas:Whose rdf:resource="Mitsumine_Yuika"/>

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -86,7 +86,7 @@
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">エクスプロアセラータ</rdfs:label>
     <imas:Whose rdf:resource="Kazano_Hiori"/>
     <imas:Whose rdf:resource="Sakuragi_Mano"/>
-    <!-- <imas:Whose rdf:resource="Hachimiya_Meguru"/> -->
+    <imas:Whose rdf:resource="Hachimiya_Meguru"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="One_Day_Officer">
@@ -338,6 +338,17 @@
     <imas:Whose rdf:resource="Yukoku_Kiriko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Museo_Forma_Rinascita">
+    <schema:name xml:lang="ja">ミュゼオフォルマーリナーシタ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ミュゼオフォルマーリナーシタ</rdfs:label>
+    <imas:Whose rdf:resource="Shirase_Sakuya"/>
+    <!-- <imas:Whose rdf:resource="Tanaka_Mamimi"/> -->
+    <!-- <imas:Whose rdf:resource="Tsukioka_Kogane"/> -->
+    <!-- <imas:Whose rdf:resource="Mitsumine_Yuika"/> -->
+    <!-- <imas:Whose rdf:resource="Yukoku_Kiriko"/> -->
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+
   <rdf:Description rdf:about="Wonderland_Hoppin">
     <schema:name xml:lang="ja">ワンダーランドホッピン</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ワンダーランドホッピン</rdfs:label>
@@ -549,7 +560,7 @@
     <schema:name xml:lang="ja">エキサイティーンコレクション</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エキサイティーンコレクション</rdfs:label>
     <imas:Whose rdf:resource="Arisugawa_Natsuha"/>
-    <!-- <imas:Whose rdf:resource="Komiya_Kaho"/> -->
+    <imas:Whose rdf:resource="Komiya_Kaho"/>
     <!-- <imas:Whose rdf:resource="Saijo_Juri"/> -->
     <!-- <imas:Whose rdf:resource="Sonoda_Chiyoko"/> -->
     <imas:Whose rdf:resource="Morino_Rinze"/>
@@ -1289,6 +1300,15 @@
     <imas:Whose rdf:resource="Ichikawa_Hinana"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Aquario_Diva">
+    <schema:name xml:lang="ja">アクアリオディーバー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アクアリオディーバー</rdfs:label>
+    <!-- <imas:Whose rdf:resource="Asakura_Toru"/> -->
+    <imas:Whose rdf:resource="Higuchi_Madoka"/>
+    <!-- <imas:Whose rdf:resource="Fukumaru_Koito"/> -->
+    <!-- <imas:Whose rdf:resource="Ichikawa_Hinana"/> -->
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <rdf:Description rdf:about="LoveLaughRabbits_AsakuraToru">
     <schema:name xml:lang="ja">ラブラフラビッツ</schema:name>
@@ -1428,7 +1448,7 @@
   <rdf:Description rdf:about="Monochromatic_Zircon">
     <schema:name xml:lang="ja">モノクロマテイクジルコン</schema:name>
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">モノクロマテイクジルコン</rdfs:label>
-    <!-- <imas:Whose rdf:resource="Aketa_Mikoto"/> -->
+    <imas:Whose rdf:resource="Aketa_Mikoto"/>
     <imas:Whose rdf:resource="Nanakusa_Nichika"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -1111,6 +1111,14 @@
     <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Energy_Desiderata">
+    <schema:name xml:lang="ja">エナジーデシデラータ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">エナジーデシデラータ</rdfs:label>
+    <imas:Whose rdf:resource="Izumi_Mei"/>
+    <imas:Whose rdf:resource="Serizawa_Asahi"/>
+    <!-- <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/> -->
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
   <rdf:Description rdf:about="Merry_Merry_Delivery">
     <schema:name xml:lang="ja">メリーメリーデリバリー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">メリーメリーデリバリー</rdfs:label>

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -545,6 +545,16 @@
     <imas:Whose rdf:resource="Morino_Rinze"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Exciteen_Collection">
+    <schema:name xml:lang="ja">エキサイティーンコレクション</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エキサイティーンコレクション</rdfs:label>
+    <imas:Whose rdf:resource="Arisugawa_Natsuha"/>
+    <!-- <imas:Whose rdf:resource="Komiya_Kaho"/> -->
+    <!-- <imas:Whose rdf:resource="Saijo_Juri"/> -->
+    <!-- <imas:Whose rdf:resource="Sonoda_Chiyoko"/> -->
+    <imas:Whose rdf:resource="Morino_Rinze"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
   <rdf:Description rdf:about="Galactic_Hero">
     <schema:name xml:lang="ja">ギャラクティックヒーロー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ギャラクティックヒーロー</rdfs:label>

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -945,6 +945,14 @@
     <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Eternity_Pomponner">
+    <schema:name xml:lang="ja">エタニティポンポーネ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エタニティポンポーネ</rdfs:label>
+    <imas:Whose rdf:resource="Osaki_Amana"/>
+    <imas:Whose rdf:resource="Osaki_Tenka"/>
+    <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
   <rdf:Description rdf:about="Cutie_Time_Sweets">
     <schema:name xml:lang="ja">キューティータイムスイーツ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">キューティータイムスイーツ</rdfs:label>

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -1300,7 +1300,7 @@
     <imas:Whose rdf:resource="Ichikawa_Hinana"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Aquario_Diva">
+  <rdf:Description rdf:about="Acquario_Diva">
     <schema:name xml:lang="ja">アクアリオディーバー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アクアリオディーバー</rdfs:label>
     <!-- <imas:Whose rdf:resource="Asakura_Toru"/> -->


### PR DESCRIPTION
以下の衣装を追加しました。

- メルティアイデンティティ (田中摩美々)
- サンデーチョコデート♡ (園田智代子)
- オートクチュールアルテピエス (白瀬咲耶, 幽谷霧子)
- エナジーデシデラータ (和泉愛依)
- ドレスアップパルファム (有栖川夏葉, 大崎甘奈, 大崎甜花)
- リスペクティブワークスタイル (小宮果穂, 市川雛菜, 風野灯織)
- エキサイティーンコレクション (有栖川夏葉, 小宮果穂)
- エタニティポンポーネ (アルストロメリア)
- エクスプロアセラータ (八宮めぐる)
- ミュゼオフォルマーリナーシタ (白瀬咲耶)
- アクアリオディーバー (樋口円香)
- モノクロマテイクジルコン (緋田美琴)