### PR TITLE
シャイニーカラーズ (enza) の衣装を追加

### DIFF
--- a/RDFs/Clothes/ShinyColorsCommon.rdf
+++ b/RDFs/Clothes/ShinyColorsCommon.rdf
@@ -2101,6 +2101,20 @@
     <imas:Whose rdf:resource="Osaki_Tenka"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="DressUpParfum_MayuzumiFuyuko">
+    <schema:name xml:lang="ja">ドレスアップパルファム</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ドレスアップパルファム</rdfs:label>
+    <schema:description xml:lang="ja">Cheers! 秘せずとも花</schema:description>
+    <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="DressUpParfum_IzumiMei">
+    <schema:name xml:lang="ja">ドレスアップパルファム</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ドレスアップパルファム</rdfs:label>
+    <schema:description xml:lang="ja">Cheers! ハンパなく豪華なカンジ！</schema:description>
+    <imas:Whose rdf:resource="Izumi_Mei"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- セレスティアルカラーズ -->
   <rdf:Description rdf:about="CelestialColors_SakuragiMano">
@@ -2597,6 +2611,20 @@
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リスペクティブワークスタイル</rdfs:label>
     <schema:description xml:lang="ja">WORKING：滞在中、最高の時間を提供します</schema:description>
     <imas:Whose rdf:resource="Kazano_Hiori"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="RespectiveWorkStyle_HachimiyaMeguru">
+    <schema:name xml:lang="ja">リスペクティブワークスタイル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リスペクティブワークスタイル</rdfs:label>
+    <schema:description xml:lang="ja">WORKING：左オーライです！</schema:description>
+    <imas:Whose rdf:resource="Hachimiya_Meguru"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="RespectiveWorkStyle_AketaMikoto">
+    <schema:name xml:lang="ja">リスペクティブワークスタイル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リスペクティブワークスタイル</rdfs:label>
+    <schema:description xml:lang="ja">WORKING：私が作ったカクテル、飲む？</schema:description>
+    <imas:Whose rdf:resource="Aketa_Mikoto"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
 

--- a/RDFs/Clothes/ShinyColorsPersonal.rdf
+++ b/RDFs/Clothes/ShinyColorsPersonal.rdf
@@ -413,6 +413,12 @@
     <imas:Whose rdf:resource="Morino_Rinze"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Tokosaki_No_Tokiwa">
+    <schema:name xml:lang="ja">トコサキノトキワ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">トコサキノトキワ</rdfs:label>
+    <imas:Whose rdf:resource="Morino_Rinze"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- 有栖川夏葉 -->
   <rdf:Description rdf:about="Glitter_Bubbly">
@@ -436,6 +442,12 @@
   <rdf:Description rdf:about="Agent_D">
     <schema:name xml:lang="ja">エイジェント[D]</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">エイジェント[D]</rdfs:label>
+    <imas:Whose rdf:resource="Arisugawa_Natsuha"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Abrumador_Damascus">
+    <schema:name xml:lang="ja">アブルマドールダマスカス</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">アブルマドールダマスカス</rdfs:label>
     <imas:Whose rdf:resource="Arisugawa_Natsuha"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -643,6 +655,12 @@
     <imas:Whose rdf:resource="Izumi_Mei"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Going_Straight">
+    <schema:name xml:lang="ja">ゴーイング・ストレイト</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ゴーイング・ストレイト</rdfs:label>
+    <imas:Whose rdf:resource="Izumi_Mei"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- 浅倉透 -->
   <rdf:Description rdf:about="Sparkle_Glass">
@@ -660,6 +678,12 @@
   <rdf:Description rdf:about="Darkest_Ever_Red">
     <schema:name xml:lang="ja">ダーケストエバーレッド</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ダーケストエバーレッド</rdfs:label>
+    <imas:Whose rdf:resource="Asakura_Toru"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Leaving_Statice">
+    <schema:name xml:lang="ja">リーヴィングスターチス</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リーヴィングスターチス</rdfs:label>
     <imas:Whose rdf:resource="Asakura_Toru"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -89,6 +89,14 @@
     <imas:Whose rdf:resource="Hachimiya_Meguru"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Present_From_Estrella">
+    <schema:name xml:lang="ja">プレゼントフロムエストレア</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">プレゼントフロムエストレア</rdfs:label>
+    <!-- <imas:Whose rdf:resource="Kazano_Hiori"/> -->
+    <!-- <imas:Whose rdf:resource="Sakuragi_Mano"/> -->
+    <imas:Whose rdf:resource="Hachimiya_Meguru"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
   <rdf:Description rdf:about="One_Day_Officer">
     <schema:name xml:lang="ja">ワンデイオフィサー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ワンデイオフィサー</rdfs:label>
@@ -562,7 +570,7 @@
     <imas:Whose rdf:resource="Arisugawa_Natsuha"/>
     <imas:Whose rdf:resource="Komiya_Kaho"/>
     <!-- <imas:Whose rdf:resource="Saijo_Juri"/> -->
-    <!-- <imas:Whose rdf:resource="Sonoda_Chiyoko"/> -->
+    <imas:Whose rdf:resource="Sonoda_Chiyoko"/>
     <imas:Whose rdf:resource="Morino_Rinze"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -964,6 +972,14 @@
     <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Lepre_Lasciato_Faenza">
+    <schema:name xml:lang="ja">レプラシャートファエンツァ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">レプラシャートファエンツァ</rdfs:label>
+    <!-- <imas:Whose rdf:resource="Osaki_Amana"/> -->
+    <!-- <imas:Whose rdf:resource="Osaki_Tenka"/> -->
+    <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
   <rdf:Description rdf:about="Cutie_Time_Sweets">
     <schema:name xml:lang="ja">キューティータイムスイーツ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">キューティータイムスイーツ</rdfs:label>
@@ -1145,7 +1161,7 @@
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">エナジーデシデラータ</rdfs:label>
     <imas:Whose rdf:resource="Izumi_Mei"/>
     <imas:Whose rdf:resource="Serizawa_Asahi"/>
-    <!-- <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/> -->
+    <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
   <rdf:Description rdf:about="Merry_Merry_Delivery">
@@ -1306,7 +1322,7 @@
     <!-- <imas:Whose rdf:resource="Asakura_Toru"/> -->
     <imas:Whose rdf:resource="Higuchi_Madoka"/>
     <!-- <imas:Whose rdf:resource="Fukumaru_Koito"/> -->
-    <!-- <imas:Whose rdf:resource="Ichikawa_Hinana"/> -->
+    <imas:Whose rdf:resource="Ichikawa_Hinana"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
 


### PR DESCRIPTION
以下の衣装を追加しました。

### 共通

- ドレスアップパルファム(黛冬優子, 和泉愛依)
- リスペクティブワークスタイル (八宮めぐる, 緋田美琴)

### ユニット

- プレゼントフロムエストレア (八宮めぐる)
- エナジーデシデラータ (黛冬優子)
- エキサイティーンコレクション (園田智代子)
- レプラシャートファエンツァ (桑山千雪)
  - lepre: https://kotobank.jp/itjaword/lepre
  - lasciato: https://kotobank.jp/itjaword/lasciare
    - 離れ離れになる、離れる のようなニュアンスかな…と解釈しましたが少し厳しい感じもします
  - faenza: https://kotobank.jp/itjaword/Faenza

### 個人

- アブルマドールダマスカス (有栖川夏葉)
  - abrumador: https://kotobank.jp/esjaword/abrumador
- ゴーイング・ストレイト (和泉愛依)
- トコサキノトキワ (杜野凛世)
- リーヴィングスターチス (浅倉透)