### PR TITLE
update 秦谷美鈴, 雨夜燕

### DIFF
--- a/RDFs/Gakuen.rdf
+++ b/RDFs/Gakuen.rdf
@@ -405,6 +405,21 @@
     <schema:name xml:lang="ja">秦谷美鈴</schema:name>
     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">秦谷美鈴</rdfs:label>
     <schema:name xml:lang="en">Misuzu Hataya</schema:name>
+    <foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">15</foaf:age>
+    <schema:height rdf:datatype="http://www.w3.org/2001/XMLSchema#float">160.0</schema:height>
+    <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
+    <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">73.0</imas:Bust>
+    <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">54.0</imas:Waist>
+    <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">73.0</imas:Hip>
+    <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--02-06</schema:birthDate>
+    <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
+    <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>
+    <imas:Handedness rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right</imas:Handedness>
+    <imas:Hobby xml:lang="ja">お昼寝</imas:Hobby>
+    <imas:Hobby xml:lang="ja">お散歩</imas:Hobby>
+    <imas:Talent xml:lang="ja">料理</imas:Talent>
+    <imas:Talent xml:lang="ja">生け花</imas:Talent>
+    <imas:Talent xml:lang="ja">体内時計が正確</imas:Talent>
     <imas:Color rdf:datatype="http://www.w3.org/2001/XMLSchema#hexBinary">A0B6DC</imas:Color>
     <imas:cv xml:lang="ja">春咲暖</imas:cv>
     <imas:cv rdf:resource="http://ja.dbpedia.org/resource/春咲暖"/>
@@ -412,7 +427,9 @@
     <schema:gender rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female</schema:gender>
     <imas:Brand xml:lang="en">Gakuen</imas:Brand>
     <schema:memberOf rdf:resource="HatsuboshiGakuen"/>
+    <schema:birthPlace xml:lang="ja">京都</schema:birthPlace>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
+    <imas:IdolListURL rdf:resource="https://idollist.idolmaster-official.jp/detail/60012"/>
     <imas:SchoolGrade xml:lang="ja">高等部アイドル科1年2組</imas:SchoolGrade>
     <schema:description xml:lang="ja">のんびりマイペースな女の子。自分にも他人にも優しく甘い。他者のお世話をしたり、甘やかしたりするのが大好き。甘えん坊な親友を、妹や娘のように慈しみ、大切にしている。</schema:description>
   </rdf:Description>

--- a/RDFs/Gakuen.rdf
+++ b/RDFs/Gakuen.rdf
@@ -490,7 +490,7 @@
     <imas:Brand xml:lang="en">Gakuen</imas:Brand>
     <schema:memberOf rdf:resource="HatsuboshiGakuen"/>
     <rdf:type rdf:resource="https://sparql.crssnky.xyz/imasrdf/URIs/imas-schema.ttl#Idol"/>
-    <imas:SchoolGrade xml:lang="ja">高等部アイドル科3年生</imas:SchoolGrade>
+    <imas:SchoolGrade xml:lang="ja">高等部アイドル科3年1組</imas:SchoolGrade>
     <schema:description xml:lang="ja">初星学園生徒会副会長。学園No.2のアイドル。実力相応のプライドを持ち、尊大な態度を取る。自分にも他人にも厳しいが、面倒見は良い。幼馴染の星南をライバル視しており、いずれ星南を超えて『一番星』になると公言している。</schema:description>
   </rdf:Description>
 </rdf:RDF>

--- a/RDFs/Gakuen.rdf
+++ b/RDFs/Gakuen.rdf
@@ -410,7 +410,7 @@
     <schema:weight rdf:datatype="http://www.w3.org/2001/XMLSchema#float">42.0</schema:weight>
     <imas:Bust rdf:datatype="http://www.w3.org/2001/XMLSchema#float">73.0</imas:Bust>
     <imas:Waist rdf:datatype="http://www.w3.org/2001/XMLSchema#float">54.0</imas:Waist>
-    <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">73.0</imas:Hip>
+    <imas:Hip rdf:datatype="http://www.w3.org/2001/XMLSchema#float">74.0</imas:Hip>
     <schema:birthDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gMonthDay">--02-06</schema:birthDate>
     <imas:Constellation xml:lang="ja">水瓶座</imas:Constellation>
     <imas:BloodType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B</imas:BloodType>

--- a/constraints/IdolShape.ttl
+++ b/constraints/IdolShape.ttl
@@ -362,7 +362,6 @@ imas-shape:IdolShape a sh:NodeShape;
             "高等部アイドル科1年1組"@ja
             "高等部アイドル科1年2組"@ja
             "高等部アイドル科3年1組"@ja
-            "高等部アイドル科3年生"@ja # FIXME: 雨夜燕対応
         );
     ];
     sh:property [


### PR DESCRIPTION
秦谷美鈴さんのプロデュースが始まってプロフィールが充実したので更新しました

https://gakuen.idolmaster-official.jp/idol/misuzu/

学園アイドルマスターのイベントで「3年1組の修学旅行」内で雨夜燕さんが有村真央さん・十王星南さん・姫崎利波さんとともに行動していたことから、1組所属だと判断しました

![Screenshot_20250619-200951](https://github.com/user-attachments/assets/d081b70a-85a4-496b-8746-4f3d60f9b27b)
