### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,12 @@ jobs:
   rdflint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-java@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-java@v5
       with:
         distribution: temurin
-        java-version: 17
-    - uses: imas/setup-rdflint@v3
+        java-version: 21
+    - uses: imas/setup-rdflint@v4
 
     - name: Run rdflint (Clothes_Own)
       run: rdflint -config .rdflint/Clothes_Own.yml

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true


### PR DESCRIPTION
Node 20 の EOL に伴い、ワークフローのバージョンを最新にアップデートしました。

参考：[Deprecation of Node 20 on GitHub Actions runners - GitHub Changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)