### PR TITLE
ローカル開発用にdocker環境を用意する

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.gitignore
+.github
+.rdflint
+RDFs
+URIs
+constraints
+README.md
+CONTRIBUTING.md
+LICENSE
+rdflint-*.jar
+*.yml
+*.yaml
+!docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM stain/jena-fuseki:5.1.0
+
+COPY docker/fuseki-config.ttl /fuseki-config.ttl
+COPY docker/entrypoint.sh /entrypoint.sh
+
+USER root
+RUN chmod +x /entrypoint.sh
+USER fuseki
+
+ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  fuseki:
+    build: .
+    ports:
+      - "3030:3030"
+    volumes:
+      - fuseki-data:/fuseki
+      - ./RDFs:/rdf-data:ro
+    environment:
+      ADMIN_PASSWORD: admin
+
+volumes:
+  fuseki-data:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -12,7 +12,15 @@ if [ ! -f "${FUSEKI_BASE}/shiro.ini" ]; then
     echo "[imasparql] Initializing Fuseki base directory..."
     mkdir -p "${FUSEKI_BASE}"
     cp "${FUSEKI_HOME}/shiro.ini" "${FUSEKI_BASE}/shiro.ini"
-    sed -i "s|admin=YOURPASSWORD|admin=${ADMIN_PASSWORD}|g" "${FUSEKI_BASE}/shiro.ini"
+    # admin=<任意の値> を置換（プレースホルダー名に依存しない）
+    sed -i "s|^admin=.*$|admin=${ADMIN_PASSWORD}|g" "${FUSEKI_BASE}/shiro.ini"
+fi
+
+# Fuseki起動前にデータロードが必要かどうか判定（起動後はTDB2がDIRを作成するため起動前に確認）
+NEEDS_DATA_LOAD=false
+if [ ! -d "${DATASET_DIR}" ] || [ -z "$(ls -A "${DATASET_DIR}" 2>/dev/null)" ]; then
+    NEEDS_DATA_LOAD=true
+    echo "[imasparql] Initial data load will be performed after Fuseki starts."
 fi
 
 # Fusekiをバックグラウンド起動
@@ -33,7 +41,7 @@ done
 echo "[imasparql] Fuseki is ready."
 
 # 初回のみRDFデータをロード
-if [ -d "${DATASET_DIR}" ] && [ "$(ls -A "${DATASET_DIR}" 2>/dev/null)" ]; then
+if [ "${NEEDS_DATA_LOAD}" = "false" ]; then
     echo "[imasparql] TDB2 database already exists. Skipping data load."
 else
     echo "[imasparql] Loading RDF data from ${RDF_SOURCE}..."

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -euo pipefail
+
+FUSEKI_BASE="${FUSEKI_BASE:-/fuseki}"
+FUSEKI_HOME="${FUSEKI_HOME:-/jena-fuseki}"
+DATASET_DIR="${FUSEKI_BASE}/databases/imas"
+RDF_SOURCE="/rdf-data"
+FUSEKI_URL="http://localhost:3030"
+
+# shiro.ini初期化（初回のみ）
+if [ ! -f "${FUSEKI_BASE}/shiro.ini" ]; then
+    echo "[imasparql] Initializing Fuseki base directory..."
+    mkdir -p "${FUSEKI_BASE}"
+    cp "${FUSEKI_HOME}/shiro.ini" "${FUSEKI_BASE}/shiro.ini"
+    sed -i "s|admin=YOURPASSWORD|admin=${ADMIN_PASSWORD}|g" "${FUSEKI_BASE}/shiro.ini"
+fi
+
+# Fusekiをバックグラウンド起動
+echo "[imasparql] Starting Fuseki..."
+"${FUSEKI_HOME}/fuseki-server" --config=/fuseki-config.ttl --port=3030 &
+FUSEKI_PID=$!
+
+# 起動待機
+echo "[imasparql] Waiting for Fuseki to become available..."
+MAX_WAIT=120
+WAITED=0
+until curl --silent --fail "${FUSEKI_URL}/\$/ping" > /dev/null 2>&1; do
+    sleep 2; WAITED=$((WAITED + 2))
+    if [ "${WAITED}" -ge "${MAX_WAIT}" ]; then
+        echo "[imasparql] ERROR: Timeout waiting for Fuseki" >&2; exit 1
+    fi
+done
+echo "[imasparql] Fuseki is ready."
+
+# 初回のみRDFデータをロード
+if [ -d "${DATASET_DIR}" ] && [ "$(ls -A "${DATASET_DIR}" 2>/dev/null)" ]; then
+    echo "[imasparql] TDB2 database already exists. Skipping data load."
+else
+    echo "[imasparql] Loading RDF data from ${RDF_SOURCE}..."
+    LOAD_ERRORS=0
+    while IFS= read -r -d '' rdf_file; do
+        echo "[imasparql]   Loading: ${rdf_file}"
+        HTTP_STATUS=$(curl --silent --output /dev/null --write-out "%{http_code}" \
+            --request POST \
+            --user "admin:${ADMIN_PASSWORD}" \
+            --header "Content-Type: application/rdf+xml" \
+            --data-binary @"${rdf_file}" \
+            "${FUSEKI_URL}/imas/data?default")
+        if [ "${HTTP_STATUS}" -lt 200 ] || [ "${HTTP_STATUS}" -ge 300 ]; then
+            echo "[imasparql]   WARNING: Failed ${rdf_file} (HTTP ${HTTP_STATUS})" >&2
+            LOAD_ERRORS=$((LOAD_ERRORS + 1))
+        fi
+    done < <(find "${RDF_SOURCE}" -name "*.rdf" -print0 | sort -z)
+    echo "[imasparql] Data load complete (errors: ${LOAD_ERRORS})"
+fi
+
+echo "[imasparql] SPARQL endpoint: ${FUSEKI_URL}/imas/query"
+wait "${FUSEKI_PID}"

