### PR TITLE
add: enza版シャイニーカラーズの衣装を追加

### DIFF
--- a/RDFs/Clothes/ShinyColorsCommon.rdf
+++ b/RDFs/Clothes/ShinyColorsCommon.rdf
@@ -2165,6 +2165,20 @@
     <imas:Whose rdf:resource="Asakura_Toru"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="DressUpParfum_HiguchiMadoka">
+    <schema:name xml:lang="ja">ドレスアップパルファム</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ドレスアップパルファム</rdfs:label>
+    <schema:description xml:lang="ja">Cheers! シャンデリア・ミラージュ</schema:description>
+    <imas:Whose rdf:resource="Higuchi_Madoka"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="DressUpParfum_FukumaruKoito">
+    <schema:name xml:lang="ja">ドレスアップパルファム</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ドレスアップパルファム</rdfs:label>
+    <schema:description xml:lang="ja">Cheers! まだバタ足だけど、少しずつ</schema:description>
+    <imas:Whose rdf:resource="Fukumaru_Koito"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- セレスティアルカラーズ -->
   <rdf:Description rdf:about="CelestialColors_SakuragiMano">
@@ -2695,6 +2709,20 @@
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リスペクティブワークスタイル</rdfs:label>
     <schema:description xml:lang="ja">WORKING：じ、人命救助、第一です……！</schema:description>
     <imas:Whose rdf:resource="Fukumaru_Koito"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="RespectiveWorkStyle_MayuzumiFuyuko">
+    <schema:name xml:lang="ja">リスペクティブワークスタイル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リスペクティブワークスタイル</rdfs:label>
+    <schema:description xml:lang="ja">WORKING：ふゆ先生と遊びましょ</schema:description>
+    <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="RespectiveWorkStyle_MitsumineYuika">
+    <schema:name xml:lang="ja">リスペクティブワークスタイル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リスペクティブワークスタイル</rdfs:label>
+    <schema:description xml:lang="ja">WORKING：『いらっしゃいませ』の未来</schema:description>
+    <imas:Whose rdf:resource="Mitsumine_Yuika"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
 

--- a/RDFs/Clothes/ShinyColorsCommon.rdf
+++ b/RDFs/Clothes/ShinyColorsCommon.rdf
@@ -2909,6 +2909,20 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
     <schema:description xml:lang="ja">ブランクペイジ。翼なんか　いらねぇ</schema:description>
   </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_Suzuki_Hana">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Suzuki_Hana"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。鈴木羽那領域</schema:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="FlowingBhel_Ikuta_Haruki">
+    <schema:name xml:lang="ja">フローウィングベル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">フローウィングベル</rdfs:label>
+    <imas:Whose rdf:resource="Ikuta_Haruki"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+    <schema:description xml:lang="ja">ブランクペイジ。なんにでもなれると願って</schema:description>
+  </rdf:Description>
 
   <!-- ディライトサマー -->
   <rdf:Description rdf:about="Delight_Summer_SakuragiMano">

--- a/RDFs/Clothes/ShinyColorsPersonal.rdf
+++ b/RDFs/Clothes/ShinyColorsPersonal.rdf
@@ -151,6 +151,12 @@
     <imas:Whose rdf:resource="Tsukioka_Kogane"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="My_Heart_Signal">
+    <schema:name xml:lang="ja">マイハート・シグナル</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">マイハート・シグナル</rdfs:label>
+    <imas:Whose rdf:resource="Tsukioka_Kogane"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- 田中摩美々 -->
   <rdf:Description rdf:about="Mystic_Maestra">
@@ -212,6 +218,12 @@
   <rdf:Description rdf:about="Spirit_Of_Zorro">
     <schema:name xml:lang="ja">スピリットオブゾロ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">スピリットオブゾロ</rdfs:label>
