### PR TITLE
シャイニーカラーズの新衣装を追加

### DIFF
--- a/RDFs/Clothes/ShinyColorsCommon.rdf
+++ b/RDFs/Clothes/ShinyColorsCommon.rdf
@@ -683,6 +683,13 @@
     <schema:description xml:lang="ja">トリック・オア・トリート！Found you！</schema:description>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="MidnightMonster_IkarugaLuca">
+    <schema:name xml:lang="ja">ミッドナイトモンスター</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ミッドナイトモンスター</rdfs:label>
+    <schema:description xml:lang="ja">トリック・オア・トリート！　闇への忠誠（不本意）</schema:description>
+    <imas:Whose rdf:resource="Ikaruga_Luca"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- ホーリーナイトケープ -->
   <rdf:Description rdf:about="HolyNightCape_SakuragiMano">
@@ -2108,6 +2115,13 @@
     <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="DressUpParfum_SerizawaAsahi">
+    <schema:name xml:lang="ja">ドレスアップパルファム</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ドレスアップパルファム</rdfs:label>
+    <schema:description xml:lang="ja">Cheers! 高鳴りのタイミング</schema:description>
+    <imas:Whose rdf:resource="Serizawa_Asahi"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- セレスティアルカラーズ -->
   <rdf:Description rdf:about="CelestialColors_SakuragiMano">
@@ -2611,6 +2625,13 @@
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リスペクティブワークスタイル</rdfs:label>
     <schema:description xml:lang="ja">WORKING：大盛り！いつでもサービス♪</schema:description>
     <imas:Whose rdf:resource="Izumi_Mei"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="RespectiveWorkStyle_MorinoRinze">
+    <schema:name xml:lang="ja">リスペクティブワークスタイル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リスペクティブワークスタイル</rdfs:label>
+    <schema:description xml:lang="ja">WORKING：召しませ特製焙煎珈琲</schema:description>
+    <imas:Whose rdf:resource="Morino_Rinze"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
 

--- a/RDFs/Clothes/ShinyColorsCommon.rdf
+++ b/RDFs/Clothes/ShinyColorsCommon.rdf
@@ -2783,4 +2783,188 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
     <schema:description xml:lang="ja">ブランクペイジ。翼なんか　いらねぇ</schema:description>
   </rdf:Description>
+
+  <!-- ディライトサマー -->
+  <rdf:Description rdf:about="Delight_Summer_SakuragiMano">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Sakuragi_Mano"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　ストロベリーバニラをコーンで</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="Delight_Summer_KazanoHiori">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Kazano_Hiori"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　歯磨き粉とは言わせません</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="Delight_Summer_HachimiyaMeguru">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Hachimiya_Meguru"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　どっちにも合うでしょう？</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="Delight_Summer_TsukiokaKogane">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Tsukioka_Kogane"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　耐水性の夏、はじめ</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="Delight_Summer_TanakaMamimi">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Tanaka_Mamimi"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　悪い子先生の水泳教室</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="Delight_Summer_ShiraseSakuya">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Shirase_Sakuya"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　波に任せて</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="Delight_Summer_MitsumineYuika">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Mitsumine_Yuika"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　――で、遊びます？</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="Delight_Summer_YukokuKiriko">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Yukoku_Kiriko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　いうことはよく聞いて</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="Delight_Summer_KomiyaKaho">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Komiya_Kaho"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　放クラ・フルーツモード！</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="Delight_Summer_SonodaChiyoko">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Sonoda_Chiyoko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　おでこが見えるのはレア</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="Delight_Summer_SaijoJuri">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Saijo_Juri"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　この夏最アツパイナッポー</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="Delight_Summer_MorinoRinze">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Morino_Rinze"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　群青に包まれり</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="Delight_Summer_ArisugawaNatsuha">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Arisugawa_Natsuha"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　爽やかレモンもマストバイ</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="Delight_Summer_OsakiAmana">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Osaki_Amana"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　ポイントはイルカさん☆</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="Delight_Summer_OsakiTenka">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Osaki_Tenka"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　シュガーミルク・リトルホエール</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="Delight_Summer_KuwayamaChiyuki">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　帽子の下、鯨の唄を口遊め</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="Delight_Summer_SerizawaAsahi">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Serizawa_Asahi"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　ふわふわり、つかまえられる？</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="Delight_Summer_MayuzumiFuyuko">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　ゆらり汗、ゆられて浮遊</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="Delight_Summer_IzumiMei">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Izumi_Mei"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　ひらひらと、水を纏うように</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="Delight_Summer_AsakuraToru">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Asakura_Toru"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　桃源郷ってやつ</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="Delight_Summer_HiguchiMadoka">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Higuchi_Madoka"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　そよぐ、薫り、潮に溶ける</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="Delight_Summer_FukumaruKoito">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Fukumaru_Koito"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　太陽の下、青空に負けないで</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="Delight_Summer_IchikawaHinana">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Ichikawa_Hinana"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　今だけのメロディを浴びて</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="Delight_Summer_NanakusaNichika">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Nanakusa_Nichika"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　辿りつく、いつか</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="Delight_Summer_AketaMikoto">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Aketa_Mikoto"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　砂にステップを刻む</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="Delight_Summer_IkarugaLuca">
+    <schema:name xml:lang="ja">ディライトサマー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ディライトサマー</rdfs:label>
+    <imas:Whose rdf:resource="Ikaruga_Luca"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">Have fun!　波の音じゃ、足りない</schema:description>
+  </rdf:Description>
 </rdf:RDF>

