### PR TITLE
ミリオン10thライブAct-2に郁原ゆうさんを追加

### DIFF
--- a/RDFs/Lives/Live_2023.rdf
+++ b/RDFs/Lives/Live_2023.rdf
@@ -417,6 +417,7 @@
     <schema:actor xml:lang="ja">伊藤美来</schema:actor>
     <schema:actor xml:lang="ja">稲川英里</schema:actor>
     <schema:actor xml:lang="ja">大関英里</schema:actor>
+    <schema:actor xml:lang="ja">郁原ゆう</schema:actor>
     <schema:actor xml:lang="ja">桐谷蝶々</schema:actor>
     <schema:actor xml:lang="ja">小岩井ことり</schema:actor>
     <schema:actor xml:lang="ja">香里有佐</schema:actor>


### PR DESCRIPTION
ミリオン10thライブAct-2に郁原ゆうさんが追加出演されることが発表されました
情報源：https://idolmaster-official.jp/news/01_8407