+    <imas:Whose rdf:resource="Shirase_Sakuya"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Alf_Layla_Ripetere">
+    <schema:name xml:lang="ja">アルフライラリペーテレ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">アルフライラリペーテレ</rdfs:label>
     <imas:Whose rdf:resource="Shirase_Sakuya"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -279,6 +291,13 @@
     <imas:Whose rdf:resource="Yukoku_Kiriko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Stagione_Cambiare">
+    <schema:name xml:lang="ja">セゾンカンヴィアーレ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">セゾンカンヴィアーレ</rdfs:label>
+    <schema:description xml:lang="ja">ClotheDesc</schema:description>
+    <imas:Whose rdf:resource="Yukoku_Kiriko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- 小宮果穂 -->
   <rdf:Description rdf:about="Passionate_Bonita">
@@ -308,6 +327,12 @@
   <rdf:Description rdf:about="Longing_Prince">
     <schema:name xml:lang="ja">ロンギングプリンス</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ロンギングプリンス</rdfs:label>
+    <imas:Whose rdf:resource="Komiya_Kaho"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Hanamaru_Sunrize">
+    <schema:name xml:lang="ja">ハナマルサンライズ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ハナマルサンライズ</rdfs:label>
     <imas:Whose rdf:resource="Komiya_Kaho"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -495,6 +520,13 @@
     <imas:Whose rdf:resource="Osaki_Amana"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Catch_You_Domani">
+    <schema:name xml:lang="ja">キャッチュードマーニ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">キャッチュードマーニ</rdfs:label>
+    <schema:description xml:lang="ja">ClotheDesc</schema:description>
+    <imas:Whose rdf:resource="Osaki_Tenka"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- 大崎甜花 -->
   <rdf:Description rdf:about="Devilish_Future">
@@ -562,6 +594,12 @@
   <rdf:Description rdf:about="Cheer_Up_Leader">
     <schema:name xml:lang="ja">チアアップリーダー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">チアアップリーダー</rdfs:label>
+    <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Ruban_Forever">
+    <schema:name xml:lang="ja">リュバン・フォー・エヴァー</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">リュバン・フォー・エヴァー</rdfs:label>
     <imas:Whose rdf:resource="Kuwayama_Chiyuki"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -787,6 +825,12 @@
     <imas:Whose rdf:resource="Aketa_Mikoto"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Immersed_Look_Up">
+    <schema:name xml:lang="ja">イマースドルックアップ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">イマースドルックアップ</rdfs:label>
+    <imas:Whose rdf:resource="Aketa_Mikoto"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- 斑鳩ルカ -->
   <rdf:Description rdf:about="Breaking_Caution">
@@ -799,6 +843,14 @@
     <schema:name xml:lang="ja">プリートリィチェイン</schema:name>
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">プリートリィチェイン</rdfs:label>
     <imas:Whose rdf:resource="Ikaruga_Luca"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+
+  <!-- 鈴木羽那 -->
+  <rdf:Description rdf:about="Cropped_Lilas">
+    <schema:name xml:lang="ja">クロップド・リラ</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">クロップド・リラ</rdfs:label>
+    <imas:Whose rdf:resource="Suzuki_Hana"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
 </rdf:RDF>

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -1611,6 +1611,34 @@
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
     <schema:description xml:lang="ja">✕monotone✕シロとクロの間には何がある？</schema:description>
   </rdf:Description>