--- a/RDFs/Clothes/ShinyColorsCommon.rdf
+++ b/RDFs/Clothes/ShinyColorsCommon.rdf
@@ -2101,6 +2101,13 @@
     <imas:Whose rdf:resource="Osaki_Tenka"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="DressUpParfum_KuwayamaChiyuki">
+    <schema:name xml:lang="ja">ドレスアップパルファム</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ドレスアップパルファム</rdfs:label>
+    <schema:description xml:lang="ja">Cheers! ふわり、シフォンの魔法</schema:description>
+    <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- セレスティアルカラーズ -->
   <rdf:Description rdf:about="CelestialColors_SakuragiMano">
@@ -2597,6 +2604,13 @@
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リスペクティブワークスタイル</rdfs:label>
     <schema:description xml:lang="ja">WORKING：滞在中、最高の時間を提供します</schema:description>
     <imas:Whose rdf:resource="Kazano_Hiori"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="RespectiveWorkStyle_IzumiMei">
+    <schema:name xml:lang="ja">リスペクティブワークスタイル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リスペクティブワークスタイル</rdfs:label>
+    <schema:description xml:lang="ja">WORKING：大盛り！いつでもサービス♪</schema:description>
+    <imas:Whose rdf:resource="Izumi_Mei"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
 

--- a/RDFs/Clothes/ShinyColorsCommon.rdf
+++ b/RDFs/Clothes/ShinyColorsCommon.rdf
@@ -2120,6 +2120,7 @@
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ドレスアップパルファム</rdfs:label>
     <schema:description xml:lang="ja">Cheers! 高鳴りのタイミング</schema:description>
     <imas:Whose rdf:resource="Serizawa_Asahi"/>
+  </rdf:Description>
   <rdf:Description rdf:about="DressUpParfum_MayuzumiFuyuko">
     <schema:name xml:lang="ja">ドレスアップパルファム</schema:name>
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ドレスアップパルファム</rdfs:label>
@@ -2644,6 +2645,7 @@
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リスペクティブワークスタイル</rdfs:label>
     <schema:description xml:lang="ja">WORKING：召しませ特製焙煎珈琲</schema:description>
     <imas:Whose rdf:resource="Morino_Rinze"/>
+  </rdf:Description>
   <rdf:Description rdf:about="RespectiveWorkStyle_HachimiyaMeguru">
     <schema:name xml:lang="ja">リスペクティブワークスタイル</schema:name>
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リスペクティブワークスタイル</rdfs:label>