--- a/docker/fuseki-config.ttl
+++ b/docker/fuseki-config.ttl
@@ -1,0 +1,29 @@
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+PREFIX tdb2:    <http://jena.apache.org/2016/tdb#>
+
+<#service_imas> rdf:type fuseki:Service ;
+    fuseki:name "imas" ;
+    fuseki:endpoint [
+        fuseki:operation fuseki:query ;
+        fuseki:name      "query"
+    ] ;
+    fuseki:endpoint [
+        fuseki:operation fuseki:update ;
+        fuseki:name      "update"
+    ] ;
+    fuseki:endpoint [
+        fuseki:operation fuseki:gsp-r ;
+        fuseki:name      "get"
+    ] ;
+    fuseki:endpoint [
+        fuseki:operation fuseki:gsp-rw ;
+        fuseki:name      "data"
+    ] ;
+    fuseki:dataset <#dataset_imas> ;
+    .
+
+<#dataset_imas> rdf:type tdb2:DatasetTDB2 ;
+    tdb2:location "/fuseki/databases/imas" ;
+    .


### PR DESCRIPTION
# 概要
fusekiのdocker環境を構築しました。
https://github.com/imas/imasparql/issues/572 で記載したIssue対応です。

# 変更点
docker環境の準備

# 動作確認
## 1. コンテナ起動(この時データもロードされます)
```
docker compose up -d --build
```

## 2. http://localhost:3030 にアクセス
BASIC認証
- ユーザー名: admin
- パスワード: admin


## 3. http://localhost:3030/#/dataset/imas/query でクエリを実行
例)
```
# クエリ
SELECT ?member
WHERE {
     <https://sparql.crssnky.xyz/imasrdf/RDFs/detail/765MillionStars> <http://schema.org/member> ?member.
}
```

## 4. クエリ結果の確認
<img width="1316" height="792" alt="スクリーンショット 2026-02-24 23 06 02" src="https://github.com/user-attachments/assets/9afdd462-1916-4810-badd-b9cdbeba0746" />


# 補足
ClaudeでのVibe Codingを利用しました。変なことはしてないと考えています。
コンテナ起動時のデータロードシェルスクリプトが少し強引かもしれません 🙏 

# Todo
docker環境で開発したい場合の環境構築方法のドキュメントは後ほど別で作成しようと考えています。 