+  <rdf:Description rdf:about="TeddyFollowWhite_AsakuraToru">
+    <schema:name xml:lang="ja">テディフォローホワイト</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">テディフォローホワイト</rdfs:label>
+    <schema:description xml:lang="ja">フワーフワーベアー♡ クマ式、飴獲得大作戦</schema:description>
+    <imas:Whose rdf:resource="Asakura_Toru"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="TeddyFollowWhite_HiguchiMadoka">
+    <schema:name xml:lang="ja">テディフォローホワイト</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">テディフォローホワイト</rdfs:label>
+    <schema:description xml:lang="ja">フワーフワーベアー♡ ガウガウ・メルティスノー</schema:description>
+    <imas:Whose rdf:resource="Asakura_Toru"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="TeddyFollowWhite_FukumaruKoito">
+    <schema:name xml:lang="ja">テディフォローホワイト</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">テディフォローホワイト</rdfs:label>
+    <schema:description xml:lang="ja">フワーフワーベアー♡ 真っ白な気持ちに信頼を描いて</schema:description>
+    <imas:Whose rdf:resource="Asakura_Toru"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="TeddyFollowWhite_IchikawaHinana">
+    <schema:name xml:lang="ja">テディフォローホワイト</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">テディフォローホワイト</rdfs:label>
+    <schema:description xml:lang="ja">フワーフワーベアー♡ ふわふわキャンディーはどこ？</schema:description>
+    <imas:Whose rdf:resource="Asakura_Toru"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
 
   <!-- SHHis -->
   <rdf:Description rdf:about="Silky_Gemsilica">

--- a/RDFs/Clothes/ShinyColorsUnit.rdf
+++ b/RDFs/Clothes/ShinyColorsUnit.rdf
@@ -373,7 +373,7 @@
     <imas:Whose rdf:resource="Shirase_Sakuya"/>
     <imas:Whose rdf:resource="Tanaka_Mamimi"/>
     <imas:Whose rdf:resource="Tsukioka_Kogane"/>
-    <!-- <imas:Whose rdf:resource="Mitsumine_Yuika"/> -->
+    <imas:Whose rdf:resource="Mitsumine_Yuika"/>
     <imas:Whose rdf:resource="Yukoku_Kiriko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
@@ -701,9 +701,9 @@
     <imas:Whose rdf:resource="Morino_Rinze"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
-  <rdf:Description rdf:about="Hanamaru_Sunrize">
-    <schema:name xml:lang="ja">ハナマルサンライズ</schema:name>
-    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ハナマルサンライズ</rdfs:label>
+  <rdf:Description rdf:about="We_Are_Breakthrougher">
+    <schema:name xml:lang="ja">ウィーアーブレイクスーラー！</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">ウィーアーブレイクスーラー！</rdfs:label>
     <!-- <imas:Whose rdf:resource="Arisugawa_Natsuha"/> -->
     <imas:Whose rdf:resource="Komiya_Kaho"/>
     <!-- <imas:Whose rdf:resource="Saijo_Juri"/> -->
@@ -711,6 +711,7 @@
     <!-- <imas:Whose rdf:resource="Morino_Rinze"/> -->
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+
   <rdf:Description rdf:about="Pajamas_De_Kabukabu">
     <schema:name xml:lang="ja">パジャマ・デ・カブカブ</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">パジャマ・デ・カブカブ</rdfs:label>
@@ -1288,6 +1289,14 @@
     <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
+  <rdf:Description rdf:about="Chimimouryou_Simstim">
+    <schema:name xml:lang="ja">魑魅魍魎シムスティーム</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">魑魅魍魎シムスティーム</rdfs:label>
+    <imas:Whose rdf:resource="Izumi_Mei"/>
+    <!-- <imas:Whose rdf:resource="Serizawa_Asahi"/> -->
+    <imas:Whose rdf:resource="Mayuzumi_Fuyuko"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
   <rdf:Description rdf:about="Merry_Merry_Delivery">
     <schema:name xml:lang="ja">メリーメリーデリバリー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">メリーメリーデリバリー</rdfs:label>
@@ -1464,10 +1473,19 @@
   <rdf:Description rdf:about="Acquario_Diva">
     <schema:name xml:lang="ja">アクアリオディーバー</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">アクアリオディーバー</rdfs:label>