--- a/RDFs/Clothes/ShinyColorsPersonal.rdf
+++ b/RDFs/Clothes/ShinyColorsPersonal.rdf
@@ -703,7 +703,7 @@
     <imas:Whose rdf:resource="Fukumaru_Koito"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Watachi_Pretty_Confident">
+  <rdf:Description rdf:about="Watashi_Pretty_Confident">
     <schema:name xml:lang="ja">ワタシプリティコンフィデント</schema:name>
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ワタシプリティコンフィデント</rdfs:label>
     <imas:Whose rdf:resource="Fukumaru_Koito"/>

--- a/RDFs/Clothes/ShinyColorsPersonal.rdf
+++ b/RDFs/Clothes/ShinyColorsPersonal.rdf
@@ -241,6 +241,12 @@
     <imas:Whose rdf:resource="Mitsumine_Yuika"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Fields_Plastic">
+    <schema:name xml:lang="ja">フィールズ・プラスチック</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">フィールズ・プラスチック</rdfs:label>
+    <imas:Whose rdf:resource="Mitsumine_Yuika"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- 幽谷霧子 -->
   <rdf:Description rdf:about="Secret_Curely">
@@ -697,6 +703,12 @@
     <imas:Whose rdf:resource="Fukumaru_Koito"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Watachi_Pretty_Confident">
+    <schema:name xml:lang="ja">ワタシプリティコンフィデント</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ワタシプリティコンフィデント</rdfs:label>
+    <imas:Whose rdf:resource="Fukumaru_Koito"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- 市川雛菜 -->
   <rdf:Description rdf:about="Sunny_Sunny_Sunflower">
@@ -731,6 +743,12 @@
     <imas:Whose rdf:resource="Nanakusa_Nichika"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Living_Fairy">
+    <schema:name xml:lang="ja">リヴィングフェアリー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リヴィングフェアリー</rdfs:label>
+    <imas:Whose rdf:resource="Nanakusa_Nichika"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- 緋田美琴 -->
   <rdf:Description rdf:about="Buriki_Steamy_Blue">
@@ -750,6 +768,12 @@
   <rdf:Description rdf:about="Breaking_Caution">
     <schema:name xml:lang="ja">ブレイキングコーション</schema:name>
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ブレイキングコーション</rdfs:label>
+    <imas:Whose rdf:resource="Ikaruga_Luca"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Prettily_Chain">
+    <schema:name xml:lang="ja">プリートリィチェイン</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">プリートリィチェイン</rdfs:label>
     <imas:Whose rdf:resource="Ikaruga_Luca"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -561,7 +561,7 @@
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エキサイティーンコレクション</rdfs:label>
     <imas:Whose rdf:resource="Arisugawa_Natsuha"/>
     <imas:Whose rdf:resource="Komiya_Kaho"/>
-    <!-- <imas:Whose rdf:resource="Saijo_Juri"/> -->
+    <imas:Whose rdf:resource="Saijo_Juri"/>
     <!-- <imas:Whose rdf:resource="Sonoda_Chiyoko"/> -->
     <imas:Whose rdf:resource="Morino_Rinze"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
@@ -633,6 +633,16 @@
     <imas:Whose rdf:resource="Saijo_Juri"/>
     <imas:Whose rdf:resource="Sonoda_Chiyoko"/>
     <imas:Whose rdf:resource="Morino_Rinze"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamaru_Sunrize">
+    <schema:name xml:lang="ja">ハナマルサンライズ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ハナマルサンライズ</rdfs:label>
+    <!-- <imas:Whose rdf:resource="Arisugawa_Natsuha"/> -->
+    <imas:Whose rdf:resource="Komiya_Kaho"/>
+    <!-- <imas:Whose rdf:resource="Saijo_Juri"/> -->
+    <!-- <imas:Whose rdf:resource="Sonoda_Chiyoko"/> -->
+    <!-- <imas:Whose rdf:resource="Morino_Rinze"/> -->
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Pajamas_De_Kabukabu">
@@ -1449,6 +1459,13 @@
     <schema:name xml:lang="ja">モノクロマテイクジルコン</schema:name>
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">モノクロマテイクジルコン</rdfs:label>
     <imas:Whose rdf:resource="Aketa_Mikoto"/>
+    <imas:Whose rdf:resource="Nanakusa_Nichika"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Living_Fairy">
+    <schema:name xml:lang="ja">リヴィングフェアリー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リヴィングフェアリー</rdfs:label>
+    <!-- <imas:Whose rdf:resource="Aketa_Mikoto"/> -->
     <imas:Whose rdf:resource="Nanakusa_Nichika"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -342,7 +342,7 @@
     <schema:name xml:lang="ja">ミュゼオフォルマーリナーシタ</schema:name>
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ミュゼオフォルマーリナーシタ</rdfs:label>
     <imas:Whose rdf:resource="Shirase_Sakuya"/>
-    <!-- <imas:Whose rdf:resource="Tanaka_Mamimi"/> -->
+    <imas:Whose rdf:resource="Tanaka_Mamimi"/>
     <!-- <imas:Whose rdf:resource="Tsukioka_Kogane"/> -->
     <!-- <imas:Whose rdf:resource="Mitsumine_Yuika"/> -->
     <imas:Whose rdf:resource="Yukoku_Kiriko"/>

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -345,7 +345,7 @@
     <!-- <imas:Whose rdf:resource="Tanaka_Mamimi"/> -->
     <!-- <imas:Whose rdf:resource="Tsukioka_Kogane"/> -->
     <!-- <imas:Whose rdf:resource="Mitsumine_Yuika"/> -->
-    <!-- <imas:Whose rdf:resource="Yukoku_Kiriko"/> -->
+    <imas:Whose rdf:resource="Yukoku_Kiriko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
 
@@ -1462,9 +1462,9 @@
     <imas:Whose rdf:resource="Nanakusa_Nichika"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Living_Fairy">
-    <schema:name xml:lang="ja">リヴィングフェアリー</schema:name>
-    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リヴィングフェアリー</rdfs:label>
+  <rdf:Description rdf:about="Portier_Les_Ordine">
+    <schema:name xml:lang="ja">ポルティエレオルディーネ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ポルティエレオルディーネ</rdfs:label>
     <!-- <imas:Whose rdf:resource="Aketa_Mikoto"/> -->
     <imas:Whose rdf:resource="Nanakusa_Nichika"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -1462,7 +1462,7 @@
     <imas:Whose rdf:resource="Nanakusa_Nichika"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Portier_Les_Ordine">
+  <rdf:Description rdf:about="Portiere_Les_Ordine">
     <schema:name xml:lang="ja">ポルティエレオルディーネ</schema:name>
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ポルティエレオルディーネ</rdfs:label>
     <!-- <imas:Whose rdf:resource="Aketa_Mikoto"/> -->


### PR DESCRIPTION
以下の衣装を追加しました。

- ディライトサマー (全体)
- ドレスアップパルファム (桑山千雪, 芹沢あさひ)
- リスペクティブワークスタイル (和泉愛依, 杜野凛世)
- エキサイティーンコレクション (西城樹里)
- ハナマルサンライズ (小宮果穂)
- リヴィングフェアリー (七草にちか)
- ミッドナイトモンスター (斑鳩ルカ)
- ミュゼオフォルマーリナーシタ (幽谷霧子, 田中摩美々)
- プリートリィチェイン (斑鳩ルカ)
- フィールズ・プラスチック (三峰結華)
- ワタシプリティコンフィデント (福丸小糸)
- ポルティエレオルディーネ (七草にちか)
  - ポルティエ: https://kotobank.jp/itjaword/portiere
  - オルディネ: https://kotobank.jp/itjaword/ordine