+    <imas:Whose rdf:resource="Asakura_Toru"/>
+    <imas:Whose rdf:resource="Higuchi_Madoka"/>
+    <imas:Whose rdf:resource="Fukumaru_Koito"/>
+    <imas:Whose rdf:resource="Ichikawa_Hinana"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Peinture_Pickout">
+    <schema:name xml:lang="ja">パンチュールピッカウト</schema:name>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">パンチュールピッカウト</rdfs:label>
     <!-- <imas:Whose rdf:resource="Asakura_Toru"/> -->
     <imas:Whose rdf:resource="Higuchi_Madoka"/>
     <!-- <imas:Whose rdf:resource="Fukumaru_Koito"/> -->
-    <imas:Whose rdf:resource="Ichikawa_Hinana"/>
+    <!-- <imas:Whose rdf:resource="Ichikawa_Hinana"/> -->
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>
 
@@ -1739,6 +1757,14 @@
     <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">コメティックノート</rdfs:label>
     <imas:Whose rdf:resource="Ikaruga_Luca"/>
     <imas:Whose rdf:resource="Suzuki_Hana"/>
+    <imas:Whose rdf:resource="Ikuta_Haruki"/>
+    <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="Reflectic_Optique">
+    <schema:name xml:lang="ja">リフレクティックオプティーク</schema:name>
+    <rdfs:label rdf:datatype="http://www.w5.org/2001/XMLSchema#string">コメティックノート</rdfs:label>
+    <!-- <imas:Whose rdf:resource="Ikaruga_Luca"/> -->
+    <!-- <imas:Whose rdf:resource="Suzuki_Hana"/> -->
     <imas:Whose rdf:resource="Ikuta_Haruki"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Clothes"/>
   </rdf:Description>


### PR DESCRIPTION
次の衣装を追加しました

- ドレスアップパルファム (樋口円香, 福丸小糸)
- リスペクティブワークスタイル (黛冬優子, 三峰結華)
- テディフォローホワイト (noctchill)
- セゾンカンヴィアーレ (幽谷霧子)
- キャッチュードマーニ (大崎甜花)
  - Catch you (またね) + Domani (明日) = また明日 かなと思います 🤔 
    - 参考1: https://news.yahoo.co.jp/expert/articles/face9b54f6c11e0d59e2e4fea77cafce3027e96a
    - 参考2: https://dictionary.goo.ne.jp/word/%E3%83%89%E3%83%9E%E3%83%BC%E3%83%8B/
- リュバン・フォー・エヴァー (桑山千雪)
- ウィーアーブレイクスーラー！ (小宮果穂)
- アクアリオディーバー (浅倉透, 福丸小糸)
- 魑魅魍魎シムスティーム (黛冬優子, 和泉愛依)
  - SF小説 [ニューロマンサー](https://ja.wikipedia.org/wiki/%E3%83%8B%E3%83%A5%E3%83%BC%E3%83%AD%E3%83%9E%E3%83%B3%E3%82%B5%E3%83%BC) に登場した用語「シムスティム」から。作品自体がストレイのベースになってたりするんですね……知りませんでした
    - 参考1: https://x.com/haruaki_touma/status/1755769946754502703
    - 参考2: https://note.com/ctr/n/ndd6ecfc63e15
- クロップド・リラ (鈴木羽那)
- パンチュールピッカウト (樋口円香)
- アルフライラリペーテレ (白瀬咲耶)
  - [アルフ・ライラ・ワ・ライラ](https://ja.wikipedia.org/wiki/%E3%82%A2%E3%83%AB%E3%83%95%E3%83%BB%E3%83%A9%E3%82%A4%E3%83%A9%E3%83%BB%E3%83%AF%E3%83%BB%E3%83%A9%E3%82%A4%E3%83%A9) + リペーテレ (繰り返し)
- リフレクティックオプティーク (郁田はるき)
- ミュゼオフォルマリナーシタ (三峰結華)
- フローウィングベル (郁田はるき, 鈴木羽那)
- マイハート・シグナル (月岡恋鐘)
- イマースドルックアップ (緋田美琴)

また ハナマルサンライズ(小宮果穂) を個人衣装に移動しました